### PR TITLE
[DISCUSS] add support for loading environment vars from s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ to change Zappa's behavior. Use these at your own risk!
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
+        "remote_env_bucket": "my-project-config-files", // optional s3 bucket where remote_env_file can be located.
+        "remote_env_file": "filename.json", // file in remote_env_bucket containing a flat json object which will be used to set custom environment variables.
         "role_name": "MyLambdaRole", // Lambda execution Role
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,
@@ -194,6 +196,41 @@ To enable Cross-Origin Resource Sharing (CORS) for your application, follow the 
 #### Deploying to a Domain With a Let's Encrypt Certificate
 
 If you want to use Zappa on a domain with a free Let's Encrypt certificate, you can follow [this guide](https://github.com/Miserlou/Zappa/blob/master/docs/domain_with_free_ssl.md).
+
+#### Setting Environment Variables
+
+If you want to use environment variables to configure your application (especially useful for things like sensitive credentials) you can create a file and place it in an s3 bucket to which your lambda function has access (check your roles if you are having problems). Add the `remote_env_bucket` and `remote_env_file` keys to zappa_settings pointing to a file containing a flat, json-encoded object -- each key-value pair on the object will be set as an environment variable and value whenever a new lambda instance spins up.
+
+For Example:
+
+To ensure your application has access to the database credentials without storing them in your version control, you can add a file to s3 with the connection string and load it into the lambda environment using the remote_env_bucket and remote_env_file configuration settings.
+
+super-secret-config.json (uploaded to my-config-bucket)
+```
+{
+    "DB_CONNECTION_STRING": "super-secret:database"
+}
+```
+
+zappa_settings.json
+```
+{
+    "dev": {
+        ...
+        "remote_env_bucket": "my-config-bucket",
+        "remote_env_file": "super-secret-config.json"
+    },
+    ...
+}
+```
+
+Now in your application you can use:
+
+```
+import os
+db_string = os.environ('DB_CONNECTION_STRING')
+```
+
 
 ## Zappa Guides
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -451,6 +451,10 @@ class ZappaCLI(object):
             self.api_stage].get('use_apigateway', True)
         self.lambda_handler = self.zappa_settings[
             self.api_stage].get('lambda_handler', 'handler.lambda_handler')
+        self.remote_env_bucket = self.zappa_settings[
+            self.api_stage].get('remote_env_bucket', None)
+        self.remote_env_file = self.zappa_settings[
+            self.api_stage].get('remote_env_file', None)
 
         self.zappa = Zappa(boto_session=session, profile_name=self.profile_name, aws_region=self.aws_region)
 
@@ -508,6 +512,14 @@ class ZappaCLI(object):
                     settings_s = settings_s + "DOMAIN='{0!s}'\n".format((self.domain))
                 else:
                     settings_s = settings_s + "DOMAIN=None\n"
+
+                # Pass through remote config bucket and path
+                settings_s = settings_s + "REMOTE_ENV_BUCKET='{0!s}'\n".format(
+                    self.remote_env_bucket
+                )
+                settings_s = settings_s + "REMOTE_ENV_FILE".format(
+                    self.remote_env_file
+                )
 
                 # We can be environment-aware
                 settings_s = settings_s + "API_STAGE='{0!s}'\n".format((self.api_stage))

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -5,7 +5,10 @@ import datetime
 import importlib
 import logging
 import traceback
+import os
+import json
 
+import boto3
 from werkzeug.wrappers import Response
 
 # This file may be copied into a project's root,
@@ -46,6 +49,50 @@ class LambdaHandler(object):
         # Loading settings from a python module
         self.settings = importlib.import_module(settings_name)
         self.settings_name = settings_name
+
+        remote_bucket = getattr(self.settings, 'REMOTE_ENV_BUCKET', None)
+        remote_file = getattr(self.settings, 'REMOTE_ENV_FILE', None)
+
+        if remote_bucket and remote_file:
+            self.load_remote_settings(remote_bucket, remote_file)
+
+    def load_remote_settings(self, remote_bucket, remote_file):
+        """
+        Attempt to read a file from s3 containing a flat json object. Adds each
+        key->value pair as environment variables. Helpful for keeping
+        sensitive or stage-specific configuration variables in s3 instead of
+        version control.
+        """
+        boto_session = boto3.Session()
+        s3 = boto_session.resource('s3')
+        try:
+            remote_env_object = s3.Object(
+                remote_bucket,
+                remote_file
+            ).get()
+        except Exception:  # catch everything aws might decide to raise
+            print('Could not load remote settings file')
+            return
+
+        try:
+            content = remote_env_object['Body'].read().decode('utf-8')
+        except Exception as e:  # catch everything aws might decide to raise
+            print('Exception while reading remote settings file', e)
+            return
+
+        try:
+            settings_dict = json.loads(content)
+        except (ValueError, TypeError):
+            print('Failed to parse remote settings!')
+            return
+
+        # add each key-value to environment - overwrites existing keys!
+        for key, value in settings_dict.items():
+            print('Adding {} -> {} to environment'.format(
+                key,
+                value
+            ))
+            os.environ[key] = value
 
     @classmethod
     def lambda_handler(cls, event, context): # pragma: no cover


### PR DESCRIPTION
A few things should be considered/discussed before merging this in:

1. Is this worth baking into zappa or is it better to just let this get handled application by application? A fairly simple snippet or django app / flask extension can do the same thing (in fact, this came from one I have been using) and be more flexible for whatever the user/application needs. On the other hand, including it gives everyone clear instructions on how to answer a fairly common use case that requires at least a bit of lambda/s3 knowledge to tackle correctly, effectively reducing the barrier to entry to using zappa.

1. Should the file format be a json encoded object? This is setting environment vars, which is simple, flat, and typeless - it might make more sense to use a bash- or ini-like format (eg: KEY_NAME=val). On the other hand, we are already zappa_settings.json, so adding another json format file kind of 'fits'.


From the commit message:

On first initialization, attempt to load a json settings file from s3
and use it to populate environment variables. This will be read every
time lambda creates a new instance or restarts but will be cached for
'warm' runs.

Currently assumes the remote env file is a json formatted object
without any nesting -- each top level key-value pair is added to the
environment. Items are added to the environment instead of passed
around as a configuration object for both simplicity within zappa and
maximium compatibility with third party libraries (eg, both flask and
django often take configuration from environment variables).

Access this feature by specifying `remote_env_bucket` and
`remote_env_file` in your zappa_settings.json file.