### PR TITLE
Added fallback for project_name not in package_to_keep

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -107,8 +107,8 @@ class TestZappa(unittest.TestCase):
     def test_create_lambda_package(self):
         # mock the pip.get_installed_distributions() to include a package in lambda_packages so that the code
         # for zipping pre-compiled packages gets called
-        mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name'])
-        mock_return_val = [mock_named_tuple(lambda_packages.keys()[0])]  # choose name of 1st package in lambda_packages
+        mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name', 'location'])
+        mock_return_val = [mock_named_tuple(lambda_packages.keys()[0], '/path')]  # choose name of 1st package in lambda_packages
         with mock.patch('pip.get_installed_distributions', return_value=mock_return_val):
             z = Zappa()
             path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
@@ -122,8 +122,8 @@ class TestZappa(unittest.TestCase):
 
         # mock the pip.get_installed_distributions() to include a package in manylinux so that the code
         # for zipping pre-compiled packages gets called
-        mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name'])
-        mock_return_val = [mock_named_tuple('pandas')]
+        mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name', 'location'])
+        mock_return_val = [mock_named_tuple('pandas', '/path')]
         with mock.patch('pip.get_installed_distributions', return_value=mock_return_val):
             z = Zappa()
             path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -499,7 +499,8 @@ class Zappa(object):
         if use_precompiled_packages:
             print("Downloading and installing dependencies..")
             installed_packages_name_set = [package.project_name.lower() for package in
-                                           pip.get_installed_distributions() if package.project_name in package_to_keep]
+                                           pip.get_installed_distributions() if package.project_name in package_to_keep or
+                                           package.location in [site_packages, site_packages_64]]
             # First, try lambda packages
             for name, details in lambda_packages.items():
                 if name.lower() in installed_packages_name_set:


### PR DESCRIPTION
## Description
For the issue linked below, where a package like python-ldap doesn't get resolved in the lambda-packages resolving step, due to there being no listdir entry corresponding to the pip-wise project name.

It adds another check if the package is part of the site-packages by using pips package location entry.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/644
