### PR TITLE
Feature/event kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Zappa Changelog
 
+## 0.25.0
+
+* Add ability to invoke raw python strings, like so:
+
+    `zappa invoke dev "print 1+2+3" --raw`
+
+* Fixes multi-argument `manage` commands.
+* Updated related documentation.
+
 ## 0.24.2
 
 * Fix a problem from trying to `update` old-style API routes using new Tropo code. Ensures `touch` works as intended again. Fix by @mathom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Fixes multi-argument `manage` commands.
 * Updated related documentation.
+* Fixes places where program was exiting with status 0 instead of -1. Thanks @mattc!
+* Adds old-to-new-style check on delete, thanks @mathom.
 
 ## 0.24.2
 

--- a/README.md
+++ b/README.md
@@ -284,13 +284,25 @@ For instance, suppose you have a basic application in a file called "my_app.py",
 
 Any remote print statements made and the value the function returned will then be printed to your local console. **Nifty!**
 
+You can also invoke interpretable Python 2.7 strings directly by using `--raw`, like so:
+
+   $ zappa invoke production "print 1 + 2 + 3" --raw 
+
 #### Django Management Commands
 
 As a convenience, Zappa can also invoke remote Django 'manage.py' commands with the `manage` command. For instance, to perform the basic Django status check:
 
-    $ zappa manage production check
+    $ zappa manage production showmigrations admin
 
