### PR TITLE
Adds support for POST/PUT/PATCH requests with an empty request body

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -478,6 +478,45 @@ class TestZappa(unittest.TestCase):
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
         response = response_tuple(200, 'hello')
 
+
+    def test_wsgi_without_body(self):
+        event = {
+            u'body': None,
+            u'resource': u'/',
+            u'requestContext': {
+                u'resourceId': u'6cqjw9qu0b',
+                u'apiId': u'9itr2lba55',
+                u'resourcePath': u'/',
+                u'httpMethod': u'POST',
+                u'requestId': u'c17cb1bf-867c-11e6-b938-ed697406e3b5',
+                u'accountId': u'724336686645',
+                u'identity': {
+                    u'apiKey': None,
+                    u'userArn': None,
+                    u'cognitoAuthenticationType': None,
+                    u'caller': None,
+                    u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:48.0) Gecko/20100101 Firefox/48.0',
+                    u'user': None,
+                    u'cognitoIdentityPoolId': None,
+                    u'cognitoIdentityId': None,
+                    u'cognitoAuthenticationProvider': None,
+                    u'sourceIp': u'50.191.225.98',
+                    u'accountId': None,
+                    },
+                u'stage': u'devorr',
+                },
+            u'queryStringParameters': None,
+            u'httpMethod': u'POST',
+            u'pathParameters': None,
+            u'headers': {u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'},
+            u'stageVariables': None,
+            u'path': u'/',
+            }
+
+        environ = create_wsgi_request(event, trailing_slash=False)
+        response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
+        response = response_tuple(200, 'hello')
+
     ##
     # Handler
     ##

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -92,7 +92,10 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
                 environ['CONTENT_TYPE'] = headers['Content-Type']
 
             environ['wsgi.input'] = StringIO(body)
-            environ['CONTENT_LENGTH'] = str(len(body))
+            if body:
+                environ['CONTENT_LENGTH'] = str(len(body))
+            else:
+                environ['CONTENT_LENGTH'] = '0'
 
         for header in headers:
             wsgi_name = "HTTP_" + header.upper().replace('-', '_')


### PR DESCRIPTION
It is valid for HTTP POST/PUT/PATCH requests to provide an empty
request body, and should not raise an exception.

This PR allows the request body to be empty.

# Steps to reproduce

Deploy a hello world Flask app:

```
from flask import Flask

app = Flask(__name__)


@app.route('/', methods=['GET', 'POST'])
def lambda_handler(event=None, context=None):
    return 'hello from Flask!'

if __name__ == '__main__':
    app.run(debug=True)
```

Perform a POST request with an empty body:

```
$ curl -d '' -i https://k2h8a6sv0e.execute-api.us-east-1.amazonaws.com/dev
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
Content-Length: 530
Connection: keep-alive
Date: Fri, 07 Oct 2016 07:24:59 GMT
x-amzn-RequestId: 2777e78f-8c5f-11e6-b49d-57d543c2d16c
X-Cache: Error from cloudfront
Via: 1.1 8b1633b834f6beaa5a2d7797c38cf775.cloudfront.net (CloudFront)
X-Amz-Cf-Id: eN2I7Zbv2BiBv-sCX9HAXd1bfazI7QfGMMaI_MGNfmgEAL7jfnay0A==

{
    "message": "An uncaught exception happened while servicing this request. You can investigate this with the `zappa tail` command.",
    "traceback": [
        "Traceback (most recent call last):\n",
        "  File \"/var/task/handler.py\", line 396, in handler\n    trailing_slash=self.trailing_slash\n",
        "  File \"/Users/logan/.pyenv/versions/2.7.11/envs/zappa/lib/python2.7/site-packages/zappa/wsgi.py\", line 95, in create_wsgi_request\n",
        "TypeError: object of type 'NoneType' has no len()\n"
    ]
}
```