### PR TITLE
(doc) change to os.environ.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ zappa_settings.json:
 Now in your application you can use:
 ```python
 import os
-db_string = os.environ('DB_CONNECTION_STRING')
+db_string = os.environ.get('DB_CONNECTION_STRING')
 ```
 
 #### Setting Integration Content-Type Aliases

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -167,4 +167,4 @@ Now in your application you can use:
 ::
 
     import os
-    db_string = os.environ('DB_CONNECTION_STRING')
+    db_string = os.environ.get('DB_CONNECTION_STRING')


### PR DESCRIPTION
super simple doc change to fix accidental use of `os.environ` as a method