### PR TITLE
Zappa never finds domain name in route 53 and will always delete api gateway domain when calling certify again

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1314,19 +1314,11 @@ class Zappa(object):
             for zone in zones['HostedZones']:
                 records = self.route53.list_resource_record_sets(HostedZoneId=zone['Id'])
                 for record in records['ResourceRecordSets']:
-                    if record['Type'] == 'CNAME' and record['Name'] == domain_name:
+                    if record['Type'] == 'CNAME' and record['Name'][:-1] == domain_name:
                         return record
 
         except Exception:
             return None
-
-        # We may be in a position where Route53 doesn't have a domain, but the API Gateway does.
-        # We need to delete this before we can create the new Route53.
-        try:
-            api_gateway_domain = self.apigateway_client.get_domain_name(domainName=domain_name)
-            self.apigateway_client.delete_domain_name(domainName=domain_name)
-        except Exception:
-            pass
 
         return None
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1308,6 +1308,12 @@ class Zappa(object):
         Returns the record entry, else None.
 
         """
+        # make sure api gateway domain is present
+        try:
+            self.apigateway_client.get_domain_name(domainName=domain_name)
+        except Exception:
+            return None
+            
         try:
 
             zones = self.route53.list_hosted_zones()


### PR DESCRIPTION
## Description
Zappa is not properly checking if there is an existing route 53 record for the domain. Record names end with a period so that has to be stripped when comparing to the domain name. 

I've also removed the deletion of the api gateway domain when no route 53 record is found because deletion takes several minutes to take effect and you'll get an error trying to create another one right away (I've run into this problem multiple times). A better way would be to use the update_domain_name method in the api gateway client.