### PR TITLE
allow for different regions

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -685,10 +685,14 @@ class Zappa(object):
         """
 
         user_home = expanduser("~")
+        credentials = ConfigParser.ConfigParser()
         config = ConfigParser.ConfigParser()
-        config.read([str(user_home + "/.aws/credentials")])
-        self.access_key = config.get('default', 'aws_access_key_id')
-        self.secret_key = config.get('default', 'aws_secret_access_key')
+        credentials.read([str(user_home + "/.aws/credentials")])
+        config.read([str(user_home + "/.aws/config")])
+        self.access_key = credentials.get('default', 'aws_access_key_id')
+        self.secret_key = credentials.get('default', 'aws_secret_access_key')
+        self.aws_region = config.get('default', 'region')
+
         return
 
     def human_size(self, num, suffix='B'):


### PR DESCRIPTION
I noticed when I ran Zappa in us-west-2 instead of us-east-1 I ran into errors about no integrations found. 

