### PR TITLE
Changed URLs to be without trailing slash

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -94,5 +94,22 @@ class TestZappa(unittest.TestCase):
         }
         request = create_wsgi_request(event)
 
+    def test_wsgi_path_info(self):
+
+        event = {
+            "body": {},
+            "headers": {},
+            "params": {
+                "parameter_1": "asdf1",
+                "parameter_2": "asdf2",
+            },
+            "method": "GET",
+            "query": {}
+        }
+        request = create_wsgi_request(event)
+
+        self.assertEqual("/asdf1/asdf2", request['PATH_INFO'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -95,7 +95,22 @@ class TestZappa(unittest.TestCase):
         request = create_wsgi_request(event)
 
     def test_wsgi_path_info(self):
+        # Test no parameters (site.com/)
+        event = {
+            "body": {},
+            "headers": {},
+            "params": {},
+            "method": "GET",
+            "query": {}
+        }
 
+        request = create_wsgi_request(event, trailing_slash=True)
+        self.assertEqual("/", request['PATH_INFO'])
+
+        request = create_wsgi_request(event, trailing_slash=False)
+        self.assertEqual("/", request['PATH_INFO'])
+
+        # Test parameters (site.com/asdf1/asdf2 or site.com/asdf1/asdf2/)
         event = {
             "body": {},
             "headers": {},
@@ -106,8 +121,11 @@ class TestZappa(unittest.TestCase):
             "method": "GET",
             "query": {}
         }
-        request = create_wsgi_request(event)
 
+        request = create_wsgi_request(event, trailing_slash=True)
+        self.assertEqual("/asdf1/asdf2/", request['PATH_INFO'])
+
+        request = create_wsgi_request(event, trailing_slash=False)
         self.assertEqual("/asdf1/asdf2", request['PATH_INFO'])
 
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -1,7 +1,8 @@
 from urllib import urlencode
 from StringIO import StringIO
 
-def create_wsgi_request(event_info, server_name='zappa', script_name=None):
+def create_wsgi_request(event_info, server_name='zappa', script_name=None,
+                        trailing_slash=True):
         """
         Given some event_info,
         create and return a valid WSGI request environ.
@@ -13,8 +14,18 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None):
         query = event_info['query']
 
         path = "/"
-        sorted_params = sorted(params.iteritems(), key=lambda (x,_): x)
-        path += "/".join([value for (_, value) in sorted_params])
+        for key in sorted(params.keys()):
+            path = path + params[key] + "/"
+
+        # This determines if we should return
+        # site.com/resource/ : site.com/resource
+        # site.com/resource : site.com/resource
+        # vs.
+        # site.com/resource/ : site.com/resource/
+        # site.com/resource : site.com/resource/
+        # If no params are present, keep the slash.
+        if not trailing_slash and params.keys():
+            path = path[:-1]
 
         query_string = urlencode(query)
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -13,8 +13,8 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None):
         query = event_info['query']
 
         path = "/"
-        for key in sorted(params.keys()):
-            path = path + params[key] + "/"
+        sorted_params = sorted(params.iteritems(), key=lambda (x,_): x)
+        path += "/".join([value for (_, value) in sorted_params])
 
         query_string = urlencode(query)
 


### PR DESCRIPTION
I ran into this while creating a minimal flask example.

The WSGI application receives urls with a trailing slash from `zappa/wsgi.py:create_wsgi_request`, regardless of the url visited actually having one or not.

I poked around API Gateway, and I could not find a way to allow both addresses with and without trailing slashes. By experimenting, it appears the `$input.path` is stripped from trailing slashes. I could not find this behavior documented anywhere. [Here is the docs](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) for the mapping template in case anyone wants to take a look.

However I think the most sensible thing is to let the default be without the trailing slash.

What do you guys think?