### PR TITLE
set CONTENT_LENGTH for PUT requests

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -69,7 +69,7 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
         }
 
         # Input processing
-        if method == "POST":
+        if method == "POST" or method =="PUT":
             if 'Content-Type' in event_info["headers"]:
                 environ['CONTENT_TYPE'] = event_info["headers"]['Content-Type']
 


### PR DESCRIPTION
Zappa is not creating environ['CONTENT_LENGTH'] when the HTTP method called is PUT. This path try to solve this issue.