### PR TITLE
Only get the prepackaged lambdas listed as installed in site_package …

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -493,7 +493,8 @@ class Zappa(object):
         if use_precompiled_packages:
             print("Downloading and installing dependencies..")
             installed_packages_name_set = [package.project_name.lower() for package in
-                                           pip.get_installed_distributions()]
+                                           pip.get_installed_distributions() if (package.project_name in site_packages or
+                                           package.project_name in site_packages_64) and slim_handler]
             # First, try lambda packages
             for name, details in lambda_packages.items():
                 if name.lower() in installed_packages_name_set:

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -489,12 +489,17 @@ class Zappa(object):
 
         copy_tree(temp_package_path, temp_project_path, update=True)
 
+        package_to_keep = []
+        if os.path.isdir(site_packages):
+            package_to_keep += os.listdir(site_packages)
+        if os.path.isdir(site_packages_64):
+            package_to_keep += os.listdir(site_packages_64)
+
         # Then the pre-compiled packages..
         if use_precompiled_packages:
             print("Downloading and installing dependencies..")
             installed_packages_name_set = [package.project_name.lower() for package in
-                                           pip.get_installed_distributions() if (package.project_name in site_packages or
-                                           package.project_name in site_packages_64) and slim_handler]
+                                           pip.get_installed_distributions() if package.project_name in package_to_keep]
             # First, try lambda packages
             for name, details in lambda_packages.items():
                 if name.lower() in installed_packages_name_set:


### PR DESCRIPTION
…or site_packages64. The pip call gets all installed packages, but when slim_handler is used we don't need everything

## Description
The lambda_packages was getting pulled in according to pip, but we are faking a venv for the slim handler and specifying its packages in site_packages. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#641 
