### PR TITLE
Disable passthrough for unrecognised media types.

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -730,7 +730,8 @@ class Zappa(object):
                 requestParameters={},
                 requestTemplates=content_mapping_templates,
                 cacheNamespace='none',
-                cacheKeyParameters=[]
+                passthroughBehavior='NEVER',
+                cacheKeyParameters=[],
             )
             report_progress()
 


### PR DESCRIPTION
 Clients that explicitly set an unmapped media type will be presented with a 415 status code and a message saying "Unsupported media type".

Helps to identify media type issues early.