### PR TITLE
Exception handling callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ to change Zappa's behavior. Use these at your own risk!
                 }
             }
         ],
+        "exception_handler": "your_module.report_exception", // function that will be invoked in case zappa sees an unhandled exception raised from your code
         "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "integration_response_codes": [200, 301, 404, 500], // Integration response status codes to route
@@ -380,6 +381,12 @@ zappa_settings.json:
 ```
 
 Now Zappa will use `application/json`'s template to route requests with MIME-type of `application/vnd.webhooks+json`. You will need to re-deploy your application for this change to take affect.
+
+
+#### Catching unhandled exceptions
+
+TODO:
+
 
 ## Zappa Guides
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,26 @@ Now Zappa will use `application/json`'s template to route requests with MIME-typ
 
 #### Catching unhandled exceptions
 
-TODO:
+By default if an exception happens in your code zappa will just print the stacktrace into cloud watch log. If you wish have an external reporting tool taking note of those exceptions you can use `exception_handler` configuration option.
+
+zappa_settings.json:
+```javascript
+{
+    "dev": {
+        ...
+        "exception_handler": "your_module.unhandled_exceptions"
+    },
+    ...
+}
+```
+
+The function has to accept three arguments: exception, event, and context:
+
+your_module.py
+```python
+def unhandled_exceptions(e, event, context):
+    send_to_raygun(e, event)  # gather data you need and send
+```
 
 
 ## Zappa Guides

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -96,6 +96,7 @@ class ZappaCLI(object):
     lambda_handler = None
     django_settings = None
     manage_roles = True
+    exception_handler = None
 
     @property
     def stage_config(self):
@@ -849,6 +850,8 @@ class ZappaCLI(object):
             self.api_stage].get('memory_size', 512)
         self.app_function = self.zappa_settings[
             self.api_stage].get('app_function', None)
+        self.exception_handler = self.zappa_settings[
+            self.api_stage].get('exception_handler', None)
         self.aws_region = self.zappa_settings[
             self.api_stage].get('aws_region', 'us-east-1')
         self.debug = self.zappa_settings[
@@ -932,6 +935,11 @@ class ZappaCLI(object):
                 if self.app_function:
                     app_module, app_function = self.app_function.rsplit('.', 1)
                     settings_s = settings_s + "APP_MODULE='{0!s}'\nAPP_FUNCTION='{1!s}'\n".format(app_module, app_function)
+
+                if self.exception_handler:
+                    settings_s += "EXCEPTION_HANDLER='{0!s}'\n".format(self.exception_handler)
+                else:
+                    settings_s += "EXCEPTION_HANDLER=None\n"
 
                 if self.debug:
                     settings_s = settings_s + "DEBUG='{0!s}'\n".format((self.debug)) # Cast to Bool in handler

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -119,7 +119,19 @@ class LambdaHandler(object):
 
     @classmethod
     def lambda_handler(cls, event, context): # pragma: no cover
-        return cls().handler(event, context)
+        handler = cls()
+        try:
+            return handler.handler(event, context)
+        except Exception as ex:
+            exception_handler = handler.settings.EXCEPTION_HANDLER
+            if exception_handler:
+                handler_function = handler.import_module_and_get_function(exception_handler)
+                try:
+                    handler_function(ex, event, context)
+                except Exception as cex:
+                    logger.error(msg='Failed to process exception via custom handler.')
+                    print(cex)
+            raise ex
 
     def handler(self, event, context):
         """

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -122,6 +122,9 @@ class LambdaHandler(object):
         handler = cls()
         try:
             return handler.handler(event, context)
+        except LambdaException as lex:
+            # do nothing about LambdaExceptions since those are already handled (or should be handled by the wsgi app).
+            raise lex
         except Exception as ex:
             exception_handler = handler.settings.EXCEPTION_HANDLER
             if exception_handler:


### PR DESCRIPTION
Useful e.g. for sending crash reports to Raygun or Sentry, or any other error accounting tool.