### PR TITLE
Cloud watch event management improvements

### DIFF
--- a/tests/placebo/TestZappa.test_cli_aws_status/events.ListRules_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws_status/events.ListRules_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Rules": [
+            {
+                "ScheduleExpression": "rate(5 minutes)", 
+                "Name": "zappa-keep-warm-zappa-ttt666", 
+                "RoleArn": "arn:aws:iam::724336686645:role/ZappaLambdaExecution", 
+                "State": "ENABLED", 
+                "Arn": "arn:aws:events:us-east-1:724336686645:rule/zappa-keep-warm-zappa-ttt666", 
+                "Description": "Zappa Keep Warm - zappa-ttt666"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "afe859ba-28f4-11e6-aa28-4d9f2eb25de5"
+        }
+    }
+}

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -259,10 +259,8 @@ class ZappaCLI(object):
                                                        timeout=self.timeout_seconds,
                                                        memory_size=self.memory_size)
 
-        # Create a Keep Warm for this deployment
-        if self.stage_config.get('keep_warm', True):
-            keep_warm_rate = self.stage_config.get('keep_warm_expression', "rate(5 minutes)")
-            self.zappa.create_keep_warm(self.lambda_arn, self.lambda_name, schedule_expression=keep_warm_rate)
+        # Schedule events for this deployment
+        self.schedule()
         endpoint_url = ''
         if self.use_apigateway:
             # Create and configure the API Gateway
@@ -415,17 +413,12 @@ class ZappaCLI(object):
             self.zappa.remove_api_gateway_logs(self.lambda_name)
 
         gateway_id = self.zappa.undeploy_api_gateway(self.lambda_name, self.api_key_required)
-
-        if self.stage_config.get('keep_warm', True):
-            self.zappa.remove_keep_warm(self.lambda_name)
-
+        self.unschedule()  # removes event triggers, including warm up event.
         self.zappa.delete_lambda_function(self.lambda_name)
         if remove_logs:
             self.zappa.remove_lambda_function_logs(self.lambda_name)
 
         print("Done!")
-
-        return
 
     def schedule(self):
         """
@@ -433,24 +426,33 @@ class ZappaCLI(object):
         setup up regular execution.
 
         """
+        events = self.stage_config.get('events')
 
-        if self.stage_config.get('events'):
-            events = self.stage_config['events']
-
+        if events:
             if not isinstance(events, list): # pragma: no cover
                 print("Events must be supplied as a list.")
                 return
 
+        if self.zappa_settings[self.api_stage].get('keep_warm', True):
+            if not events:
+                events = []
+            keep_warm_rate = self.zappa_settings[self.api_stage].get('keep_warm_expression', "rate(5 minutes)")
+            events.append({'name': 'zappa-keep-warm',
+                           'function': self.lambda_handler,
+                           'expression': keep_warm_rate,
+                           'description': 'Zappa Keep Warm - {}'.format(self.lambda_name)})
+            print("Keep warm event will be scheduled.")
+        if events:
             try:
                 function_response = self.zappa.lambda_client.get_function(FunctionName=self.lambda_name)
             except botocore.exceptions.ClientError as e: # pragma: no cover
-                print("Function does not exist, please deploy first. Ex: zappa deploy {}".format(self.api_stage))
+                print("Function does not exist, please deploy first. Ex: zappa deploy {}.".format(self.api_stage))
                 return
 
             print("Scheduling..")
             self.zappa.schedule_events(
                 lambda_arn=function_response['Configuration']['FunctionArn'],
-                lambda_name=function_response['Configuration']['FunctionName'],
+                lambda_name=self.lambda_name,
                 events=events
                 )
 
@@ -462,26 +464,32 @@ class ZappaCLI(object):
 
         """
 
-        if self.stage_config.get('events', None):
-            events = self.stage_config['events']
+        # Run even events are not defined to remove previously existing ones (thus default to []).
+        events = self.stage_config.get('events', [])
 
-            if not isinstance(events, list): # pragma: no cover
-                print("Events must be supplied as a list.")
-                return
+        if not isinstance(events, list): # pragma: no cover
+            print("Events must be supplied as a list.")
+            return
 
-            try:
-                function_response = self.zappa.lambda_client.get_function(FunctionName=self.lambda_name)
-            except botocore.exceptions.ClientError as e: # pragma: no cover
-                print("Function does not exist, please deploy first. Ex: zappa deploy {}".format(self.api_stage))
-                return
+        if not events:
+            print("No events defined in zappa config. Proceeding to unschedule to remove leftovers (in case "
+                  "configuration was changed).")
 
-            print("Unscheduling..")
-            self.zappa.unschedule_events(
-                lambda_arn=function_response['Configuration']['FunctionArn'],
-                events=events
-                )
+        function_arn = None
+        try:
+            function_response = self.zappa.lambda_client.get_function(FunctionName=self.lambda_name)
+            function_arn = function_response['Configuration']['FunctionArn']
+        except botocore.exceptions.ClientError as e: # pragma: no cover
+            print("Function does not exist, you should deploy first. Ex: zappa deploy {}. "
+                  "Proceeding to unschedule CloudWatch based events.".format(self.api_stage))
 
-        return
+        print("Unscheduling..")
+        self.zappa.unschedule_events(
+            lambda_name=self.lambda_name,
+            lambda_arn=function_arn,
+            events=events
+            )
+
 
     def invoke(self, function_name, command="command"):
         """
