### PR TITLE
356 catch invalid stage name

### DIFF
--- a/tests/test_bad_stage_name_settings.json
+++ b/tests/test_bad_stage_name_settings.json
@@ -1,0 +1,48 @@
+{
+    "ttt-888": {
+       "touch": false,
+       "s3_bucket": "lmbda",
+       "app_function": "tests.test_app.hello_world",
+       "callbacks": {
+           "settings": "test_settings.callback",
+           "post": "test_settings.callback",
+           "zip": "test_settings.callback"
+       },
+       "delete_local_zip": true,
+       "debug": true,
+       "parameter_depth": 2, 
+       "prebuild_script": "test_settings.prebuild_me",
+       "events": [
+           {
+               "function": "tests.test_app.schedule_me",
+               "expression": "rate(1 minute)"
+           },
+           {
+               "function": "test.test_app.method",
+               "event_source": {
+                   "arn": "arn:aws:sns:::1",
+                   "events": [
+                     "sns:Publish"
+                   ]
+               }
+           }
+       ]
+    },
+    "devor": {
+       "s3_bucket": "lmbda",
+       "app_function": "tests.test_app.hello_world",
+       "callbacks": {
+           "settings": "test_settings.callback",
+           "post": "test_settings.callback",
+           "zip": "test_settings.callback"
+       },
+       "delete_local_zip": true,
+       "debug": true,
+       "parameter_depth": 2, 
+       "prebuild_script": "test_settings.prebuild_me",
+       "events": [{
+          "function": "tests.test_app.schedule_me",
+          "expression": "rate(1 minute)"
+       }]
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -541,6 +541,10 @@ class TestZappa(unittest.TestCase):
         zappa_cli = ZappaCLI()
         self.assertRaises(ValueError, zappa_cli.load_settings_file('tests/test_bad_settings.json'))
 
+    def test_bad_stage_name_catch(self):
+        zappa_cli = ZappaCLI()
+        self.assertRaises(ValueError, zappa_cli.load_settings, 'tests/test_bad_stage_name_settings.json')
+
     @placebo_session
     def test_cli_aws(self, session):
         zappa_cli = ZappaCLI()


### PR DESCRIPTION
Closes #356

Stage names must match `a-zA-Z0-9_` according to the error message from the AWS API.
This patch prevents the user from supplying one during `init` and also prevents the use of one in the config file.