### PR TITLE
Enhacement/Allow importing local files for callbacks #468

### DIFF
--- a/test_settings.json
+++ b/test_settings.json
@@ -5,9 +5,9 @@
        "app_function": "tests.test_app.hello_world",
        "use_precompiled_packages": false, 
        "callbacks": {
-           "settings": "test_settings.callback",
-           "post": "test_settings.callback",
-           "zip": "test_settings.callback"
+			"settings": "tests.test_app.callback",
+			"post": "tests.test_app.callback",
+			"zip": "test_settings.callback"
        },
        "delete_local_zip": true,
        "debug": true,

--- a/test_settings.json
+++ b/test_settings.json
@@ -5,9 +5,9 @@
        "app_function": "tests.test_app.hello_world",
        "use_precompiled_packages": false, 
        "callbacks": {
-		"settings": "tests.test_app.callback",
-		"post": "tests.test_app.callback",
-		"zip": "test_settings.callback"
+           "settings": "tests.test_app.callback",
+	   "post": "tests.test_app.callback",
+	   "zip": "test_settings.callback"
        },
        "delete_local_zip": true,
        "debug": true,

--- a/test_settings.json
+++ b/test_settings.json
@@ -5,9 +5,9 @@
        "app_function": "tests.test_app.hello_world",
        "use_precompiled_packages": false, 
        "callbacks": {
-			"settings": "tests.test_app.callback",
-			"post": "tests.test_app.callback",
-			"zip": "test_settings.callback"
+		"settings": "tests.test_app.callback",
+		"post": "tests.test_app.callback",
+		"zip": "test_settings.callback"
        },
        "delete_local_zip": true,
        "debug": true,

--- a/test_settings.json
+++ b/test_settings.json
@@ -6,8 +6,8 @@
        "use_precompiled_packages": false, 
        "callbacks": {
            "settings": "tests.test_app.callback",
-	   "post": "tests.test_app.callback",
-	   "zip": "test_settings.callback"
+           "post": "tests.test_app.callback",
+           "zip": "test_settings.callback"
        },
        "delete_local_zip": true,
        "debug": true,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,3 +14,7 @@ def hello_world(environ, start_response):
 
 def schedule_me():
     return "Hello!"
+
+def callback(self):
+    print("this is a callback")
+

--- a/tests/test_settings.yml
+++ b/tests/test_settings.yml
@@ -23,8 +23,8 @@ devor:
   s3_bucket: lmbda
   app_function: tests.test_app.hello_world
   callbacks:
-    settings: test_settings.callback
-    post: test_settings.callback
+    settings: tests.test_app.callback
+    post: tests.test_app.callback
     zip: test_settings.callback
   delete_local_zip: true
   debug: true

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1239,15 +1239,16 @@ class ZappaCLI(object):
                 working_dir_importer = pkgutil.get_importer(working_dir)
                 module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
 
-            except (ImportError, AttributeError):  # Callback func might be in virtualenv
-                try:
+            except (ImportError, AttributeError): # pragma: no cover
+              
+                try: # Callback func might be in virtualenv
                     module_ = importlib.import_module(mod_path)
                 except ImportError:
                     raise ClickException(click.style("Failed ", fg="red") + 'to ' + click.style(
                         "import {position} callback ".format(position=position),
                         bold=True) + 'module: "{mod_path}"'.format(mod_path=click.style(mod_path, bold=True)))
 
-            if not hasattr(module_, cb_func):
+            if not hasattr(module_, cb_func): # pragma: no cover
                 raise ClickException(click.style("Failed ", fg="red") + 'to ' + click.style(
                     "find {position} callback ".format(position=position), bold=True) + 'function: "{cb_func}" '.format(
                     cb_func=click.style(cb_func, bold=True)) + 'in module "{mod_path}"'.format(mod_path=mod_path))

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1240,7 +1240,17 @@ class ZappaCLI(object):
                 module_ = working_dir_importer.find_module(mod_name).load_module(mod_name)
 
             except (ImportError, AttributeError):  # Callback func might be in virtualenv
-                module_ = importlib.import_module(mod_path)
+                try:
+                    module_ = importlib.import_module(mod_path)
+                except ImportError:
+                    raise ClickException(click.style("Failed ", fg="red") + 'to ' + click.style(
+                        "import {position} callback ".format(position=position),
+                        bold=True) + 'module: "{mod_path}"'.format(mod_path=click.style(mod_path, bold=True)))
+
+            if not hasattr(module_, cb_func):
+                raise ClickException(click.style("Failed ", fg="red") + 'to ' + click.style(
+                    "find {position} callback ".format(position=position), bold=True) + 'function: "{cb_func}" '.format(
+                    cb_func=click.style(cb_func, bold=True)) + 'in module "{mod_path}"'.format(mod_path=mod_path))
 
             getattr(module_, cb_func)(self)  # Call the function passing self
 


### PR DESCRIPTION
## Description
This allows for a callback to be set in the working directory.
This is backwards-compatible, the user can still install callbacks over his virtualenv, in the Zappa folder.
Also compatible with Python 3.

## GitHub Issues
#468 

