### PR TITLE
Call django.setup() from zappa only for django < 1.7.0

### DIFF
--- a/zappa/ext/django_zappa.py
+++ b/zappa/ext/django_zappa.py
@@ -1,16 +1,20 @@
+import os
 import sys
 
 # add the Lambda root path into the sys.path
 sys.path.append('/var/task')
 
-from django.core.handlers.wsgi import WSGIHandler
-from django.core.wsgi import get_wsgi_application
-import os
 
 def get_django_wsgi(settings_module):
+    from django.core.wsgi import get_wsgi_application
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
 
     import django
-    django.setup()
+
+    if django.VERSION[0] <= 1 and django.VERSION[1] < 7:
+        # call django.setup only for django <1.7.0
+        # (because setup already in get_wsgi_application since that)
+        # https://github.com/django/django/commit/80d74097b4bd7186ad99b6d41d0ed90347a39b21
+        django.setup()
 
     return get_wsgi_application()


### PR DESCRIPTION
* because since django 1.7 it leads to double initialization, which is problematic on some installations

To be honest I didn't test it on any django except 1.10, but I am sure that with django 1.9 and 1.10 on my installation it has such problems without this fix. Shall we add tox here?

The error message was about "Populate isn't reentrant".