### PR TITLE
[Doppins] Upgrade dependency tqdm to ==4.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.5.3
 python-slugify==1.2.0
 requests[security]>=2.10.0
 six==1.10.0
-tqdm==4.8.2
+tqdm==4.8.3
 Werkzeug==0.11.10
 wheel==0.29.0
 wsgi-request-logger==0.4.5


### PR DESCRIPTION
Hi!

A new version was just released of `tqdm`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded tqdm from `==4.8.2` to `==4.8.3`

