### PR TITLE
Adding VPC Lambda support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.39.0
 boto3==1.2.3
-botocore==1.3.22
+botocore==1.3.26
 docutils==0.12
 filechunkio==1.6
 futures==3.0.4

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -363,7 +363,7 @@ class Zappa(object):
     # Lambda
     ##
 
-    def create_lambda_function(self, bucket, s3_key, function_name, handler, description="Zappa Deployment", timeout=30, memory_size=512, publish=True):
+    def create_lambda_function(self, bucket, s3_key, function_name, handler, description="Zappa Deployment", timeout=30, memory_size=512, publish=True, vpc_config={}):
         """
         Given a bucket and key of a valid Lambda-zip, a function name and a handler, register that Lambda function.
 
@@ -382,7 +382,8 @@ class Zappa(object):
             Description=description,
             Timeout=timeout,
             MemorySize=memory_size,
-            Publish=publish
+            Publish=publish,
+            VpcConfig=vpc_config
         )
 
         return response['FunctionArn']

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -101,7 +101,14 @@ ATTACH_POLICY = """{
             "Resource": [
                 "*"
             ]
-        }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateNetworkInterface"
+            ],
+            "Resource": "*"
+        },
     ]
 }"""
 


### PR DESCRIPTION
AWS recently added [VPC support](https://aws.amazon.com/blogs/aws/new-access-resources-in-a-vpc-from-your-lambda-functions/) to Lambda. This PR adds a keword argument to support this and bumps botocore to the version it was introduced in. Since the VPC support needs ec2:CreateNetworkInterface to function, I had to add that in the IAM profile as well.