### PR TITLE
IS177-Add Clarity for installing zappa to virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _Before you begin, make sure you have a valid AWS account and your [AWS credenti
 
     $ pip install zappa
 
+It is required to install zappa to the project's virtualenv.
 If you're looking for Django-specific integration, you should probably check out _**[django-zappa](https://github.com/Miserlou/django-zappa)**_ instead.
 
 Next, you'll need to define your local and server-side settings.


### PR DESCRIPTION
Was receiving errors because i had installed zappa globally and not in the virtualenv.