### PR TITLE
Pyenv-compatible deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _Before you begin, make sure you have a valid AWS account and your [AWS credenti
 
     $ pip install zappa
 
-Please note that Zappa *must* be installed into your project's [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
+Please note that Zappa *must* be installed into your project's [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/). If you use pyenv and love to manage virtualenvs with **pyenv-virtualenv**, you just have to call `pyenv local [your_venv_name]` and it's ready.
 
 If you're looking for Django-specific integration, you should probably check out _**[django-zappa](https://github.com/Miserlou/django-zappa)**_ instead.
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -262,7 +262,7 @@ class Zappa(object):
                     subprocess.check_output('pyenv', stderr=subprocess.STDOUT)
                 except OSError as e:
                     print("This directory seems to have pyenv's local venv"
-                          "but pyenv excecutable was not found.")
+                          "but pyenv executable was not found.")
                 with open('.python-version', 'r') as f:
                     env_name = f.read()[:-1]
                     logger.debug('env name = %s' % env_name)

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -265,10 +265,10 @@ class Zappa(object):
                           "but pyenv executable was not found.")
                 with open('.python-version', 'r') as f:
                     env_name = f.read()[:-1]
-                    logger.debug('env name = %s' % env_name)
+                    logger.debug('env name = {}'.format(env_name))
                 bin_path = subprocess.check_output('pyenv which python', shell=True).decode('utf-8')
                 venv = bin_path[:bin_path.rfind(env_name)] + env_name
-                logger.debug('env path = %s' % venv)
+                logger.debug('env path = {}'.format(venv))
             else: # pragma: no cover
                 print("Zappa requires an active virtual environment.")
                 quit()

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -9,6 +9,7 @@ import random
 import requests
 import shutil
 import string
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -253,9 +254,18 @@ class Zappa(object):
         print("Packaging project as zip...")
 
         if not venv:
-            try:
+            if 'VIRTUAL_ENV' in os.environ:
                 venv = os.environ['VIRTUAL_ENV']
-            except KeyError as e: # pragma: no cover
+            elif os.path.exists('.python-version'): # pragma: no cover
+                print("pyenv environment detected.")
+                try:
+                    subprocess.check_output('pyenv', stderr=subprocess.STDOUT)
+                except OSError as e:
+                    print("This directory seems to have pyenv's local env"
+                          "but pyenv excecutable was not found.")
+                venv = subprocess.check_output('pyenv which python', shell=True).decode('utf-8')
+                venv = '/'.join(venv.split('/')[:-2])
+            else: # pragma: no cover
                 print("Zappa requires an active virtual environment.")
                 quit()
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -257,14 +257,18 @@ class Zappa(object):
             if 'VIRTUAL_ENV' in os.environ:
                 venv = os.environ['VIRTUAL_ENV']
             elif os.path.exists('.python-version'): # pragma: no cover
-                print("pyenv environment detected.")
+                logger.debug("Pyenv's local virtualenv detected.")
                 try:
                     subprocess.check_output('pyenv', stderr=subprocess.STDOUT)
                 except OSError as e:
-                    print("This directory seems to have pyenv's local env"
+                    print("This directory seems to have pyenv's local venv"
                           "but pyenv excecutable was not found.")
-                venv = subprocess.check_output('pyenv which python', shell=True).decode('utf-8')
-                venv = '/'.join(venv.split('/')[:-2])
+                with open('.python-version', 'r') as f:
+                    env_name = f.read()[:-1]
+                    logger.debug('env name = %s' % env_name)
+                bin_path = subprocess.check_output('pyenv which python', shell=True).decode('utf-8')
+                venv = bin_path[:bin_path.rfind(env_name)] + env_name
+                logger.debug('env path = %s' % venv)
             else: # pragma: no cover
                 print("Zappa requires an active virtual environment.")
                 quit()

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -266,7 +266,7 @@ class Zappa(object):
                 with open('.python-version', 'r') as f:
                     env_name = f.read()[:-1]
                     logger.debug('env name = {}'.format(env_name))
-                bin_path = subprocess.check_output('pyenv which python', shell=True).decode('utf-8')
+                bin_path = subprocess.check_output(['pyenv', 'which', 'python']).decode('utf-8')
                 venv = bin_path[:bin_path.rfind(env_name)] + env_name
                 logger.debug('env path = {}'.format(venv))
             else: # pragma: no cover


### PR DESCRIPTION
## Issue
Related issue: #195 

## What I did
 - Added deployment method for venv which is under pyenv's management

`.python-version` is a file which `pyenv` makes when setting venv for the working directory and pyenv writes the name of venv into it. Pyenv makes auto-activating possible with this file. Unlike normal `virtualenv` command, pyenv makes / stores new venv into `~/.pyenv/versions/[name_of_venv]` and Zappa has to bring the venv directory from there when making a ZIP of venv.

The command `pyenv which python` shows the venv directory where the real binary of python sits on and Zappa will get it from the STDOUT.

`subprocess.check_output` is not a best method but I believe this is a simplest way to do this because we don't have to take care of pyenv's installed directory.