### PR TITLE
Fix bad settings test

### DIFF
--- a/tests/test_bad_settings.json
+++ b/tests/test_bad_settings.json
@@ -1,7 +1,9 @@
 {
     "ttt888": {
        "s3_bucket": "lmbda"
-       "app_function": "tests.test_app.hello_world",
+       // note: missing comma is not enough to make hjson raise
+       // ValueError, however missing quote is enough;
+       "app_function": "tests.test_app.hello_world
        "callbacks": {
            "settings": "test_settings.callback",
            "post": "test_settings.callback",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -553,7 +553,7 @@ class TestZappa(unittest.TestCase):
 
     def test_bad_json_catch(self):
         zappa_cli = ZappaCLI()
-        self.assertRaises(ValueError, zappa_cli.load_settings_file('tests/test_bad_settings.json'))
+        self.assertRaises(ValueError, zappa_cli.load_settings_file, 'tests/test_bad_settings.json')
 
     @placebo_session
     def test_cli_aws(self, session):


### PR DESCRIPTION
When I ran the tests, I got:

```
  0%|                                        | 0.00/11.2M [00:00<?, ?B/s]
  0%|                                        | 0.00/87.7K [00:00<?, ?B/s]
100%|██████████████████████████████████| 16/16 [00:00<00:00, 786.36res/s]
  0%|                                        | 0.00/11.2M [00:00<?, ?B/s]
  0%|                                        | 0.00/87.7K [00:00<?, ?B/s]
..................Registering account...
Parsing account key...
Registered!
Parsing account key...
Parsing CSR...
Signing certificate...
Parsing account key...
Domain verified!
  0%|                                        | 0.00/71.1M [00:00<?, ?B/s]
.............
======================================================================
ERROR: test_bad_json_catch (tests.tests.TestZappa)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sean/src/Zappa/tests/tests.py", line 556, in test_bad_json_catch
    self.assertRaises(ValueError, zappa_cli.load_settings_file('tests/test_bad_settings.json'))
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 475, in assertRaises
    callableObj(*args, **kwargs)
TypeError: 'NoneType' object is not callable

Name                        Stmts   Miss  Cover
-----------------------------------------------
zappa.py                        0      0   100%
zappa/cli.py                  543    135    75%
zappa/ext.py                    0      0   100%
zappa/ext/django_zappa.py      10      1    90%
zappa/handler.py              208     46    78%
zappa/letsencrypt.py          182     61    66%
zappa/middleware.py            73      3    96%
zappa/util.py                 119     11    91%
zappa/wsgi.py                  53      0   100%
zappa/zappa.py                640    107    83%
-----------------------------------------------
TOTAL                        1828    364    80%
----------------------------------------------------------------------
Ran 46 tests in 104.643s

FAILED (errors=1)
```

`hjson` is much more forgiving than `json`, so it's not raising a `ValueError` as the test expects; so I broke the "bad" json a little worse.

I also had to change the way `assertRaises` is called (uses a callable so that the exception is raised within the scope of `assertRaises` and not in the same scope where `assertRaises` is called).

With this patch in place:

```
$ nosetests tests.tests:TestZappa.test_bad_json_catch
.
----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
```

Or, more generally:

```
$ ./test.sh
  0%|                                        | 0.00/11.2M [00:00<?, ?B/s]
  0%|                                        | 0.00/87.7K [00:00<?, ?B/s]
100%|██████████████████████████████████| 16/16 [00:00<00:00, 837.96res/s]
  0%|                                        | 0.00/11.2M [00:00<?, ?B/s]
  0%|                                        | 0.00/87.7K [00:00<?, ?B/s]
..................Registering account...
Parsing account key...
Registered!
Parsing account key...
Parsing CSR...
Signing certificate...
Parsing account key...
Domain verified!
  0%|                                        | 0.00/71.1M [00:00<?, ?B/s]
.............
Name                        Stmts   Miss  Cover
-----------------------------------------------
zappa.py                        0      0   100%
zappa/cli.py                  543    133    76%
zappa/ext.py                    0      0   100%
zappa/ext/django_zappa.py      10      1    90%
zappa/handler.py              208     46    78%
zappa/letsencrypt.py          182     61    66%
zappa/middleware.py            73      3    96%
zappa/util.py                 119     11    91%
zappa/wsgi.py                  53      0   100%
zappa/zappa.py                640    107    83%
-----------------------------------------------
TOTAL                        1828    362    80%
----------------------------------------------------------------------
Ran 46 tests in 89.588s

OK
```