### PR TITLE
Simplify API Gateway configuration

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -31,17 +31,22 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
             if canonical != header:
                 headers[canonical] = headers.pop(header)
 
-        path = "/"
-        for key in sorted(params.keys()):
-            path = path + params[key] + "/"
+        if 'url' in params:
+            # new style
+            path = '/' + params.get('url') + "/"
+        else:
+            # old style
+            path = "/"
+            for key in sorted(params.keys()):
+                path = path + params[key] + "/"
 
-        # This determines if we should return
-        # site.com/resource/ : site.com/resource
-        # site.com/resource : site.com/resource
-        # vs.
-        # site.com/resource/ : site.com/resource/
-        # site.com/resource : site.com/resource/
-        # If no params are present, keep the slash.
+            # This determines if we should return
+            # site.com/resource/ : site.com/resource
+            # site.com/resource : site.com/resource
+            # vs.
+            # site.com/resource/ : site.com/resource/
+            # site.com/resource : site.com/resource/
+            # If no params are present, keep the slash.
         if not trailing_slash and params.keys():
             path = path[:-1]
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -695,18 +695,15 @@ class Zappa(object):
         self.create_and_setup_methods(restapi, root_id, lambda_arn, api_key_required,
                                       integration_content_type_aliases, authorization_type, 0)
 
-        parent_id = root_id
-        for i in range(1, self.parameter_depth):
-            resource = troposphere.apigateway.Resource('Resource{0}'.format(i))
-            self.cf_api_resources.append(resource.title)
-            resource.RestApiId = troposphere.Ref(restapi)
-            resource.ParentId = parent_id
-            resource.PathPart = "{parameter_" + str(i) + "}"
-            self.cf_template.add_resource(resource)
+        resource = troposphere.apigateway.Resource('ResourceAnyPathSlashed')
+        self.cf_api_resources.append(resource.title)
+        resource.RestApiId = troposphere.Ref(restapi)
+        resource.ParentId = root_id
+        resource.PathPart = "{url+}"
+        self.cf_template.add_resource(resource)
 
-            self.create_and_setup_methods(restapi, resource, lambda_arn, api_key_required,
-                                          integration_content_type_aliases, authorization_type, i)  # pragma: no cover
-            parent_id = troposphere.Ref(resource)
+        self.create_and_setup_methods(restapi, resource, lambda_arn, api_key_required,
+                                      integration_content_type_aliases, authorization_type, 1)  # pragma: no cover
 
         return restapi
 
@@ -752,8 +749,8 @@ class Zappa(object):
             integration.Credentials = credentials
             integration.IntegrationHttpMethod = 'POST'
             integration.IntegrationResponses = []
-            integration.PassthroughBehavior = 'NEVER'
-            integration.RequestParameters = {}
+            # integration.PassthroughBehavior = 'NEVER'
+            # integration.RequestParameters = {}
             integration.RequestTemplates = content_mapping_templates
             integration.Type = 'AWS'
             integration.Uri = uri


### PR DESCRIPTION
Checked it on couple of my installations.
It probably requires redeployment, but `¯\_(ツ)_/¯`
If cloudformation replaces fine then it shall work fine; if cloudformation script have no changes and still sends old parameters then it's also shall be fine.
Also, I use `"http_methods": ["ANY"]`, and I can't see the reason not to make it default behaviour. Just because it N times simplier for API Gateway and CF creation (N equal to current length of this list).

Also I've tried to make better slash handling (true slash passing, not monkeyappending it), but unsuccessfully yet. I'll return to it when I have more time.