### PR TITLE
log exception when get_lambda_function_versions fails

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -842,7 +842,8 @@ class Zappa(object):
                 FunctionName=function_name
             )
             return response.get('Versions', [])
-        except Exception:
+        except Exception as e:
+            logger.exception('Could not list lambda versions: {}'.format(e.message))
             return []
 
     def delete_lambda_function(self, function_name):


### PR DESCRIPTION
## Description
I propose we at least log the exception here in order for devs to know why it fails.

