### PR TITLE
Return exit code 1 for CLI command failures

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -741,6 +741,15 @@ class TestZappa(unittest.TestCase):
         argv = '-s test_settings.json derp ttt888'.split()
         zappa_cli.handle(argv)
 
+    def test_cli_error_exit_code(self):
+        # Discussion: https://github.com/Miserlou/Zappa/issues/407
+        zappa_cli = ZappaCLI()
+        # Sanity
+        argv = '-s test_settings.json status devor'.split()
+        with self.assertRaises(SystemExit) as system_exit:
+            zappa_cli.handle(argv)
+        self.assertEqual(system_exit.exception.code, 1)
+
     def test_bad_json_catch(self):
         zappa_cli = ZappaCLI()
         self.assertRaises(ValueError, zappa_cli.load_settings_file, 'tests/test_bad_settings.json')


### PR DESCRIPTION
## Description
CLI commands will return exit code 1 to indicate failure. See #407 for discussion.

This currently covers only validation-type errors that I've changed to now raise as `ClickException` - but beyond those, any uncaught exceptions should still result in an exit code of 1 with python.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#407

