### PR TITLE
Update description of `log_level` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ to change Zappa's behavior. Use these at your own risk!
         "lambda_handler": "your_custom_handler", // The name of Lambda handler. Default: handler.lambda_handler
         "lets_encrypt_key": "s3://your-bucket/account.key", // Let's Encrypt account key path. Can either be an S3 path or a local file path.
         "lets_encrypt_schedule": "rate(15 days)" // How often to auto-renew Let's Encrypt certificate on the server. Must be set to enable autorenewing, rate or cron syntax.
-        "log_level": "DEBUG", // Set the Zappa log level. Default INFO, can be one of CRITICAL, ERROR, WARNING, INFO and DEBUG.
+        "log_level": "DEBUG", // Set the Zappa log level. Can be one of CRITICAL, ERROR, WARNING, INFO and DEBUG. Default: DEBUG
         "manage_roles": true, // Have Zappa automatically create and define IAM execution roles and policies. Default true. If false, you must define your own IAM Role and role_name setting.
         "memory_size": 512, // Lambda function memory in MB
         "method_header_types": [ // Which headers to include in the API response. Defaults:


### PR DESCRIPTION
## Description


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->


The default for `log_level` is "DEBUG" however the description stated "INFO". I updated that and formatted the description to be more consistent with the others. Although the default is also implied in the key/value pair at the beginning of the line and could be removed all together in the comment. 