### PR TITLE
Expose context lambda payload, context.

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,41 @@
+import unittest
+from zappa.handler import LambdaHandler
+
+
+def no_args():
+    return
+
+
+def one_arg(first):
+    return first
+
+
+def two_args(first, second):
+    return first, second
+
+
+def var_args(*args):
+    return args
+
+
+def var_args_with_one(first, *args):
+    return first, args[0]
+
+def unsupported(first, second, third):
+    return first, second, third
+
+
+class TestZappa(unittest.TestCase):
+
+    def test_run_function(self):
+        self.assertIsNone(LambdaHandler.run_function(no_args, 'e', 'c'))
+        self.assertEqual(LambdaHandler.run_function(one_arg, 'e', 'c'), 'e')
+        self.assertEqual(LambdaHandler.run_function(two_args, 'e', 'c'), ('e', 'c'))
+        self.assertEqual(LambdaHandler.run_function(var_args, 'e', 'c'), ('e', 'c'))
+        self.assertEqual(LambdaHandler.run_function(var_args_with_one, 'e', 'c'), ('e', 'c'))
+
+        try:
+            LambdaHandler.run_function(unsupported, 'e', 'c')
+            self.fail('Exception expected')
+        except RuntimeError, e:
+            pass

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -154,10 +154,9 @@ class LambdaHandler(object):
 
             whole_function = event['command']
             app_function = self.import_module_and_get_function(whole_function)
-            result = app_function()
+            result = app_function(event, context)
             print("Result of %s:" % whole_function)
             print(result)
-
             return result
 
         # This is a Django management command invocation.
@@ -250,6 +249,7 @@ class LambdaHandler(object):
                 # We are always on https on Lambda, so tell our wsgi app that.
                 environ['HTTPS'] = 'on'
                 environ['wsgi.url_scheme'] = 'https'
+                environ['lambda.context'] = context
 
                 # Execute the application
                 response = Response.from_app(app, environ)


### PR DESCRIPTION
Useful e.g. when you need to get access to current lambda function name.

```current_lambda_name = request.environ['lambda.context'].function_name```

And having payload passed to 'command' invocations allows for parametrised calls.