-Obviously, this only works for Django projects which have their settings properly defined. _(Please note that commands which take over 30 seconds to execute may time-out. See [this related issue](https://github.com/Miserlou/Zappa/issues/205#issuecomment-236391248) for a work-around.)_ 
+Obviously, this only works for Django projects which have their settings properly defined. 
+
+For commands which have their own arguments, you can also pass the command in as a string, like so:
+
+    # zappa manage production "shell --version"
+
+Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `invoke --raw`.
+
+_(Please note that commands which take over 30 seconds to execute may time-out. See [this related issue](https://github.com/Miserlou/Zappa/issues/205#issuecomment-236391248) for a work-around.)_ 
 
 #### Let's Encrypt SSL Domain Certification and Installation
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Any remote print statements made and the value the function returned will then b
 
 You can also invoke interpretable Python 2.7 strings directly by using `--raw`, like so:
 
-   $ zappa invoke production "print 1 + 2 + 3" --raw 
+    $ zappa invoke production "print 1 + 2 + 3" --raw 
 
 #### Django Management Commands
 
@@ -298,9 +298,9 @@ Obviously, this only works for Django projects which have their settings properl
 
 For commands which have their own arguments, you can also pass the command in as a string, like so:
 
-    # zappa manage production "shell --version"
+    $ zappa manage production "shell --version"
 
-Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `invoke --raw`.
+Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `zappa <env> invoke --raw`.
 
 _(Please note that commands which take over 30 seconds to execute may time-out. See [this related issue](https://github.com/Miserlou/Zappa/issues/205#issuecomment-236391248) for a work-around.)_ 
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,23 @@ And then:
 
 And now your function will execute every minute!
 
+If you need to pass arguments to the function, use the function_kwargs key. The dictionary will then be available within the lambda
+event argument as function_kwargs.
+
+```javascript
+{
+    "production": {
+       ...
+       "events": [{
+           "function": "your_module.your_function", // The function to execute
+           "function_kwargs": {"key": "val"},
+           "expression": "rate(1 minute)" // When to execute it (in cron or rate format)
+       }],
+       ...
+    }
+}
+```
+
 If you want to cancel these, you can simply use the `unschedule` command:
 
     $ zappa unschedule production
@@ -350,6 +367,11 @@ to change Zappa's behavior. Use these at your own risk!
         "events": [
             {   // Recurring events
                 "function": "your_module.your_recurring_function", // The function to execute
+                "expression": "rate(1 minute)" // When to execute it (in cron or rate format)
+            },
+            {   // Recurring event with arguments
+                "function": "your_module.your_recurring_function", // The function to execute
+                "function_kwargs": {"key": "val", "key2": "val2"},
                 "expression": "rate(1 minute)" // When to execute it (in cron or rate format)
             },
             {   // AWS Reactive events

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(os.path.dirname(__file__), 'test_requirements.txt')) as f
 
 setup(
     name='zappa',
-    version='0.24.2',
+    version='0.25.0',
     packages=['zappa'],
     install_requires=required,
     tests_require=test_required,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -390,6 +390,20 @@ class TestZappa(unittest.TestCase):
                 }
         lh.handler(event, None)
 
+        # Test raw_command event
+        event = {
+                    u'account': u'72333333333',
+                    u'region': u'us-east-1',
+                    u'detail': {},
+                    u'raw_command': u'print("check one two")',
+                    u'source': u'aws.events',
+                    u'version': u'0',
+                    u'time': u'2016-05-10T21:05:39Z',
+                    u'id': u'0d6a6db0-d5e7-4755-93a0-750a8bf49d55',
+                    u'resources': [u'arn:aws:events:us-east-1:72333333333:rule/tests.test_app.schedule_me']
+                }
+        lh.handler(event, None)
+
         # Test AWS S3 event
         event = {
                     u'account': u'72333333333',

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -209,7 +209,13 @@ class ZappaCLI(object):
                 print("If this is a Django project, please define django_settings in your zappa_settings.")
                 return
 
-            self.invoke(command_env[-1], "manage")
+            command_tail = command_env[2:]
+            if len(command_tail) > 1:
+                command = " ".join(command_tail) # ex: zappa manage dev "shell --version"
+            else:
+                command = command_tail[0] # ex: zappa manage dev showmigrations admin
+
+            self.invoke(command, "manage")
 
         elif command == 'tail': # pragma: no cover
             self.tail()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -522,20 +522,21 @@ class ZappaCLI(object):
             if confirm != 'y':
                 return
 
-        if remove_logs:
-            self.zappa.remove_api_gateway_logs(self.lambda_name)
+        if self.use_apigateway:
+            if remove_logs:
+                self.zappa.remove_api_gateway_logs(self.lambda_name)
 
-        domain_name = self.stage_config.get('domain', None)
+            domain_name = self.stage_config.get('domain', None)
 
-        # Only remove the api key when not specified
-        if self.api_key_required and self.api_key is None:
-            api_id = self.zappa.get_api_id(self.lambda_name)
-            self.zappa.remove_api_key(api_id, self.api_stage)
+            # Only remove the api key when not specified
+            if self.api_key_required and self.api_key is None:
+                api_id = self.zappa.get_api_id(self.lambda_name)
+                self.zappa.remove_api_key(api_id, self.api_stage)
 
-        gateway_id = self.zappa.undeploy_api_gateway(
-            self.lambda_name,
-            domain_name=domain_name
-        )
+            gateway_id = self.zappa.undeploy_api_gateway(
+                self.lambda_name,
+                domain_name=domain_name
+            )
 
         self.unschedule()  # removes event triggers, including warm up event.
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -147,7 +147,7 @@ class ZappaCLI(object):
         # Version requires no arguments
         if args.version: # pragma: no cover
             self.print_version()
-            sys.exit(-1)
+            sys.exit(0)
 
         # Parse the input
         command_env = vargs['command_env']

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -300,7 +300,9 @@ class ZappaCLI(object):
         self.schedule()
 
         endpoint_url = ''
+        deployment_string = click.style("Deployment complete", fg="green", bold=True) + "!"
         if self.use_apigateway:
+            
 
             if self.iam_authorization:
                 auth_type = "AWS_IAM"
@@ -330,6 +332,7 @@ class ZappaCLI(object):
                                         cloudwatch_data_trace=self.zappa_settings[self.api_stage].get('cloudwatch_data_trace', False),
                                         cloudwatch_metrics_enabled=self.zappa_settings[self.api_stage].get('cloudwatch_metrics_enabled', False),
                                     )
+            deployment_string = deployment_string + ": {}".format(endpoint_url)
 
             # Create/link API key
             if self.api_key_required:
@@ -351,8 +354,7 @@ class ZappaCLI(object):
 
         self.callback('post')
 
-        click.echo(click.style("Deployment complete", fg="green", bold=True) + "!: {}".format(endpoint_url))
-
+        click.echo(deployment_string)
 
     def update(self):
         """
@@ -476,8 +478,6 @@ class ZappaCLI(object):
 
         click.echo(deployed_string)
 
-        return
-
     def rollback(self, revision):
         """
         Rollsback the currently deploy lambda code to a previous revision.
@@ -488,8 +488,6 @@ class ZappaCLI(object):
         self.zappa.rollback_lambda_function_version(
             self.lambda_name, versions_back=revision)
         print("Done!")
-
-        return
 
     def tail(self, keep_open=True):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -133,7 +133,7 @@ class ZappaCLI(object):
         parser.add_argument('-v', '--version', action='store_true', help='Print the zappa version', default=False)
         parser.add_argument('-y', '--yes', action='store_true', help='Auto confirm yes', default=False)
         parser.add_argument('--remove-logs', action='store_true', help='Removes log groups of api gateway and lambda task during the undeployment.', default=False)
-        parser.add_argument('--raw-python', action='store_true', help='When invoking remotely, invoke this python as a string, not as a modular path.', default=False)
+        parser.add_argument('--raw', action='store_true', help='When invoking remotely, invoke this python as a string, not as a modular path.', default=False)
 
         args = parser.parse_args(argv)
 
@@ -198,7 +198,7 @@ class ZappaCLI(object):
                 parser.error("Please enter the function to invoke.")
                 return
 
-            self.invoke(command_env[-1], raw_python=vargs['raw_python'])
+            self.invoke(command_env[-1], raw_python=vargs['raw'])
         elif command == 'manage': # pragma: no cover
 
             if len(command_env) < 2:

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -445,9 +445,9 @@ class LambdaHandler(object):
         except Exception as e:  # pragma: no cover
 
             # Print statements are visible in the logs either way
-            print(e)
+            print(e)`
             exc_info = sys.exc_info()
-            message = 'An uncaught exception happened while servicing this request.'
+            message = 'An uncaught exception happened while servicing this request. You can investigate this with the `zappa tail` command.'
 
             # If we didn't even build an app_module, just raise.
             if not settings.DJANGO_SETTINGS:

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -312,6 +312,8 @@ class LambdaHandler(object):
             return result
 
         # This is a direct, raw python invocation.
+        # It's _extremely_ important we don't allow this event source
+        # to be overriden by unsanitized, non-admin user input.
         elif event.get('raw_command', None):
 
             raw_command = event['raw_command']

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -445,7 +445,7 @@ class LambdaHandler(object):
         except Exception as e:  # pragma: no cover
 
             # Print statements are visible in the logs either way
-            print(e)`
+            print(e)
             exc_info = sys.exc_info()
             message = 'An uncaught exception happened while servicing this request. You can investigate this with the `zappa tail` command.'
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -311,6 +311,13 @@ class LambdaHandler(object):
             print(result)
             return result
 
+        # This is a direct, raw python invocation.
+        elif event.get('raw_command', None):
+
+            raw_command = event['raw_command']
+            exec(raw_command) 
+            return
+
         # This is a Django management command invocation.
         elif event.get('manage', None):
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -289,6 +289,9 @@ class LambdaHandler(object):
         # This is the result of a keep alive, recertify
         # or scheduled event.
         if event.get('detail-type') == u'Scheduled Event':
+            if 'time' not in event:
+                # Replaces the time that CW would have put in for triggering this. https://github.com/Miserlou/Zappa/pull/360
+                event['time'] = datetime.datetime.now().isoformat()
 
             whole_function = event['resources'][0].split('/')[-1].split('-')[-1]
 
@@ -317,7 +320,7 @@ class LambdaHandler(object):
         elif event.get('raw_command', None):
 
             raw_command = event['raw_command']
-            exec(raw_command) 
+            exec(raw_command)
             return
 
         # This is a Django management command invocation.

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -865,7 +865,6 @@ class Zappa(object):
         )
         print('Created a new x-api-key: {}'.format(response['id']))
 
-
     def remove_api_key(self, api_id, stage_name):
         """
         Remove a generated API key for api_id and stage_name

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1327,6 +1327,7 @@ class Zappa(object):
         self.unschedule_events(lambda_name=lambda_name, lambda_arn=lambda_arn, events=events)
         for event in events:
             function = event['function']
+            function_kwargs = event.get('function_kwargs', None)
             expression = event.get('expression', None)
             event_source = event.get('event_source', None)
             name = self.get_scheduled_event_name(event, function, lambda_name)
@@ -1354,15 +1355,24 @@ class Zappa(object):
                 # Specific permissions are necessary for any trigger to work.
                 self.create_event_permission(lambda_name, 'events.amazonaws.com', rule_response['RuleArn'])
 
+                t = {
+                    'Id': 'Id' + ''.join(random.choice(string.digits) for _ in range(12)),
+                    'Arn': lambda_arn,
+                }
+
+                if function_kwargs:
+                    # We are overwriting the default CW event dict, so replace as much of it as we can and supply kwargs
+                    t['Input'] = json.dumps({
+                        'detail-type': u'Scheduled Event',
+                        'source': u'aws.events',
+                        'resources': [rule_response['RuleArn']],
+                        'function_kwargs': function_kwargs
+                    })
+
                 # Create the CloudWatch event ARN for this function.
                 target_response = self.events_client.put_targets(
                     Rule=name,
-                    Targets=[
-                        {
-                            'Id': 'Id' + ''.join(random.choice(string.digits) for _ in range(12)),
-                            'Arn': lambda_arn,
-                        }
-                    ]
+                    Targets=[t]
                 )
 
                 if target_response['ResponseMetadata']['HTTPStatusCode'] == 200:

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -3,7 +3,6 @@ import botocore
 import json
 import logging
 import os
-import datetime
 import random
 import requests
 import shutil
@@ -1366,7 +1365,6 @@ class Zappa(object):
                     t['Input'] = json.dumps({
                         'detail-type': u'Scheduled Event',
                         'source': u'aws.events',
-                        'time': datetime.datetime.now().isoformat(),
                         'resources': [rule_response['RuleArn']],
                         'function_kwargs': function_kwargs
                     })

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -3,6 +3,7 @@ import botocore
 import json
 import logging
 import os
+import datetime
 import random
 import requests
 import shutil
@@ -1365,6 +1366,7 @@ class Zappa(object):
                     t['Input'] = json.dumps({
                         'detail-type': u'Scheduled Event',
                         'source': u'aws.events',
+                        'time': datetime.datetime.now().isoformat(),
                         'resources': [rule_response['RuleArn']],
                         'function_kwargs': function_kwargs
                     })

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -865,6 +865,7 @@ class Zappa(object):
         )
         print('Created a new x-api-key: {}'.format(response['id']))
 
+
     def remove_api_key(self, api_id, stage_name):
         """
         Remove a generated API key for api_id and stage_name

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1361,12 +1361,17 @@ class Zappa(object):
                 }
 
                 if function_kwargs:
-                    # We are overwriting the default CW event dict, so replace as much of it as we can and supply kwargs
+                    # We are overwriting the default CW event dict, so replace as much of it as we can and supply kwargs https://github.com/Miserlou/Zappa/issues/359
+                    arn, aws, service, region, account, resource = rule_response['RuleArn'].split(':', 5)
                     t['Input'] = json.dumps({
                         'detail-type': u'Scheduled Event',
                         'source': u'aws.events',
                         'resources': [rule_response['RuleArn']],
-                        'function_kwargs': function_kwargs
+                        'function_kwargs': function_kwargs,
+                        'account': account,
+                        'region': region,
+                        'detail': {},  # Cloudwatch Scheduled Events always have empty details
+                        'version': 0  # Always 0 http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
                     })
 
                 # Create the CloudWatch event ARN for this function.


### PR DESCRIPTION
#359

This allows for a dict to be passed to an event. Doing so causes us to lose some of the event arguments passed by CW. Not sure if this loss is acceptable. The following keys are no longer in the event. 

['account', 'region', 'detail', 'version', 'time', 'id']

These are not used by Zappa, and won't break existing events because the function_kwargs argument wouldn't be in the settings file.
