### PR TITLE
remove input in target creation when scheduling tasks

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -910,7 +910,6 @@ class Zappa(object):
                     {
                         'Id': 'Id' + ''.join(random.choice(string.digits) for _ in range(12)),
                         'Arn': lambda_arn,
-                        'Input': json.dumps({'detail': function})
                     }
                 ]
             )


### PR DESCRIPTION
AFAICT, when injecting JSON on the target instead of the "matched event" prevents the event data this function is looking for above, specifically:
https://github.com/Miserlou/Zappa/blob/master/zappa/handler.py#L120-L122

Since it never gets  the event with the data it's looking for here, like the ARN and the `detail-type`, we're never entering this if block, and the scheduled code isn't running.

Removing the input fixes this.

I can probably help with tests and such, just wanted to let CI run.