### PR TITLE
Changing usages of 'environment' in favor of 'stage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This will automatically detect your application type (Flask/Django - Pyramid use
 
 ```javascript
 {
-    "dev": { // The name of your environment
+    "dev": { // The name of your stage
        "s3_bucket": "lmbda", // The name of your S3 bucket
        "app_function": "your_module.app" // The python path to your WSGI application function. In Flask, this is your 'app' object.
     }
@@ -140,14 +140,14 @@ or for Django:
 
 ```javascript
 {
-    "dev": { // The name of your environment
+    "dev": { // The name of your stage
        "s3_bucket": "lmbda", // The name of your S3 bucket
        "django_settings": "your_project.settings" // The python path to your Django settings.
     }
 }
 ```
 
-You can define as many environments as your like - we recommend having _dev_, _staging_, and _production_.
+You can define as many stages as your like - we recommend having _dev_, _staging_, and _production_.
 
 Now, you're ready to deploy!
 
@@ -155,7 +155,7 @@ Now, you're ready to deploy!
 
 #### Initial Deployments
 
-Once your settings are configured, you can package and deploy your application to an environment called "production" with a single command:
+Once your settings are configured, you can package and deploy your application to a stage called "production" with a single command:
 
     $ zappa deploy production
     Deploying..
@@ -301,7 +301,7 @@ If you have a `zip` callback in your `callbacks` setting, this will also be invo
 
 ```javascript
 {
-    "production": { // The name of your environment
+    "production": { // The name of your stage
         "callbacks": {
             "zip": "my_app.zip_callback"// After creating the package
         }

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -2,7 +2,7 @@
 Configuration Reference
 =======================
 
-Envirnments, such as *dev*, *staging*, and *production* are configured in the *zappa_settings.json* file.  Here is an example of defining many of the available settings:
+Stages, such as *dev*, *staging*, and *production* are configured in the *zappa_settings.json* file.  Here is an example of defining many of the available settings:
 
 ::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,13 +31,13 @@ Running the Initial Setup / Settings
 This will automatically detect your application type and help you define your deployment configuration settings. Once you finish initialization, you'll have a file named *zappa_settings.json* in your project directory defining your deployment settings. It will probably look something like this: ::
 
     {
-        "dev": { // The name of your environment
+        "dev": { // The name of your stage
             "s3_bucket": "lmbda", // The name of your S3 bucket
             "app_function": "your_module.app" // The python path to your WSGI application function. In Flask, this is your 'app' object.
         }
     }
 
-You can define as many environments as you like. We recommend having dev, staging, and production.
+You can define as many stages as you like. We recommend having dev, staging, and production.
 
 Now, you're ready to deploy!
 
@@ -47,7 +47,7 @@ Basic Usage
 Initial Deployments
 -------------------
 
-Once your settings are configured, you can package and deploy your application to an environment called "production" with a single command: ::
+Once your settings are configured, you can package and deploy your application to a stage called "production" with a single command: ::
 
     $ zappa deploy production
     Deploying..


### PR DESCRIPTION
## Description

Changing usages of 'environment' in favor of 'stage' in documentation

## GitHub Issues

Fixes #585
