### PR TITLE
Filter private hosted zones to avoid conflicts while certifying

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -862,7 +862,10 @@ class TestZappa(unittest.TestCase):
         zone = Zappa.get_best_match_zone(all_zones={ 'HostedZones': [
             {
                 'Name': 'example.com.au.',
-                'Id': 'zone-correct'
+                'Id': 'zone-correct',
+                'Config': {
+                    'PrivateZone': False
+                }
             }
         ]},
             domain='www.example.com.au')
@@ -872,7 +875,10 @@ class TestZappa(unittest.TestCase):
         zone = Zappa.get_best_match_zone(all_zones={'HostedZones': [
             {
                 'Name': 'example.com.au.',
-                'Id': 'zone-incorrect'
+                'Id': 'zone-incorrect',
+                'Config': {
+                    'PrivateZone': False
+                }
             }
         ]},
             domain='something-else.com.au')
@@ -882,16 +888,54 @@ class TestZappa(unittest.TestCase):
         zone = Zappa.get_best_match_zone(all_zones={'HostedZones': [
             {
                 'Name': 'example.com.au.',
-                'Id': 'zone-incorrect'
+                'Id': 'zone-incorrect',
+                'Config': {
+                    'PrivateZone': False
+                }
             },
             {
                 'Name': 'subdomain.example.com.au.',
-                'Id': 'zone-correct'
+                'Id': 'zone-correct',
+                'Config': {
+                    'PrivateZone': False
+                }
             }
         ]},
             domain='www.subdomain.example.com.au')
         assert zone == 'zone-correct'
 
+        # Check private zone is not matched
+        zone = Zappa.get_best_match_zone(all_zones={ 'HostedZones': [
+            {
+                'Name': 'example.com.au.',
+                'Id': 'zone-private',
+                'Config': {
+                    'PrivateZone': True
+                }
+            }
+        ]},
+            domain='www.example.com.au')
+        assert zone is None
+
+        # More involved, should ignore the private zone and match the public.
+        zone = Zappa.get_best_match_zone(all_zones={'HostedZones': [
+            {
+                'Name': 'subdomain.example.com.au.',
+                'Id': 'zone-private',
+                'Config': {
+                    'PrivateZone': True
+                }
+            },
+            {
+                'Name': 'subdomain.example.com.au.',
+                'Id': 'zone-public',
+                'Config': {
+                    'PrivateZone': False
+                }
+            }
+        ]},
+            domain='www.subdomain.example.com.au')
+        assert zone == 'zone-public'
 
     ##
     # Let's Encrypt / ACME

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1710,7 +1710,11 @@ class Zappa(object):
     @staticmethod
     def get_best_match_zone(all_zones, domain):
         """Return zone id which name is closer matched with domain name."""
-        zones = {zone['Name'][:-1]: zone['Id'] for zone in all_zones['HostedZones'] if zone['Name'][:-1] in domain}
+
+        # Related: https://github.com/Miserlou/Zappa/issues/459
+        public_zones = [zone for zone in all_zones['HostedZones'] if not zone['Config']['PrivateZone']]
+
+        zones = {zone['Name'][:-1]: zone['Id'] for zone in public_zones if zone['Name'][:-1] in domain}
         if zones:
             keys = max(zones.keys(), key=lambda a: len(a))  # get longest key -- best match.
             return zones[keys]


### PR DESCRIPTION
## Description
Tested functionally it works. Even with two hosted zones (private and public) having the same name behind a same domain, now Zappa manages to select the public hosted zone, certify and expose the custom domain name.
Though I didn't manage to run the tests of the project :(

## GitHub Issues
Resolve #459 


