### PR TITLE
Pick best match for a domain name when filtering on hosted zones.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -500,6 +500,42 @@ class TestZappa(unittest.TestCase):
         # if os.path.isfile('zappa_settings.json'):
         #     os.remove('zappa_settings.json')
 
+    def test_domain_name_match(self):
+        # Simple sanity check
+        zone = Zappa._get_best_match_zone(all_zones={ 'HostedZones': [
+            {
+                'Name': 'example.com.au.',
+                'Id': 'zone-correct'
+            }
+        ]},
+            domain='www.example.com.au')
+        assert zone == 'zone-correct'
+
+        # No match test
+        zone = Zappa._get_best_match_zone(all_zones={'HostedZones': [
+            {
+                'Name': 'example.com.au.',
+                'Id': 'zone-incorrect'
+            }
+        ]},
+            domain='something-else.com.au')
+        assert zone is None
+
+        # More involved, better match should win.
+        zone = Zappa._get_best_match_zone(all_zones={'HostedZones': [
+            {
+                'Name': 'example.com.au.',
+                'Id': 'zone-incorrect'
+            },
+            {
+                'Name': 'subdomain.example.com.au.',
+                'Id': 'zone-correct'
+            }
+        ]},
+            domain='www.subdomain.example.com.au')
+        assert zone == 'zone-correct'
+
+
     ##
     # Let's Encrypt / ACME
     ##

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1425,14 +1425,20 @@ class Zappa(object):
     def get_hosted_zone_id_for_domain(self, domain):
         """
         Get the Hosted Zone ID for a given domain.
+
         """
         all_zones = self.route53.list_hosted_zones()
+        return self._get_best_match_zone(all_zones, domain)
 
-        for zone in all_zones['HostedZones']:
-            if zone['Name'][:-1] in domain:
-                return zone['Id']
-
-        return None
+    @staticmethod
+    def _get_best_match_zone(all_zones, domain):
+        """Returns zone id which name is closer matched with domain name."""
+        zones = {zone['Name'][:-1]: zone['Id'] for zone in all_zones['HostedZones'] if zone['Name'][:-1] in domain}
+        if zones:
+            keys = max(zones.keys(), key=lambda a: len(a))  # get longest key -- best match.
+            return zones[keys]
+        else:
+            return None
 
     def set_dns_challenge_txt(self, zone_id, domain, txt_challenge):
         """


### PR DESCRIPTION
Fixes an issue when zappa picks an incorrect zone if two zones have same substring. E.g. if both `example.com.au.` and `wider.example.com.au` are present, zappa could pick the former one given `subdomain.wider.example.com.au` as domain name.

The change makes zappa pick best match (longest substring).
