### PR TITLE
update .gitignore and slightly increase test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# PyCharm
+#  Project settings from the PyCharm IDE are stored in the .idea folder
+.idea/
+
 env/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,5 @@ target/
 #  Project settings from the PyCharm IDE are stored in the .idea folder
 .idea/
 
-env/
+# Apple OS X specific files are put into the .DS_Store file
 .DS_Store

--- a/tests/tests_middleware.py
+++ b/tests/tests_middleware.py
@@ -186,8 +186,8 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # Same as above but with 302f
         def simple_app(environ, start_response):
             status = '302 Found'
-            response_headers = [('Location', url),
-                                ('Derp', 'Max-Squirt'),
+            response_headers = [('Derp', 'Max-Squirt'),
+                                ('Location', url),
                                 ('Set-Cookie', 'foo=456')]
             start_response(status, response_headers)
             return [body]
@@ -202,8 +202,8 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         self.assertEqual(self.status[0], '200 OK')
         self.assertEqual(len(self.headers), 3)
 
-        self.assertEqual(self.headers[0][0], 'Location')
-        self.assertEqual(self.headers[0][1], url)
+        self.assertEqual(self.headers[1][0], 'Location')
+        self.assertEqual(self.headers[1][1], url)
 
         self.assertEqual(self.headers[2][0], 'Set-Cookie')
         self.assertTrue(self.headers[2][1].startswith('zappa='))


### PR DESCRIPTION
I'm just delving into the project code here. I'm hoping to submit more stuff in the future. For now, I have a small PR doing two things:

* Update .gitignore file with new comments and took out a duplicate reference to "env/" that was already there on line 11
* made a small tweak to an existing test in order to get 100% code coverage for the middleware.py file. Basically, on line 148 of middleware.py there is a statement `if key != 'Location': continue` which never evaluates to True, because in the tests, the Location key is always first in the response headers list. I moved the code in the test around without otherwise changing functionality so that this conditional evaluates to True and therefore the next line of code gets hit during the test.