### PR TITLE
Fix function names trimmed on AWS event names

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -967,10 +967,12 @@ USE_TZ = True
         zappa = Zappa()
         truncated = zappa.get_event_name("basldfkjalsdkfjalsdkfjaslkdfjalsdkfjadlsfkjasdlfkjasdlfkjasdflkjasdf-asdfasdfasdfasdfasdf", "this.is.my.dang.function.wassup.yeah.its.long")
         self.assertTrue(len(truncated) <= 64)
+        self.assertTrue(truncated.endswith("this.is.my.dang.function.wassup.yeah.its.long"))
         truncated = zappa.get_event_name("basldfkjalsdkfjalsdkfjaslkdfjalsdkfjadlsfkjasdlfkjasdlfkjasdflkjasdf-asdfasdfasdfasdfasdf", "thisidoasdfaljksdfalskdjfalsdkfjasldkfjalsdkfjalsdkfjalsdfkjalasdfasdfasdfasdklfjasldkfjalsdkjfaslkdfjasldkfjasdflkjdasfskdj")
         self.assertTrue(len(truncated) <= 64)
         truncated = zappa.get_event_name("a", "b")
         self.assertTrue(len(truncated) <= 64)
+        self.assertEqual(truncated, "a-b")
 
     def test_detect_dj(self):
         # Sanity

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1691,17 +1691,7 @@ class Zappa(object):
         Returns an AWS-valid Lambda event name.
 
         """
-        event_name = '{}-{}'.format(lambda_name, name)
-        if len(event_name) > 64:
-            if '.' in event_name: # leave the function name, but re-label to trim
-                name, function = event_name.split('.', 1)
-                function = "." + function
-                name_len = len(function)
-                name = name[:(64-len(function))]
-                event_name = name + function
-            else:
-                event_name = event_name[:64]
-        return event_name
+        return '{prefix:.{width}}-{postfix}'.format(prefix=lambda_name, width=max(0, 63 - len(name)), postfix=name)[:64]
 
     def delete_rule(self, rule_name):
         """


### PR DESCRIPTION
## Description
Fix function names trimmed on AWS event names when the even names were too long.
I was able to reproduce the issue using a long name for the deployment stage.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
fixes #403

