### PR TITLE
Enable cors

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ to change Zappa's behavior. Use these at your own risk!
         "timeout_seconds": 30, // Maximum lifespan for the Lambda function (default 30, max 300.)
         "touch": false, // GET the production URL upon initial deployment (default True)
         "use_precompiled_packages": false, // If possible, use C-extension packages which have been pre-compiled for AWS Lambda
+        "cors": true, // Enable cross-origin resource sharing. Disabled by default. If true, simulates the "Enable CORS" button on the API Gateway console. Can also be a dictionary specifying lists of "allowed_headers", "allowed_methods", and string of "allowed_origin"
         "vpc_config": { // Optional VPC configuration for Lambda function
             "SubnetIds": [ "subnet-12345678" ], // Note: not all availability zones support Lambda!
             "SecurityGroupIds": [ "sg-12345678" ]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -212,6 +212,24 @@ class TestZappa(unittest.TestCase):
         self.assertEqual(False, parsable_template["Resources"]["GET0"]["Properties"]["ApiKeyRequired"])
         self.assertEqual(False, parsable_template["Resources"]["GET1"]["Properties"]["ApiKeyRequired"])
 
+        # CORS with auth
+        z.create_stack_template(lambda_arn, 'helloworld', False, {}, True, None, True)
+        parsable_template = json.loads(z.cf_template.to_json())
+        self.assertEqual("AWS_IAM", parsable_template["Resources"]["GET0"]["Properties"]["AuthorizationType"])
+        self.assertEqual("AWS_IAM", parsable_template["Resources"]["GET1"]["Properties"]["AuthorizationType"])
+        self.assertEqual("NONE", parsable_template["Resources"]["OPTIONS0"]["Properties"]["AuthorizationType"])
+        self.assertEqual("NONE", parsable_template["Resources"]["OPTIONS1"]["Properties"]["AuthorizationType"])
+        self.assertEqual("MOCK", parsable_template["Resources"]["OPTIONS0"]["Properties"]["Integration"]["Type"])
+        self.assertEqual("MOCK", parsable_template["Resources"]["OPTIONS1"]["Properties"]["Integration"]["Type"])
+        self.assertEqual("'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                         parsable_template["Resources"]["OPTIONS0"]["Properties"]["Integration"]["IntegrationResponses"][0]["ResponseParameters"]["method.response.header.Access-Control-Allow-Headers"])
+        self.assertEqual("'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                         parsable_template["Resources"]["OPTIONS1"]["Properties"]["Integration"]["IntegrationResponses"][0]["ResponseParameters"]["method.response.header.Access-Control-Allow-Headers"])
+        self.assertTrue(parsable_template["Resources"]["OPTIONS0"]["Properties"]["MethodResponses"][0]["ResponseParameters"]["method.response.header.Access-Control-Allow-Headers"])
+        self.assertTrue(parsable_template["Resources"]["OPTIONS1"]["Properties"]["MethodResponses"][0]["ResponseParameters"]["method.response.header.Access-Control-Allow-Headers"])
+        self.assertEqual(False, parsable_template["Resources"]["GET0"]["Properties"]["ApiKeyRequired"])
+        self.assertEqual(False, parsable_template["Resources"]["GET1"]["Properties"]["ApiKeyRequired"])
+
         # API Key auth
         z.create_stack_template(lambda_arn, 'helloworld', True, {}, True, None)
         parsable_template = json.loads(z.cf_template.to_json())

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -395,7 +395,7 @@ class ZappaCLI(object):
                                                         self.integration_content_type_aliases,
                                                         self.iam_authorization,
                                                         self.authorizer,
-                                                        self.enable_cors)
+                                                        self.cors)
 
             self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True)
 
@@ -505,7 +505,7 @@ class ZappaCLI(object):
                                              self.integration_content_type_aliases,
                                              self.iam_authorization,
                                              self.authorizer,
-                                             self.enable_cors)
+                                             self.cors)
             self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True, update_only=True)
 
             api_id = self.zappa.get_api_id(self.lambda_name)
@@ -1316,7 +1316,7 @@ class ZappaCLI(object):
         self.api_key_required = self.stage_config.get('api_key_required', False)
         self.api_key = self.stage_config.get('api_key')
         self.iam_authorization = self.stage_config.get('iam_authorization', False)
-        self.enable_cors = self.stage_config.get("enable_cors", False)
+        self.cors = self.stage_config.get("cors", None)
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")
         self.environment_variables = self.stage_config.get('environment_variables', {})
         self.check_environment(self.environment_variables)

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -394,7 +394,8 @@ class ZappaCLI(object):
                                                         self.api_key_required,
                                                         self.integration_content_type_aliases,
                                                         self.iam_authorization,
-                                                        self.authorizer)
+                                                        self.authorizer,
+                                                        self.enable_cors)
 
             self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True)
 
@@ -503,7 +504,8 @@ class ZappaCLI(object):
                                              self.api_key_required,
                                              self.integration_content_type_aliases,
                                              self.iam_authorization,
-                                             self.authorizer)
+                                             self.authorizer,
+                                             self.enable_cors)
             self.zappa.update_stack(self.lambda_name, self.s3_bucket_name, wait=True, update_only=True)
 
             api_id = self.zappa.get_api_id(self.lambda_name)
@@ -1314,6 +1316,7 @@ class ZappaCLI(object):
         self.api_key_required = self.stage_config.get('api_key_required', False)
         self.api_key = self.stage_config.get('api_key')
         self.iam_authorization = self.stage_config.get('iam_authorization', False)
+        self.enable_cors = self.stage_config.get("enable_cors", False)
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")
         self.environment_variables = self.stage_config.get('environment_variables', {})
         self.check_environment(self.environment_variables)


### PR DESCRIPTION
## Description

As outlined here: #494 setting up a Zappa application to use CORS along with an api-gateway managed authentication mechanism requires enabling cors at the api-gateway layer to deal with the pre-flight options requests. There is a fairly simple button to manage this in the API-gateway management console, but I'd rather not have to take those steps after doing a deployment.

The "cors" option in the settings can either be "true" (defaulting to the AWS
API Gateway "Enable Cors" values) or a dictionary specifying "allowed_headers"
"allowed_methods" and "allowed_origin". Any keys not specified will default
to the API Gateway defaults.


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/494
