### PR TITLE
Add capability to specify authoriser arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,8 @@ to change Zappa's behavior. Use these at your own risk!
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "iam_authorization": true, // optional, use IAM to require request signing. Default false. Note that enabling this will override the authorizer configuration.
         "authorizer": {
-            "function": "your_module.your_auth_function", // Required. Function to run for token validation. For more information about the function see below.
+            "function": "your_module.your_auth_function", // Local function to run for token validation. For more information about the function see below.
+            "arn": "arn:aws:lambda:<region>:<account_id>:function:<function_name>", // Existing Lambda function to run for token validation.
             "result_ttl": 300, // Optional. Default 300. The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches authorizer results. Currently, the maximum TTL value is 3600 seconds.
             "token_source": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
@@ -468,11 +469,14 @@ You can enable IAM-based (v4 signing) authorization on an API by setting the `ia
 
 ##### Authorizer
 If you deploy an API endpoint with Zappa, you can take advantage of [API Gateway Authorizers](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html) to implement a token-based authentication - all you need to do is to provide a function to create the required output, Zappa takes care of the rest. A good start for the function is the [awslabs blueprint example.](https://github.com/awslabs/aws-apigateway-lambda-authorizer-blueprints/blob/master/blueprints/python/api-gateway-authorizer-python.py)
-Inside your app, the authenticated username will be available through the `REMOTE_USER` environment variable (e.g. in Flask `request.environ.get('REMOTE_USER')`)
+
 If you are wondering for what you would use an Authorizer, here are some potential use cases:
+
 1. Call out to OAuth provider
 2. Decode a JWT token inline
 3. Lookup in a self-managed DB (for example DynamoDB)
+
+Zappa can be configured to cal a function inside your code to do the authorization, or to call some other existing lambda function (which lets you share the authorizer between multiple lambdas). You control the behaviour by specifying either the `arn` or `function_name` values in the `authorizer` settings block.
 
 
 #### Deploying to a Domain With a Let's Encrypt Certificate (DNS Auth)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -229,6 +229,15 @@ class TestZappa(unittest.TestCase):
         with self.assertRaises(KeyError):
             parsable_template["Resources"]["Authorizer"]["Properties"]["IdentityValidationExpression"]
 
+        # Authorizer with arn
+        authorizer = {
+            "arn": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+        }
+        z.create_stack_template(lambda_arn, 'helloworld', False, {}, False, authorizer)
+        parsable_template = json.loads(z.cf_template.to_json())
+        self.assertEqual('arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:my-function/invocations', parsable_template["Resources"]["Authorizer"]["Properties"]["AuthorizerUri"])
+
+
     @placebo_session
     def test_get_api_url(self, session):
         z = Zappa(session)

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -689,8 +689,11 @@ class Zappa(object):
         ##
         authorizer_resource = None
         if authorizer:
+            authorizer_lambda_arn = authorizer.get('arn', lambda_arn)
+            lambda_uri = 'arn:aws:apigateway:' + self.boto_session.region_name + ':lambda:path/2015-03-31/functions/' + authorizer_lambda_arn + '/invocations'
+
             authorizer_resource = self.create_authorizer(restapi,
-                                                         invocations_uri,
+                                                         lambda_uri,
                                                          "method.request.header." + authorizer.get('token_header', 'Authorization'),
                                                          authorizer.get('result_ttl', 300),
                                                          authorizer.get('validation_expression', None))


### PR DESCRIPTION
Updated the `authorizer` config to allow specification of the authorizer ARN manually. This lets you share one authorizer between multiple lambdas and means that the authorizer code can live in a different repo to the Zappa code.