### PR TITLE
Clarify contribution workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Description
+
+
+## GitHub Issues
+<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
+<!-- Link to relevant tickets here. -->
+

--- a/README.md
+++ b/README.md
@@ -659,11 +659,11 @@ Zappa goes quite far beyond what Lambda and API Gateway were ever intended to ha
 
 This project is still young, so there is still plenty to be done. Contributions are more than welcome!
 
-Please file tickets for discussion before submitting patches, and submit your patches to the "dev" branch if possible. If dev falls behind master, feel free to rebase.
+Please file tickets for discussion before submitting patches. Pull requests should target `master` and should leave Zappa in a "shippable" state if merged.
 
-If you are adding a non-trivial amount of new code, please include a functioning test in your PR. For AWS calls, we use the placebo library, which you can learn to use [in the test writing guide](docs/README.md).
+If you are adding a non-trivial amount of new code, please include a functioning test in your PR. For AWS calls, we use the placebo library, which you can learn to use [in the test writing guide](docs/README.md). The test suite will be run by [Travis CI](https://travis-ci.org/Miserlou/Zappa) once you open a pull request.
 
-Please also write comments along with your new code, including the URL of the ticket which you filed along with the PR. This greatly helps for project maintainability, as it allows us to trace back use cases and explain decision making.
+Please also write a pull request description including the URL of the GitHub issue which you filed. This greatly helps for project maintainability, as it allows us to trace back use cases and explain decision making.
 
 #### Using a Local Repo
 

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Please file tickets for discussion before submitting patches. Pull requests shou
 
 If you are adding a non-trivial amount of new code, please include a functioning test in your PR. For AWS calls, we use the placebo library, which you can learn to use [in the test writing guide](docs/README.md). The test suite will be run by [Travis CI](https://travis-ci.org/Miserlou/Zappa) once you open a pull request.
 
-Please also write a pull request description including the URL of the GitHub issue which you filed. This greatly helps for project maintainability, as it allows us to trace back use cases and explain decision making.
+Please include the GitHub issue or pull request URL that has discussion related to your changes as a comment in the code ([example](https://github.com/Miserlou/Zappa/blob/fae2925431b820eaedf088a632022e4120a29f89/zappa/zappa.py#L241-L243)]). This greatly helps for project maintainability, as it allows us to trace back use cases and explain decision making.
 
 #### Using a Local Repo
 


### PR DESCRIPTION
## Description

As discussed in #407, Zappa's current contribution workflow is to target PRs against `master`, until automation can get set up to ensure `dev` doesn't fall behind `master`.

Keywords for these two workflows are "GitHub Flow" (master + PRs) vs. "GitFlow" (master to represent the latest release, dev for trunk + PRs against dev, or against master for "hotfixes").

Also added a PR template to cover the linked issue contribution requirement.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#407