### PR TITLE
Remove boto dependency + introduce moto tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+sudo: true
 language: python
 python:
   - "2.7"
 # command to install dependencies
 install:
-  - "pip install setuptools --upgrade; pip install -U pip; pip install -r requirements.txt"
+  - "pip install setuptools --upgrade; python setup.py install"
 # command to run tests
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - "pip install setuptools --upgrade; python setup.py install"
+  - "pip install setuptools --upgrade; pip install -U pip; python setup.py install"
 # command to run tests
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - "pip install setuptools --upgrade; pip install -U pip; python setup.py install"
+  - "pip install setuptools --upgrade; pip install -U pip; pip install -r requirements.txt"
 # command to run tests
 script: nosetests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-boto==2.39.0
 boto3==1.2.3
 botocore==1.3.26
 docutils==0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ six==1.10.0
 tqdm==3.7.1
 wheel==0.24.0
 wsgi-request-logger==0.4.4
--e git://github.com/hufman/HTTPretty.git@3b09b51ff7d71450c0f5c43557fc92d177df9465#egg=httpretty-origin/use_tempfile
+git+https://github.com/hufman/HTTPretty.git@use_tempfile#egg=httpretty==8.4.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.10.0
 tqdm==3.7.1
 wheel==0.24.0
 wsgi-request-logger==0.4.4
+-e git://github.com/hufman/HTTPretty.git@3b09b51ff7d71450c0f5c43557fc92d177df9465#egg=httpretty-origin/use_tempfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ six==1.10.0
 tqdm==3.7.1
 wheel==0.24.0
 wsgi-request-logger==0.4.4
--e git+https://github.com/hufman/HTTPretty.git@use_tempfile#egg=httpretty==8.4.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ docutils==0.12
 filechunkio==1.6
 futures==3.0.4
 jmespath==0.9.0
+moto==0.4.22
 nose==1.3.7
 python-dateutil==2.4.2
 requests>=2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ six==1.10.0
 tqdm==3.7.1
 wheel==0.24.0
 wsgi-request-logger==0.4.4
-git+https://github.com/hufman/HTTPretty.git@use_tempfile#egg=httpretty==8.4.14.1
+-e git+https://github.com/hufman/HTTPretty.git@use_tempfile#egg=httpretty==8.4.14.1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,14 +1,6 @@
-import glob
 import os
-import re
-import string
-import sys
 import unittest
 
-import nose
-from nose import case
-from nose.pyversion import unbound_method
-from nose import util
 
 from zappa.wsgi import create_wsgi_request
 from zappa.zappa import Zappa
@@ -27,7 +19,7 @@ class TestZappa(unittest.TestCase):
 
     def test_zappa(self):
         self.assertTrue(True)
-        z = Zappa()
+        Zappa()
 
     def test_create_lambda_package(self):
         self.assertTrue(True)
@@ -42,12 +34,12 @@ class TestZappa(unittest.TestCase):
         credentials = '[default]\naws_access_key_id = AK123\naws_secret_access_key = JKL456'
         config = '[default]\noutput = json\nregion = us-east-1'
 
-        credentials_file = open('credentials','w')
-        credentials_file.write(credentials) 
+        credentials_file = open('credentials', 'w')
+        credentials_file.write(credentials)
         credentials_file.close()
 
-        config_file = open('config','w')
-        config_file.write(config) 
+        config_file = open('config', 'w')
+        config_file.write(config)
         config_file.close()
 
         z.load_credentials('credentials', 'config')

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -2,20 +2,18 @@ import base64
 import boto3
 import botocore
 import ConfigParser
-import math
 import os
 import time
 import zipfile
 import requests
 
-from boto.s3.connection import S3Connection
-from filechunkio import FileChunkIO
 from os.path import expanduser
 from tqdm import tqdm
 
 ##
 # Policies And Template Mappings
 ##
+
 
 TEMPLATE_MAPPING = """{
   "body" : $input.json('$'),
@@ -276,64 +274,37 @@ class Zappa(object):
 
     def upload_to_s3(self, source_path, bucket_name):
         """
-
         Given a file, upload it to S3.
         Credentials should be stored in environment variables or ~/.aws/credentials (%USERPROFILE%\.aws\credentials on Windows).
 
         Returns True on success, false on failure.
 
         """
-
         try:
-            self.s3_connection = S3Connection()
+            s3 = boto3.resource('s3')
+            s3.create_bucket(Bucket=bucket_name)
         except Exception as e:
-            print(e)
-            return False
-
-        all_buckets = self.s3_connection.get_all_buckets()
-        if bucket_name not in [bucket.name for bucket in all_buckets]:
-            try:
-                self.s3_connection.create_bucket(bucket_name)
-            except Exception as e:
                 print(e)
                 print("Couldn't create bucket.")
                 return False
 
-        if (not os.path.isfile(source_path) or os.stat(source_path).st_size == 0):
-            print(e)
+        if not os.path.isfile(source_path) or os.stat(source_path).st_size == 0:
+            print("Problem with source file {}".format(source_path))
             return False
 
+        dest_path = os.path.split(source_path)[1]
         try:
-            bucket = self.s3_connection.get_bucket(bucket_name)
             source_size = os.stat(source_path).st_size
-            dest_path = os.path.split(source_path)[1]
-
-            # Create a multipart upload request
-            mpu = bucket.initiate_multipart_upload(dest_path)
-
-            # Use a chunk size of 5 MiB
-            chunk_size = 5242880
-            chunk_count = int(math.ceil(source_size / float(chunk_size)))
-
-            print("Uploading zip (" + str(self.human_size(source_size)) + ")..")
-
-            # Send the file parts, using FileChunkIO to create a file-like object
-            # that points to a certain byte range within the original file. We
-            # set bytes to never exceed the original file size.
-            for i in tqdm(range(chunk_count)):
-                offset = chunk_size * i
-                bytes = min(chunk_size, source_size - offset)
-                with FileChunkIO(source_path, 'r', offset=offset,
-                                     bytes=bytes) as fp:
-                    mpu.upload_part_from_file(fp, part_num=i + 1)
-
-            # Finish the upload
-            mpu.complete_upload()
-
+            print("Uploading zip (" + str(self.human_size(source_size)) + ")...")
+            progress = tqdm(total=float(os.path.getsize(source_path)))
+            s3.meta.client.upload_file(
+                source_path, bucket_name, dest_path,
+                Callback=progress.update
+            )
+            progress.close()
         except Exception as e:
             print(e)
             return False
-
         return True
 
     def remove_from_s3(self, file_name, bucket_name):


### PR DESCRIPTION
This should be able to close #14.

I used the boto3 transfer API to handle the chunking + retries for us instead of doing it explicitly. If we want more control we can also use the TransferConfig object but it didn't feel necessary at this point. http://boto3.readthedocs.org/en/latest/reference/customizations/s3.html#module-boto3.s3.transfer. I kept the tqdm progress bar you were using, but changed it to bytes instead of chunks because boto will decide for us how to chunk up the file.

In the issue thread you also talked about moto, which I never worked with but it seems like it's working fine to check if the bucket and object were indeed created/uploaded.

There's a problem with the upload, where I can't seem to stop it with a keyboard interrupt mid upload, any clues on what I might have done wrong?