### PR TITLE
Raise exceptions when app_module fails to load

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -226,6 +226,10 @@ class LambdaHandler(object):
 
             # Print statements are visible in the logs either way
             print(e)
+            
+            # If we didn't even build an app_module, just raise
+            if not app_module:
+                raise e
 
             # Print the error to the browser upon failure?
             debug = bool(getattr(app_module, settings.DEBUG, True))


### PR DESCRIPTION
Currently I'm getting an import error deep inside my app but I can't see that because it's caught and then I get an exception about app_module being referenced before assignment.
It'd be better if it showed me the real exception