### PR TITLE
added region and lambda name to "not deployed" error.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -410,7 +410,8 @@ class ZappaCLI(object):
             last_updated = parser.parse(conf['LastModified'])
             last_updated_unix = time.mktime(last_updated.timetuple())
         except Exception as e:
-            click.echo(click.style("Warning!", fg="red") + " Couldn't get function - have you deployed yet?")
+            click.echo(click.style("Warning!", fg="red") + " Couldn't get function " + self.lambda_name +
+                       " in " + self.zappa.aws_region + " - have you deployed yet?")
             sys.exit(-1)
 
         if last_updated_unix <= updated_time:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -721,7 +721,8 @@ class ZappaCLI(object):
         lambda_versions = self.zappa.get_lambda_function_versions(self.lambda_name)
 
         if not lambda_versions:
-            raise ClickException(click.style("No Lambda detected - have you deployed yet?", fg='red'))
+            raise ClickException(click.style("No Lambda %s detected in %s - have you deployed yet?" %
+                                             (self.lambda_name, self.zappa.aws_region), fg='red'))
 
         status_dict = collections.OrderedDict()
         status_dict["Lambda Versions"] = len(lambda_versions)


### PR DESCRIPTION
## Description
Added the lambda name and region name to the "not deployed" error. This error sometimes comes up when different environments are deploying and updating Zappa installations and the project_name or aws_region are determined automatically through environment settings and folder names. 

Hopefully this will help debug these errors.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#413 after 0.28 and region was not being assumed us-east-1 by Zappa. Discussed in Slack
#383 

