### PR TITLE
Make sure path info is unquoted before evnironment down to the wsgi app

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -405,6 +405,7 @@ class TestZappa(unittest.TestCase):
 
         request = create_wsgi_request(event)
 
+
     # def test_wsgi_path_info(self):
     #     # Test no parameters (site.com/)
     #     event = {
@@ -434,6 +435,20 @@ class TestZappa(unittest.TestCase):
 
     #     request = create_wsgi_request(event, trailing_slash=False, script_name='asdf1')
     #     self.assertEqual("/asdf1/asdf2", request['PATH_INFO'])
+
+    def test_wsgi_path_info_unquoted(self):
+        event = {
+                "body": {},
+                "headers": {},
+                "pathParameters": {},
+                "path": '/path%3A1', # encoded /path:1
+                "httpMethod": "GET",
+                "queryStringParameters": {},
+                "requestContext": {}
+            }
+        request = create_wsgi_request(event, trailing_slash=True)
+        self.assertEqual("/path:1", request['PATH_INFO'])
+
 
     def test_wsgi_logging(self):
         # event = {

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -5,6 +5,8 @@ from urllib import urlencode
 from requestlogger import ApacheFormatter
 from StringIO import StringIO
 
+from werkzeug import urls
+
 
 def create_wsgi_request(event_info, server_name='zappa', script_name=None,
                         trailing_slash=True):
@@ -40,7 +42,7 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
             if canonical != header:
                 headers[canonical] = headers.pop(header)
 
-        path = event_info['path']
+        path = urls.url_unquote(event_info['path'])
 
         # if 'url' in params:
         #     # new style


### PR DESCRIPTION
## Description
Uses same logic as werkzeug when preparing environment for wsgi request. Url decode path parameters so that underlying wsgi app doesn't have to cater for that.