### PR TITLE
add placebo test for create_iam_roles

### DIFF
--- a/tests/placebo/iam.CreateRole_1.json
+++ b/tests/placebo/iam.CreateRole_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Role": {
+            "AssumeRolePolicyDocument": "%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Sid%22%3A%20%22%22%2C%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Principal%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22Service%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%22lambda.amazonaws.com%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22apigateway.amazonaws.com%22%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%22sts%3AAssumeRole%22%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D", 
+            "RoleId": "AROAIKI7F76XYVJ6S7DEK", 
+            "CreateDate": {
+                "hour": 23, 
+                "__class__": "datetime", 
+                "month": 2, 
+                "second": 18, 
+                "microsecond": 5000, 
+                "year": 2016, 
+                "day": 24, 
+                "minute": 8
+            }, 
+            "RoleName": "ZappaLambdaExecution", 
+            "Path": "/", 
+            "Arn": "arn:aws:iam::123:role/ZappaLambdaExecution"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "7d87f43f-db4b-11e5-a239-c14c7df63ed2"
+        }
+    }
+}

--- a/tests/placebo/iam.GetRole_1.json
+++ b/tests/placebo/iam.GetRole_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RequestId": "7d71d42a-db4b-11e5-bd56-773950c7fb22"
+        }, 
+        "Error": {
+            "Message": "The role with name ZappaLambdaExecution cannot be found.", 
+            "Code": "NoSuchEntity", 
+            "Type": "Sender"
+        }
+    }
+}

--- a/tests/placebo/iam.PutRolePolicy_1.json
+++ b/tests/placebo/iam.PutRolePolicy_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "7da825ec-db4b-11e5-95e1-934183d5432f"
+        }
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -81,6 +81,12 @@ class TestZappa(unittest.TestCase):
         res = z.remove_from_s3(zip_path, bucket_name, session)
         self.assertTrue(res)
 
+    def test_create_iam_roles(self):
+        session = self.get_placebo_session()
+        z = Zappa()
+        arn = z.create_iam_roles(session)
+        self.assertEqual(arn, "arn:aws:iam::123:role/{}".format(z.role_name))
+
     ##
     # Logging
     ##

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -652,16 +652,16 @@ class Zappa(object):
     # IAM
     ##
 
-    def create_iam_roles(self):
+    def create_iam_roles(self, session=None):
         """
         Creates and defines the IAM roles and policies necessary for Zappa.
 
         """
-
         assume_policy_s = ASSUME_POLICY
         attach_policy_s = ATTACH_POLICY
 
-        iam = boto3.resource('iam')
+        session = session or boto3.session.Session()
+        iam = session.resource('iam')
 
         try:
             role = iam.meta.client.get_role(
@@ -670,7 +670,7 @@ class Zappa(object):
             return self.credentials_arn
 
         except botocore.client.ClientError:
-            print("Creating " + self.role_name + " IAM..")
+            print("Creating " + self.role_name + " IAM...")
 
             role = iam.create_role(
                 RoleName=self.role_name,


### PR DESCRIPTION
Like the ones for s3, introduces placebo json replies that can be replayed and tests the creation of a role by checking the returned arn