### PR TITLE
get rid of duplicates and extraneous libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ to change Zappa's behavior. Use these at your own risk!
             }
         ],
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
-        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
+        "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. By default Zappa excludes common python packages available in a lambda environment (botocore, boto3, concurrent.futures, jmespath, six.py, dateutil).
         "extends": "stage_name", // Duplicate and extend another stage's settings. For example, `dev-asia` could extend from `dev-common` with a different `s3_bucket` value.
         "http_methods": ["GET", "POST"], // HTTP Methods to route,
         "iam_authorization": true, // optional, use IAM to require request signing. Default false. Note that enabling this will override the authorizer configuration.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1548,7 +1548,9 @@ class ZappaCLI(object):
                 self.lambda_name,
                 handler_file=handler_file,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
-                exclude=self.stage_config.get('exclude', [])
+                exclude=self.stage_config.get(
+                    'exclude',
+                    ["boto3", "*.dist-info", "dateutil", "botocore", "s3transfer", "six.py", "jmespath", "concurrent"])
             )
 
         # Throw custom setings into the zip file

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1550,7 +1550,7 @@ class ZappaCLI(object):
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
                 exclude=self.stage_config.get(
                     'exclude',
-                    ["boto3", "*.dist-info", "dateutil", "botocore", "s3transfer", "six.py", "jmespath", "concurrent"])
+                    ["boto3", "dateutil", "botocore", "s3transfer", "six.py", "jmespath", "concurrent"])
             )
 
         # Throw custom setings into the zip file

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1550,6 +1550,8 @@ class ZappaCLI(object):
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
                 exclude=self.stage_config.get(
                     'exclude',
+                    # Exclude packages already builtin to the python lambda environment
+                    # https://github.com/Miserlou/Zappa/issues/556
                     ["boto3", "dateutil", "botocore", "s3transfer", "six.py", "jmespath", "concurrent"])
             )
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -196,7 +196,7 @@ LAMBDA_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-central-1', 'eu-wes
 
 ZIP_EXCLUDES = [
     '*.exe', '*.DS_Store', '*.Python', '*.git', '.git/*', '*.zip', '*.tar.gz',
-    '*.hg', '*.egg-info', 'pip', 'docutils*', 'setuputils*'
+    '*.hg', '*.egg-info', 'pip', 'docutils*', 'setuputils*', '*.dist-info',
 ]
 
 ##


### PR DESCRIPTION
they are either already present in the python lambda environment or extraneous there (dist-info).

For a simple bottle app, this shrinks the **compressed** zip from 9.3mb to 2.3mb.

first part from #556, lots more low hanging fruit.
