### PR TITLE
Cookie expiry parsing

### DIFF
--- a/zappa/middleware.py
+++ b/zappa/middleware.py
@@ -175,7 +175,7 @@ class ZappaWSGIMiddleware(object):
             for kvp in kvps:
                 kvp = kvp.strip()
                 if 'expires' in kvp.lower():
-                    exp = time.strptime(kvp.split('=')[1], "%a, %d-%b-%Y %H:%M:%S GMT")
+                    exp = time.strptime(kvp.split('=')[1], "%a, %d-%b-%y %H:%M:%S GMT")
                     yield name, exp
                     break
 


### PR DESCRIPTION
Cookie year format is 4 digits, hence a lowercase "y"