### PR TITLE
.dist-info dir is needed for cryptography package

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -163,7 +163,7 @@ REDIRECT_RESPONSE_TEMPLATE = ""
 API_GATEWAY_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-northeast-1']
 LAMBDA_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-northeast-1']
 
-ZIP_EXCLUDES =  ['*.exe', '*.DS_Store', '*.Python', '*.git', '*.zip', '*.tar.gz', '*.dist-info']
+ZIP_EXCLUDES =  ['*.exe', '*.DS_Store', '*.Python', '*.git', '*.zip', '*.tar.gz']
 
 ##
 # Classes


### PR DESCRIPTION
cryptography uses pkg_resources.iter_entry_points routine
to locate available cryptographic backends.