### PR TITLE
Fixed minor typo in zappa/cli.py

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1239,7 +1239,7 @@ def handle(): # pragma: no cover
             cli.remove_uploaded_zip()
             cli.remove_local_zip()
 
-        click.echo("Oh no! An " + click.style("error occured", fg='red', bold=True) + "! :(")
+        click.echo("Oh no! An " + click.style("error occurred", fg='red', bold=True) + "! :(")
         click.echo("\n==============\n")
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
Great thanks to all the authors and contributors for this awesome project!

I found a typo in an error message while using zappa with my messy environment, 
and here's the fix 😉


