### PR TITLE
Binary support when response body is not set.

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -453,8 +453,11 @@ class LambdaHandler(object):
 
                 if settings.BINARY_SUPPORT:
                     if not response.mimetype.startswith("text/") or response.mimetype != "application/json":
-                        zappa_returndict['body'] = base64.b64encode(zappa_returndict['body'])
-                        zappa_returndict["isBase64Encoded"] = "true"
+                        try:
+                            zappa_returndict['body'] = base64.b64encode(zappa_returndict['body'])
+                            zappa_returndict["isBase64Encoded"] = "true"
+                        except KeyError:
+                            pass
 
                 # Calculate the total response time,
                 # and log it in the Common Log format.


### PR DESCRIPTION
## Description
Came across this enabling binary support for an oauth login process. I believe at some point in that request chain, a blank response to returned and redirected. 
Here, due to https://github.com/cameronmaske/Zappa/blob/9966573da5ee41b8359c52f4e9907fe58adf41c5/zappa/handler.py#L446 it's possible that the `zappa_returndict` `body` key is not set. 
In such a case, when attempting to be b64 encoded, an error will be raised. 
I added a simple try/except to pass over this and continue the request.


