### PR TITLE
Fixes #333

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,23 +265,6 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
        ]
 ```
 
-Please note that your Lambda execution role needs the following permissions on your stream:
-
-```javascript
-{
-  "Effect": "Allow",
-  "Action": [
-    "dynamodb:GetRecords",
-    "dynamodb:GetShardIterator",
-    "dynamodb:DescribeStream",
-    "dynamodb:ListStreams"
-  ],
-  "Resource": {
-    "Fn::Sub": "arn:aws:dynamodb:us-east-1:1234554:table/YourTable/stream/*"
-  }
-}
-```
-
 #### Undeploy
 
 If you need to remove the API Gateway and Lambda function that you have previously published, you can simply:

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ to change Zappa's behavior. Use these at your own risk!
             }
         ],
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
-        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive
+        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "iam_authorization": true, // optional, use IAM to require request signing. Default false.
         "integration_response_codes": [200, 301, 404, 500], // Integration response status codes to route

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
                "event_source": {
                     "arn":  "arn:aws:dynamodb:us-east-1:1234554:table/YourTable/stream/2016-05-11T00:00:00.000",
                     "starting_position": "TRIM_HORIZON", // Supported values: TRIM_HORIZON, LATEST
-                    "batch  size": 50, // Max: 1000
+                    "batch_size": 50, // Max: 1000
                     "enabled": true // Default is false
                }
            }

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ In your *zappa_settings.json* file, define your [event sources](http://docs.aws.
             "event_source": {
                   "arn":  "arn:aws:s3:::my-bucket",
                   "events": [
-                    "s3:ObjectCreated:*"
+                    "s3:ObjectCreated:*" // Supported event types: http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
                   ]
                }
             }],
@@ -247,6 +247,39 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
                 }
             }
         ]
+```
+
+[DynamoDB](http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html) and [Kinesis](http://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) are slightly different as it is not event based but pulling from a stream:
+
+```javascript
+       "events": [
+           {
+               "function": "replication.replicate_records",
+               "event_source": {
+                    "arn":  "arn:aws:dynamodb:us-east-1:1234554:table/YourTable/stream/2016-05-11T00:00:00.000",
+                    "starting_position": "TRIM_HORIZON", // Supported values: TRIM_HORIZON, LATEST
+                    "batch  size": 50, // Max: 1000
+                    "enabled": true // Default is false
+               }
+           }
+       ]
+```
+
+Please note that your Lambda execution role needs the following permissions on your stream:
+
+```javascript
+{
+  "Effect": "Allow",
+  "Action": [
+    "dynamodb:GetRecords",
+    "dynamodb:GetShardIterator",
+    "dynamodb:DescribeStream",
+    "dynamodb:ListStreams"
+  ],
+  "Resource": {
+    "Fn::Sub": "arn:aws:dynamodb:us-east-1:1234554:table/YourTable/stream/*"
+  }
+}
 ```
 
 #### Undeploy

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -345,14 +345,13 @@ class LambdaHandler(object):
 
             records = event.get('Records')
             result = None
-            for record in records:
-                whole_function = self.get_function_for_aws_event(record)
-                if whole_function:
-                    app_function = self.import_module_and_get_function(whole_function)
-                    result = self.run_function(app_function, event, context)
-                    logger.debug(result)
-                else:
-                    logger.error("Cannot find a function to process the triggered event.")
+            whole_function = self.get_function_for_aws_event(records[0])
+            if whole_function:
+                app_function = self.import_module_and_get_function(whole_function)
+                result = self.run_function(app_function, event, context)
+                logger.debug(result)
+            else:
+                logger.error("Cannot find a function to process the triggered event.")
             return result
 
         # Normal web app flow

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1462,7 +1462,8 @@ class Zappa(object):
         rules = [r['Name'] for r in self.events_client.list_rules(NamePrefix=lambda_name)['Rules']]
         return [self.events_client.describe_rule(Name=r) for r in rules]
 
-    def unschedule_events(self, events, lambda_arn=None, lambda_name=None, excluded_source_services=[]):
+    def unschedule_events(self, events, lambda_arn=None, lambda_name=None, excluded_source_services=None):
+        excluded_source_services = excluded_source_services or []
         """
         Given a list of events, unschedule these CloudWatch Events.
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -179,7 +179,7 @@ LAMBDA_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-nor
 
 ZIP_EXCLUDES = [
     '*.exe', '*.DS_Store', '*.Python', '*.git', '.git/*', '*.zip', '*.tar.gz',
-    '*.hg', '*.egg-info', 'botocore*', 'pip', 'docutils*', 'boto3*', 'setuputils*'
+    '*.hg', '*.egg-info', 'pip', 'docutils*', 'setuputils*'
 ]
 
 ##


### PR DESCRIPTION
Depends on #347 because I needed an up-to-date boto3 version in my testing environment.

I fixed the issue with DynamoDB streams and also introduced a check if it is already existing to prevent rescheduling stream events (dynamodb, kinesis) on every update. I made the experience that it takes up to 10 minute until a newly added stream processes the first event and it causes that events are duplicated multiple times if the setting `TRIM_HORIZON` is used. All other events still are removed and re-added on every update.
While testing I discovered as well that there was an unnecessary loop which looped over all records and is submitting ALL records for processing in each iteration. This means right now, if you receive a batch of 10 records, the batch is processed 10 times.

As you predicted, this was a lot of trial and error, I hope I did not break anything existing. I tested manually against S3, DynamoDB and CloudWatch events. 
Also, I am fairly new to Python, so let me know if I did something weird.