### PR TITLE
Fixes #333

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1462,7 +1462,8 @@ class Zappa(object):
         rules = [r['Name'] for r in self.events_client.list_rules(NamePrefix=lambda_name)['Rules']]
         return [self.events_client.describe_rule(Name=r) for r in rules]
 
-    def unschedule_events(self, events, lambda_arn=None, lambda_name=None, excluded_source_services=[]):
+    def unschedule_events(self, events, lambda_arn=None, lambda_name=None, excluded_source_services=None):
+        excluded_source_services = excluded_source_services or []
         """
         Given a list of events, unschedule these CloudWatch Events.
 


### PR DESCRIPTION
I fixed the issue with DynamoDB streams and also introduced a check if it is already existing to prevent rescheduling stream events (dynamodb, kinesis) on every update. I made the experience that it takes up to 10 minute until a newly added stream processes the first event. All other events still are removed and re-added on every update.

As you predicted, this was a lot of trial and error, I hope I did not break anything existing. I tested manually against S3, DynamoDB and CloudWatch events. 
Also, I am fairly new to Python, so let me know if I did something weird.