### PR TITLE
Adds HTTP 405 to the list of default response codes

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -203,11 +203,11 @@ class Zappa(object):
         'ANY'
     ]
     parameter_depth = 8
-    integration_response_codes = [200, 201, 301, 400, 401, 403, 404, 500]
+    integration_response_codes = [200, 201, 301, 400, 401, 403, 404, 405, 500]
     integration_content_types = [
         'text/html',
     ]
-    method_response_codes = [200, 201, 301, 400, 401, 403, 404, 500]
+    method_response_codes = [200, 201, 301, 400, 401, 403, 404, 405, 500]
     method_content_types = [
         'text/html',
     ]


### PR DESCRIPTION
It would make sense to add `HTTP/1.1 405 Method Not Allowed` to the default list of response codes.

Reason: Since Zappa will allow the same HTTP methods for all deployed
endpoints through API Gateway, 405 is likely to be encountered and
should not return 200.

For instance,
```
@app.route('/', methods=['GET'])
def lambda_handler(event=None, context=None):
    return 'hello from Flask!'
```

Will return `HTTP/1.1 200 OK` using the current default Zappa config when hit with a POST request.

This PR merely adds 405 to the default response codes list for both API Gateway integrations and methods.