### PR TITLE
Fix #618. Use env_parser in 'unschedule' command

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -324,7 +324,8 @@ class ZappaCLI(object):
         ##
         # Unschedule
         ##
-        subparsers.add_parser('unschedule', help='Unschedule functions.')
+        subparsers.add_parser('unschedule', parents=[env_parser],
+                              help='Unschedule functions.')
 
         ##
         # Updating


### PR DESCRIPTION
## Description
Use env_parser in 'unschedule' command

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#618
