### PR TITLE
make sure that environment variables are strings

### DIFF
--- a/tests/test_bad_environment_vars.json
+++ b/tests/test_bad_environment_vars.json
@@ -1,0 +1,19 @@
+{
+    "ttt888": {
+       "touch": false,
+       "s3_bucket": "lmbda",
+       "app_function": "tests.test_app.hello_world",
+       "callbacks": {
+           "settings": "test_settings.callback",
+           "post": "test_settings.callback",
+           "zip": "test_settings.callback"
+       },
+       "delete_local_zip": true,
+       "debug": true,
+       "parameter_depth": 2,
+        "environment_variables": {
+            "REMOTE_HOST": "example.net",
+            "REMOTE_PORT": 9004,
+        },
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -749,6 +749,11 @@ class TestZappa(unittest.TestCase):
         zappa_cli = ZappaCLI()
         self.assertRaises(ValueError, zappa_cli.load_settings, 'tests/test_bad_stage_name_settings.json')
 
+    def test_bad_environment_vars_catch(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+        self.assertRaises(ValueError, zappa_cli.load_settings, 'tests/test_bad_environment_vars.json')
+
     @placebo_session
     def test_cli_aws(self, session):
         zappa_cli = ZappaCLI()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -792,6 +792,21 @@ class ZappaCLI(object):
             return True
         raise ValueError("AWS requires stage name to match a-zA-Z0-9_")
 
+    def check_environment(self, environment):
+        """
+        Make sure the environment contains only strings
+
+        (since putenv needs a string)
+        """
+
+        non_strings = []
+        for k,v in environment.iteritems():
+            if not isinstance(v, basestring):
+                non_strings.append(k)
+        if non_strings:
+            raise ValueError("The following environment variables are not strings: {}".format(", ".join(non_strings)))
+        else:
+            return True
 
     def init(self, settings_file="zappa_settings.json"):
         """
@@ -1126,6 +1141,7 @@ class ZappaCLI(object):
             self.api_stage].get('lambda_description', "Zappa Deployment")
         self.environment_variables = self.zappa_settings[
             self.api_stage].get('environment_variables', {})
+        self.check_environment(self.environment_variables)
         self.authorizer = self.stage_config.get('authorizer', {})
 
         self.zappa = Zappa( boto_session=session,


### PR DESCRIPTION
I accidentally set an integer environment variable, and Zappa deployed properly, but failed on request. This showed up in the `tail`:

```
Zappa Event: {}
[1476408522194] putenv() argument 2 must be string, not int: TypeError
Traceback (most recent call last):
  File "/var/task/handler.py", line 476, in lambda_handler
    return LambdaHandler.lambda_handler(event, context)
  File "/var/task/handler.py", line 187, in lambda_handler
    handler = cls()
  File "/var/task/handler.py", line 109, in __init__
    os.environ[key] = self.settings.ENVIRONMENT_VARIABLES[key]
  File "/usr/lib64/python2.7/os.py", line 473, in __setitem__
    putenv(key, item)
TypeError: putenv() argument 2 must be string, not int
```

This PR checks the `environment` for strings and errors out if they're not.