### PR TITLE
Initialize wsgi.errors to sys.stderr.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
 coveralls==1.1
 coverage==4.3.1
 Django==1.10.5
+Flask==0.12
 mock==2.0.0
 nose==1.3.7
 nose-timer==0.6.0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1195,8 +1195,10 @@ USE_TZ = True
             os.remove(zappa_cli.zip_path)
 
     def test_flask_logging_bug(self):
-        # This checks whether Flask can write errors sanely.
-        # https://github.com/Miserlou/Zappa/issues/283
+        """
+        This checks whether Flask can write errors sanely.
+        https://github.com/Miserlou/Zappa/issues/283
+        """
         event = {
                 "body": {},
                 "headers": {},

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1275,8 +1275,7 @@ class ZappaCLI(object):
         cert_chain_location = self.stage_config.get('certificate_chain', None)
 
         if not domain:
-            click.echo("Can't certify a domain without " + click.style("domain", fg="red", bold=True) + " configured!")
-            return
+            raise ClickException("Can't certify a domain without " + click.style("domain", fg="red", bold=True) + " configured!")
 
         if not cert_location:
             if not account_key_location:
@@ -1337,6 +1336,8 @@ class ZappaCLI(object):
                     certificate_private_key,
                     certificate_chain
                 )
+
+            cert_success = True
 
         # Deliberately undocumented feature (for now, at least.)
         # We are giving the user the ability to shoot themselves in the foot.

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -4,6 +4,7 @@ import base64
 from urllib import urlencode
 from requestlogger import ApacheFormatter
 from StringIO import StringIO
+from sys import stderr
 
 from werkzeug import urls
 
@@ -89,7 +90,7 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
             'wsgi.version': (1, 0),
             'wsgi.url_scheme': str('http'),
             'wsgi.input': body,
-            'wsgi.errors': str(''),
+            'wsgi.errors': stderr,
             'wsgi.multiprocess': False,
             'wsgi.multithread': False,
             'wsgi.run_once': False,


### PR DESCRIPTION
## Description
Zappa's wsgi.errors environment variable is set to a static string; this should be a stream (sys.stderr for Lambda).

This is causing the strange 'str' object has no attribute 'write' issue.

## GitHub Issues
Fixes https://github.com/Miserlou/Zappa/issues/283
