### PR TITLE
Add authorizer from event to wsgi request.

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -117,6 +117,9 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
         if remote_user:
             environ['REMOTE_USER'] = remote_user
 
+        if event_info['requestContext'].get('authorizer'):
+            environ['API_GATEWAY_AUTHORIZER'] = event_info['requestContext']['authorizer']
+
         return environ
 
 


### PR DESCRIPTION
## Description
Add authorizer data including claims. Especially useful for when API Gateway is integrated with Cognito User Pools.

In Django we can access claims via:
```python
claims = request.META['API_GATEWAY_AUTHORIZER'].get('claims', {})
user_email = claims.get('email')
```
