### PR TITLE
Accept AWS_SESSION_TOKEN when executing via an IAM role.

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1950,10 +1950,17 @@ class Zappa(object):
                 self.boto_session = boto3.Session(profile_name=profile_name, region_name=self.aws_region)
             elif os.environ.get('AWS_ACCESS_KEY_ID') and os.environ.get('AWS_SECRET_ACCESS_KEY'):
                 region_name = os.environ.get('AWS_DEFAULT_REGION') or self.aws_region
-                self.boto_session = boto3.Session(
-                    aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
-                    aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
-                    region_name=region_name)
+                session_kw = {
+                    "aws_access_key_id": os.environ.get('AWS_ACCESS_KEY_ID'),
+                    "aws_secret_access_key": os.environ.get('AWS_SECRET_ACCESS_KEY'),
+                    "region_name": region_name,
+                }
+
+                # If we're executing in a role, AWS_SESSION_TOKEN will be present, too.
+                if os.environ.get("AWS_SESSION_TOKEN"):
+                    session_kw["aws_session_token"] = os.environ.get("AWS_SESSION_TOKEN")
+
+                self.boto_session = boto3.Session(**session_kw)
             else:
                 self.boto_session = boto3.Session(region_name=self.aws_region)
 


### PR DESCRIPTION
## Description
When executing via an IAM role (e.g. on an EC2 instance or within a Lambda function), Zappa fails to make API calls (and swallows the error: "The security token included in the request is invalid").

Digging into zappa.py, it has some special logic looking for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and only creates a session with these pieces, dropping the `AWS_SESSION_TOKEN` on the floor. That third piece is essential for IAM roles.

(I'm not sure why the logic is this way -- this is pretty much what Boto does by default, after all -- but I'm guessing it's like this for a reason, perhaps related to the region code.)

## GitHub Issues
The attached pull request adds `aws_session_token` into the Boto3 `Session()` creation call.
