### PR TITLE
[Doppins] Upgrade dependency lambda-packages to ==0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docutils==0.12
 futures==3.0.5
 hjson==1.5.8
 jmespath==0.9.0
-lambda-packages==0.6.1
+lambda-packages==0.7.0
 python-dateutil==2.5.3
 python-slugify==1.2.0
 requests[security]>=2.10.0


### PR DESCRIPTION
Hi!

A new version was just released of `lambda-packages`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lambda-packages from `==0.6.1` to `==0.7.0`

