### PR TITLE
allow to use s3 subfolders for storing Let's Encrypt key

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ to change Zappa's behavior. Use these at your own risk!
         "delete_s3_zip": true, // Delete the s3 zip archive
         "django_settings": "your_project.production_settings", // The modular path to your Django project's settings. For Django projects only.
         "domain": "yourapp.yourdomain.com", // Required if you're using a domain
-        "environment_variables": {"your_key": "your_value"}, // A dictionary of environment variables that will be available to your deployed app. See also "remote_env_file". Default {}.
+        "environment_variables": {"your_key": "your_value"}, // A dictionary of environment variables that will be available to your deployed app. See also "remote_env". Default {}.
         "events": [
             {   // Recurring events
                 "function": "your_module.your_recurring_function", // The function to execute
@@ -422,8 +422,7 @@ to change Zappa's behavior. Use these at your own risk!
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
-        "remote_env_bucket": "my-project-config-files", // optional s3 bucket where remote_env_file can be located.
-        "remote_env_file": "filename.json", // file in remote_env_bucket containing a flat json object which will be used to set custom environment variables.
+        "remote_env": "s3://my-project-config-files/filename.json", // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.
         "role_name": "MyLambdaRole", // Name of Zappa execution role. Default ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,
@@ -520,9 +519,9 @@ If your project needs to be aware of the type of environment you're deployed to,
 
 ##### Remote Environment Variables
 
-If you want to use remote environment variables to configure your application (which is especially useful for things like sensitive credentials), you can create a file and place it in an S3 bucket to which your Zappa application has access to. To do this, add the `remote_env_bucket` and `remote_env_file` keys to zappa_settings pointing to a file containing a flat JSON object, so that each key-value pair on the object will be set as an environment variable and value whenever a new lambda instance spins up.
+If you want to use remote environment variables to configure your application (which is especially useful for things like sensitive credentials), you can create a file and place it in an S3 bucket to which your Zappa application has access to. To do this, add the `remote_env` key to zappa_settings pointing to a file containing a flat JSON object, so that each key-value pair on the object will be set as an environment variable and value whenever a new lambda instance spins up.
 
-For example, to ensure your application has access to the database credentials without storing them in your version control, you can add a file to S3 with the connection string and load it into the lambda environment using the `remote_env_bucket` and `remote_env_file` configuration settings.
+For example, to ensure your application has access to the database credentials without storing them in your version control, you can add a file to S3 with the connection string and load it into the lambda environment using the `remote_env` configuration setting.
 
 super-secret-config.json (uploaded to my-config-bucket):
 ```javascript
@@ -536,8 +535,7 @@ zappa_settings.json:
 {
     "dev": {
         ...
-        "remote_env_bucket": "my-config-bucket",
-        "remote_env_file": "super-secret-config.json"
+        "remote_env": "s3://my-config-bucket/super-secret-config.json",
     },
     ...
 }

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -137,9 +137,9 @@ If you want to use Zappa on a domain with a free Let's Encrypt certificate, you 
 Setting Environment Variables
 =============================
 
-If you want to use environment variables to configure your application (which is especially useful for things like sensitive credentials), you can create a file and place it in an S3 bucket to which your Zappa application has access to. To do this, add the ``remote_env_bucket`` and ``remote_env_file`` keys to zappa_settings pointing to a file containing a flat JSON object, so that each key-value pair on the object will be set as an environment variable and value whenever a new lambda instance spins up.
+If you want to use environment variables to configure your application (which is especially useful for things like sensitive credentials), you can create a file and place it in an S3 bucket to which your Zappa application has access to. To do this, add the ``remote_env`` key to zappa_settings pointing to a file containing a flat JSON object, so that each key-value pair on the object will be set as an environment variable and value whenever a new lambda instance spins up.
 
-For example, to ensure your application has access to the database credentials without storing them in your version control, you can add a file to S3 with the connection string and load it into the lambda environment using the ``remote_env_bucket`` and ``remote_env_file`` configuration settings.
+For example, to ensure your application has access to the database credentials without storing them in your version control, you can add a file to S3 with the connection string and load it into the lambda environment using the ``remote_env`` configuration setting.
 
 super-secret-config.json (uploaded to my-config-bucket):
 
@@ -156,8 +156,7 @@ zappa_settings.json:
     {
         "dev": {
             ...
-            "remote_env_bucket": "my-config-bucket",
-            "remote_env_file": "super-secret-config.json"
+            "remote_env": "s3://my-config-bucket/super-secret-config.json",
         },
         ...
     }

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -50,9 +50,8 @@ Envirnments, such as *dev*, *staging*, and *production* are configured in the *z
             "prebuild_script": "your_module.your_function",
             "profile_name": "your-profile-name",
             "project_name": "MyProject",
-            "remote_env_bucket": "my-project-config-files", // optional s3 bucket where remote_env_file can be located.
-            "remote_env_file": "filename.json",
-                // file in remote_env_bucket containing a flat json object which will be used to set custom environment variables.
+            "remote_env": "s3://my-project-config-files/filename.json",
+                // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.
             "role_name": "MyLambdaRole",
             "s3_bucket": "dev-bucket",
             "settings_file": "~/Projects/MyApp/settings/dev_settings.py",

--- a/test_settings.json
+++ b/test_settings.json
@@ -57,6 +57,15 @@
        "extends": "extendo",
        "s3_bucket": "lmbda2",
     },
+    "depricated_remote_env": {
+       "s3_bucket": "lmbda",
+       "remote_env_bucket": "lmbda-env",
+       "remote_env_file": "dev/env.json"
+    },
+    "remote_env": {
+       "s3_bucket": "lmbda",
+       "remote_env": "s3://lmbda-env/prod/env.json"
+    },
     "extendofail": {
        "extends": "failfail",
        "prebuild_script": "test_settings.prebuild_me",

--- a/test_settings.py
+++ b/test_settings.py
@@ -8,8 +8,7 @@ DOMAIN = None
 API_STAGE = 'ttt888'
 PROJECT_NAME = 'ttt888'
 
-REMOTE_ENV_BUCKET='lmbda'
-REMOTE_ENV_FILE='test_env.json'
+REMOTE_ENV='s3://lmbda/test_env.json'
 ## test_env.json
 #{
 #	"hello": "world"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1129,7 +1129,7 @@ class ZappaCLI(object):
 
             if 's3://' in account_key_location:
                 bucket = account_key_location.split('s3://')[1].split('/')[0]
-                key_name = account_key_location.split('s3://')[1].split('/')[1]
+                key_name = account_key_location.split('s3://')[1].split('/', 1)[1]
                 self.zappa.s3_client.download_file(bucket, key_name, '/tmp/account.key')
             else:
                 from shutil import copyfile

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -19,10 +19,13 @@ try:
     from zappa.cli import ZappaCLI
     from zappa.middleware import ZappaWSGIMiddleware
     from zappa.wsgi import create_wsgi_request, common_log
+    from zappa.util import parse_s3_url
 except ImportError as e:  # pragma: no cover
     from .cli import ZappaCLI
     from .middleware import ZappaWSGIMiddleware
     from .wsgi import create_wsgi_request, common_log
+    from .util import parse_s3_url
+
 
 # Set up logging
 logging.basicConfig()
@@ -88,8 +91,8 @@ class LambdaHandler(object):
                 level = logging.getLevelName(self.settings.LOG_LEVEL)
                 logger.setLevel(level)
 
-            remote_bucket = getattr(self.settings, 'REMOTE_ENV_BUCKET', None)
-            remote_file = getattr(self.settings, 'REMOTE_ENV_FILE', None)
+            remote_env = getattr(self.settings, 'REMOTE_ENV', None)
+            remote_bucket, remote_file = parse_s3_url(remote_env)
 
             if remote_bucket and remote_file:
                 self.load_remote_settings(remote_bucket, remote_file)

--- a/zappa/util.py
+++ b/zappa/util.py
@@ -4,6 +4,8 @@ import os
 import requests
 import shutil
 import stat
+import urlparse
+
 
 def copytree(src, dst, symlinks=False, ignore=None):
     """
@@ -224,3 +226,17 @@ def check_new_version_available(this_version):
         return True
     else:
         return False
+
+def parse_s3_url(url):
+    """
+    Parses S3 URL.
+
+    Returns bucket (domain) and file (full path).
+    """
+    bucket = ''
+    path = ''
+    if url:
+        result = urlparse.urlparse(url)
+        bucket = result.netloc
+        path = result.path.strip('/')
+    return bucket, path


### PR DESCRIPTION
## Description
split only bucket and path in lets_encrypt_key S3 URL.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/477
