### PR TITLE
Fixed typo in cli deploy aws permissions error

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -358,7 +358,7 @@ class ZappaCLI(object):
                     "You may " + click.style("lack the necessary AWS permissions", bold=True) +
                     " to automatically manage a Zappa execution role.\n" +
                     "To fix this, see here: " +
-                    click.style("https://github.com/Miserlou/Zappa#using-custom-aws-iam-roles-and-policie", bold=True)
+                    click.style("https://github.com/Miserlou/Zappa#using-custom-aws-iam-roles-and-policies", bold=True)
                     + '\n')
 
         # Create the Lambda Zip


### PR DESCRIPTION
## Description


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->


