### PR TITLE
Allow usage of an up-to-date version of boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ to change Zappa's behavior. Use these at your own risk!
             }
         ],
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
-        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive
+        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "iam_authorization": true, // optional, use IAM to require request signing. Default false.
         "integration_response_codes": [200, 301, 404, 500], // Integration response status codes to route

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -179,7 +179,7 @@ LAMBDA_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-nor
 
 ZIP_EXCLUDES = [
     '*.exe', '*.DS_Store', '*.Python', '*.git', '.git/*', '*.zip', '*.tar.gz',
-    '*.hg', '*.egg-info', 'botocore*', 'pip', 'docutils*', 'boto3*', 'setuputils*'
+    '*.hg', '*.egg-info', 'pip', 'docutils*', 'setuputils*'
 ]
 
 ##


### PR DESCRIPTION
Resolve #346.

boto3 and boto can still be excluded by using the `exclude` setting.