### PR TITLE
fixed s3 event trigger function name

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -258,7 +258,7 @@ class LambdaHandler(object):
         Support S3, SNS, DynamoDB and kinesis events
         """
         if 's3' in record:
-            return record['s3']['configurationId']
+            return record['s3']['configurationId'].split(':')[-1]
 
         arn = None
         if 'Sns' in record:

--- a/zappa/util.py
+++ b/zappa/util.py
@@ -157,6 +157,8 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
         arn_back = split_arn[-1]
         ctx.environment = arn_back
         funk.arn = arn_front
+        funk.name = target_function
+        funk.name = ':'.join([arn_back, target_function])
     else:
         funk.arn = lambda_arn
 

--- a/zappa/util.py
+++ b/zappa/util.py
@@ -157,7 +157,6 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
         arn_back = split_arn[-1]
         ctx.environment = arn_back
         funk.arn = arn_front
-        funk.name = target_function
         funk.name = ':'.join([arn_back, target_function])
     else:
         funk.arn = lambda_arn


### PR DESCRIPTION
## Description
I changed the funk name to be the <project_name>:<event function>.  And I changed the get_function for AWS_event function to parse the record['s3']['configurationId'] properly.


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/473


* changed the get_function_for_aws_event to returen the function part of the
  record['s3']['configurationId']