### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -186,7 +186,7 @@ class TestZappa(unittest.TestCase):
         z = Zappa(session)
         z.credentials_arn = 'arn:aws:iam::12345:role/ZappaLambdaExecution'
         events = z.fetch_logs('Spheres-demonstration')
-        self.assertTrue(events != None)
+        self.assertTrue(events is not None)
 
     def test_policy_json(self):
         # ensure the policy docs are valid JSON


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Miserlou:Zappa?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:Miserlou:Zappa?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)