### PR TITLE
Only update the CF stack if it exists in the cli

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -418,7 +418,7 @@ class ZappaCLI(object):
                                                     self.api_key_required,
                                                     self.integration_content_type_aliases,
                                                     auth_type)
-        self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True)
+        self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True, update_only=True)
 
         if self.stage_config.get('domain', None):
             endpoint_url = self.stage_config.get('domain')

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1086,7 +1086,10 @@ class Zappa(object):
         Given a lambda_name and stage_name, return a valid API URL.
         """
         api_id = self.get_api_id(lambda_name)
-        return "https://{}.execute-api.{}.amazonaws.com/{}".format(api_id, self.boto_session.region_name, stage_name)
+        if api_id:
+            return "https://{}.execute-api.{}.amazonaws.com/{}".format(api_id, self.boto_session.region_name, stage_name)
+        else:
+            return None
 
     def get_api_id(self, lambda_name):
         """
@@ -1097,6 +1100,13 @@ class Zappa(object):
                                                               LogicalResourceId='Api')
             return response['StackResourceDetail']['PhysicalResourceId']
         except:
+            # try the old method (project was probably made on an older, non CF version)
+            response = self.apigateway_client.get_rest_apis(limit=500)
+
+            for item in response['items']:
+                if item['name'] == lambda_name:
+                    return item['id']
+
             logger.exception('Could not get API id')
             return None
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -991,7 +991,7 @@ class Zappa(object):
                                                  integration_content_type_aliases, auth_type)
         return self.cf_template
 
-    def update_stack(self, name, working_bucket, wait=False):
+    def update_stack(self, name, working_bucket, wait=False, update_only=False):
         """
         Update or create the CF stack managed by Zappa.
         """
@@ -1011,6 +1011,10 @@ class Zappa(object):
             self.cf_client.describe_stacks(StackName=name)
         except botocore.client.ClientError:
             update = False
+
+        if update_only and not update:
+            print('CloudFormation stack missing, re-deploy to enable updates')
+            return
 
         if not update:
             self.cf_client.create_stack(StackName=name,


### PR DESCRIPTION
If a project was previously deployed without the CF code, we shouldn't try to create it in the update command.