### PR TITLE
Content type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ to change Zappa's behavior. Use these at your own risk!
         "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "integration_response_codes": [200, 301, 404, 500], // Integration response status codes to route
+        "integration_content_type_aliases": {"application/json": ["application/vnd.webhooks+json"]} //Useful for routing requests with non-standard mime types.
         "keep_warm": true, // Create CloudWatch events to keep the server warm.
         "keep_warm_expressions": "rate(5 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 5 minutes.
         "lambda_handler": "your_custom_handler", // The name of Lambda handler. Default: handler.lambda_handler
@@ -323,6 +324,30 @@ Now in your application you can use:
 import os
 db_string = os.environ('DB_CONNECTION_STRING')
 ```
+
+#### Setting integration content-type aliases
+
+By default Zappa will route only following mime-types that are set explicitly via `Content-Type` header: `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data` (if not Content-Type header is set, application/json mapping will apply).
+
+If a request comes in with `Content-Type` header set to anything but those 3 values Amazon will return a 415 status code and a `Mime type not supported message`.
+
+If there is a need to support custom mime-types (e.g. when a third-party making requests to your API) you can specify aliases for the 3 default types:
+
+zappa_settings.json:
+```javascript
+{
+    "dev": {
+        ...
+        "integration_content_type_aliases": {
+            "application/json": ["application/vnd.webhooks+json"]
+         }
+    },
+    ...
+}
+```
+
+Now Zappa will use `application/json's` template to route requests with mime-type of `application/vnd.webhooks+json`.
+
 
 ## Zappa Guides
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -249,7 +249,7 @@ class ZappaCLI(object):
         if self.use_apigateway:
             # Create and configure the API Gateway
             api_id = self.zappa.create_api_gateway_routes(
-                self.lambda_arn, self.lambda_name, self.api_key_required)
+                self.lambda_arn, self.lambda_name, self.api_key_required, self.integration_content_type_aliases)
 
             # Deploy the API!
             cache_cluster_enabled = self.zappa_settings[self.api_stage].get('cache_cluster_enabled', False)
@@ -720,6 +720,8 @@ class ZappaCLI(object):
             self.api_stage].get('timeout_seconds', 30)
         self.use_apigateway = self.zappa_settings[
             self.api_stage].get('use_apigateway', True)
+        self.integration_content_type_aliases = self.zappa_settings[
+            self.api_stage].get('integration_content_type_aliases', {})
         self.lambda_handler = self.zappa_settings[
             self.api_stage].get('lambda_handler', 'handler.lambda_handler')
         self.remote_env_bucket = self.zappa_settings[

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -608,7 +608,8 @@ class Zappa(object):
     # API Gateway
     ##
 
-    def create_api_gateway_routes(self, lambda_arn, api_name=None, api_key_required=False):
+    def create_api_gateway_routes(self, lambda_arn, api_name=None, api_key_required=False,
+                                  integration_content_type_aliases=None):
         """
         Creates the API Gateway for this Zappa deployment.
 
@@ -651,7 +652,8 @@ class Zappa(object):
                 root_id = item['id']
         if not root_id: # pragma: no cover
             return False
-        self.create_and_setup_methods(api_id, root_id, lambda_arn, progress.update, api_key_required)
+        self.create_and_setup_methods(api_id, root_id, lambda_arn, progress.update, api_key_required,
+                                      integration_content_type_aliases)
 
         parent_id = root_id
         for i in range(1, self.parameter_depth):
@@ -664,11 +666,13 @@ class Zappa(object):
             resource_id = response['id']
             parent_id = resource_id
 
-            self.create_and_setup_methods(api_id, resource_id, lambda_arn, progress.update, api_key_required) # pragma: no cover
+            self.create_and_setup_methods(api_id, resource_id, lambda_arn, progress.update, api_key_required,
+                                          integration_content_type_aliases) # pragma: no cover
 
         return api_id
 
-    def create_and_setup_methods(self, api_id, resource_id, lambda_arn, report_progress, api_key_required):
+    def create_and_setup_methods(self, api_id, resource_id, lambda_arn, report_progress, api_key_required,
+                                 integration_content_type_aliases):
         """
         Sets up the methods, integration responses and method responses for a given API Gateway resource.
 
@@ -692,6 +696,12 @@ class Zappa(object):
                 'application/x-www-form-urlencoded': post_template_mapping,
                 'multipart/form-data': form_encoded_template_mapping
             }
+            if integration_content_type_aliases:
+                for content_type in content_mapping_templates.keys():
+                    aliases = integration_content_type_aliases.get(content_type, [])
+                    for alias in aliases:
+                        content_mapping_templates[alias] = content_mapping_templates[content_type]
+
             credentials = self.credentials_arn  # This must be a Role ARN
             uri = 'arn:aws:apigateway:' + self.boto_session.region_name + ':lambda:path/2015-03-31/functions/' + lambda_arn + '/invocations'
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -32,29 +32,6 @@ logger.setLevel(logging.INFO)
 # Policies And Template Mappings
 ##
 
-TEMPLATE_MAPPING = """{
-  "body" : "$util.base64Encode($input.json("$"))",
-  "headers": {
-    #foreach($header in $input.params().header.keySet())
-    "$header": "$util.escapeJavaScript($input.params().header.get($header))" #if($foreach.hasNext),#end
-
-    #end
-  },
-  "method": "$context.httpMethod",
-  "params": {
-    #foreach($param in $input.params().path.keySet())
-    "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
-
-    #end
-  },
-  "query": {
-    #foreach($queryParam in $input.params().querystring.keySet())
-    "$queryParam": "$util.escapeJavaScript($input.params().querystring.get($queryParam))" #if($foreach.hasNext),#end
-
-    #end
-  }
-}"""
-
 POST_TEMPLATE_MAPPING = """#set($rawPostData = $input.path("$"))
 {
   "body" : "$util.base64Encode($input.body)",
@@ -708,7 +685,6 @@ class Zappa(object):
             )
             report_progress()
 
-            template_mapping = TEMPLATE_MAPPING
             post_template_mapping = POST_TEMPLATE_MAPPING
             form_encoded_template_mapping = FORM_ENCODED_TEMPLATE_MAPPING
             content_mapping_templates = {


### PR DESCRIPTION
Allow setting up aliases for integration template content types. Useful for e.g. picking up  `application/whatever+json`  as `application/json`.

 