@@ -592,7 +600,7 @@ class ZappaCLI(object):
         tabular_print("Domain URL", domain_url)
 
         # Scheduled Events
-        event_rules = self.zappa.get_event_rules_for_arn(conf['FunctionArn'])
+        event_rules = self.zappa.get_event_rules_for_lambda(lambda_name=self.lambda_name)
         tabular_print("Num. Event Rules", len(event_rules))
         for rule in event_rules:
             rule_name = rule['Name']

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -336,6 +336,8 @@ class ZappaCLI(object):
         else:
             endpoint_url = self.zappa.get_api_url(self.lambda_name, self.api_stage)
 
+        self.schedule()
+
         self.zappa.update_stage_config(
             self.lambda_name,
             self.api_stage,

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -435,7 +435,7 @@ class ZappaCLI(object):
                 events = []
             keep_warm_rate = self.zappa_settings[self.api_stage].get('keep_warm_expression', "rate(5 minutes)")
             events.append({'name': 'zappa-keep-warm',
-                           'function': 'handler.heater',
+                           'function': 'handler.keep_warm_callback',
                            'expression': keep_warm_rate,
                            'description': 'Zappa Keep Warm - {}'.format(self.lambda_name)})
             print("Keep warm event will be scheduled.")

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -435,7 +435,7 @@ class ZappaCLI(object):
                 events = []
             keep_warm_rate = self.zappa_settings[self.api_stage].get('keep_warm_expression', "rate(5 minutes)")
             events.append({'name': 'zappa-keep-warm',
-                           'function': self.lambda_handler,
+                           'function': 'handler.heater',
                            'expression': keep_warm_rate,
                            'description': 'Zappa Keep Warm - {}'.format(self.lambda_name)})
             print("Keep warm event will be scheduled.")

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -324,11 +324,6 @@ class ZappaCLI(object):
         self.lambda_arn = self.zappa.update_lambda_function(
             self.s3_bucket_name, self.zip_path, self.lambda_name)
 
-        # Create a Keep Warm for this deployment
-        if self.stage_config.get('keep_warm', True):
-            keep_warm_rate = self.stage_config.get('keep_warm_expression', "rate(5 minutes)")
-            self.zappa.create_keep_warm(self.lambda_arn, self.lambda_name, schedule_expression=keep_warm_rate)
-
         # Remove the uploaded zip from S3, because it is now registered..
         self.zappa.remove_from_s3(self.zip_path, self.s3_bucket_name)
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -461,16 +461,12 @@ class ZappaCLI(object):
 
         """
 
-        # Run even events are not defined to remove previously existing ones (thus default to []).
+        # Run even if events are not defined to remove previously existing ones (thus default to []).
         events = self.stage_config.get('events', [])
 
         if not isinstance(events, list): # pragma: no cover
             print("Events must be supplied as a list.")
             return
-
-        if not events:
-            print("No events defined in zappa config. Proceeding to unschedule to remove leftovers (in case "
-                  "configuration was changed).")
 
         function_arn = None
         try:

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -345,5 +345,7 @@ def lambda_handler(event, context): # pragma: no cover
     return LambdaHandler.lambda_handler(event, context)
 
 
-def heater(event, context):
-    return "I'm warm!"
+def keep_warm_callback(event, context):
+    """This method is triggered by the CloudWatch event scheduled when keep_warm setting is set to true. """
+    lambda_handler(event={}, context=context)  # overriding event with an empty one so that web app initialization will
+    # be triggered.

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -343,3 +343,7 @@ class LambdaHandler(object):
 
 def lambda_handler(event, context): # pragma: no cover
     return LambdaHandler.lambda_handler(event, context)
+
+
+def heater(event, context):
+    return "I'm warm!"

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1251,6 +1251,7 @@ class Zappa(object):
         return [self.events_client.describe_rule(Name=r) for r in rules]
 
     def unschedule_events(self, events, lambda_arn=None, lambda_name=None):
+
         """
         Given a list of events, unschedule these CloudWatch Events.
 


### PR DESCRIPTION
- Use lambda name as prefix for all CW events. 
- Make scheduling/un-scheduling part of deploy/undeploy. 
- Schedule warm-up event together with the rest of CW events.