### PR TITLE
DNS challenge cleanup fix

### DIFF
--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -271,7 +271,7 @@ def get_cert(zappa_instance, log=LOGGER, CA=DEFAULT_CA):
         verify_challenge(challenge['uri'])
 
         # Challenge verified, clean up R53
-        zappa_instance.remove_dns_challenge_txt(zone_id, domain)
+        zappa_instance.remove_dns_challenge_txt(zone_id, domain, digest)
 
     # Sign
     result = sign_certificate()

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1700,43 +1700,47 @@ class Zappa(object):
         print("Setting DNS challenge..")
         resp = self.route53.change_resource_record_sets(
             HostedZoneId=zone_id,
-            ChangeBatch={
-                'Changes': [{
-                    'Action': 'UPSERT',
-                    'ResourceRecordSet': {
-                        'Name': '_acme-challenge.{0}'.format(domain),
-                        'Type': 'TXT',
-                        'TTL': 60,
-                        'ResourceRecords': [{
-                            'Value': '"{0}"'.format(txt_challenge)
-                        }]
-                    }
-                }]
-            }
+            ChangeBatch=self._get_dns_challenge_change_batch('UPSERT', domain, txt_challenge)
         )
 
         return resp
 
-    def remove_dns_challenge_txt(self, zone_id, domain):
+    def remove_dns_challenge_txt(self, zone_id, domain, txt_challenge):
         """
         Remove DNS challenge TXT.
         """
         print("Deleting DNS challenge..")
         resp = self.route53.change_resource_record_sets(
             HostedZoneId=zone_id,
-            ChangeBatch={
-                'Changes': [{
-                    'Action': 'DELETE',
-                    'ResourceRecordSet': {
-                        'Name': '_acme-challenge.{0}'.format(domain),
-                        'Type': 'TXT',
-                    }
-                }]
-            }
+            ChangeBatch=self._get_dns_challenge_change_batch('DELETE', domain, txt_challenge)
         )
 
         return resp
 
+    @staticmethod
+    def _get_dns_challenge_change_batch(action, domain, txt_challenge):
+        """
+        Given action, domain and challege, return a change batch to use with
+        route53 call.
+
+        :param action: DELETE | UPSERT
+        :param domain: domain name
+        :param txt_challenge: challenge
+        :return: change set for a given action, domain and TXT challenge.
+        """
+        return {
+            'Changes': [{
+                'Action': action,
+                'ResourceRecordSet': {
+                    'Name': '_acme-challenge.{0}'.format(domain),
+                    'Type': 'TXT',
+                    'TTL': 60,
+                    'ResourceRecords': [{
+                        'Value': '"{0}"'.format(txt_challenge)
+                    }]
+                }
+            }]
+        }
 
     ##
     # Utility


### PR DESCRIPTION
## Description

AWS responds with a 400 (Invalid request) if DELETE request doesn't have all of ResourceRecordSet details included.
This change re-uses UPSERT request building logic to include all of the record details.