### PR TITLE
fix installed_packages_name_set

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -493,9 +493,7 @@ class Zappa(object):
         if use_precompiled_packages:
             print("Downloading and installing dependencies..")
             installed_packages_name_set = [package.project_name.lower() for package in
-                                           pip.get_installed_distributions()
-                                           if package.project_name.lower() in site_packages]
-
+                                           pip.get_installed_distributions()]
             # First, try lambda packages
             for name, details in lambda_packages.items():
                 if name.lower() in installed_packages_name_set:


### PR DESCRIPTION
## Description

` if package.project_name.lower() in site_packages` was added

But site_packages is a path

e.g.: '/Users/.../lib/python2.7/site-packages'

Not sure why this was added in: https://github.com/miserlou/Zappa/commit/fbb5387b2cd6bc9c6a886c67d248a683fb55064f#diff-beccfc9d2696a89ee77d4c8eb54dd3f2L425

