### PR TITLE
[WIP DO NOT MERGE YET] Add SNS as event source for async tasks.

### DIFF
--- a/zappa/async.py
+++ b/zappa/async.py
@@ -1,0 +1,88 @@
+import os
+import json
+import importlib
+import inspect
+import boto3
+
+AWS_REGION = os.environ.get('AWS_REGION')
+AWS_LAMBDA_FUNCTION_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+
+sts = boto3.client('sts')
+AWS_ACCOUNT_ID = sts.get_caller_identity()['Account']
+ASYNC_SNS_ARN = 'arn:aws:sns:{region}:{account}:{lambda_name}-zappa-async'.format(
+    region=AWS_REGION, account=AWS_ACCOUNT_ID,
+    lambda_name=AWS_LAMBDA_FUNCTION_NAME
+)
+
+
+def import_and_get_task(task_path):
+    """
+    Given a modular path to a function, import that module
+    and return the function.
+    """
+    module, function = task_path.rsplit('.', 1)
+    app_module = importlib.import_module(module)
+    app_function = getattr(app_module, function)
+    return app_function
+
+
+def route_task(event, context):
+    """
+    Gets SNS Message, deserialises the message,
+    imports the function, calls the function with args
+    """
+    record = event['Records'][0]
+    message = json.loads(
+        record['Sns']['Message']
+    )
+    func = import_and_get_task(message['task_path'])
+    return func(
+        *message['args'], **message['kwargs']
+    )
+
+
+def send_async_task(task_path, *args, **kwargs):
+    """
+    Send a SNS message to a specified SNS topic
+    Serialise the func path and arguments
+    """
+    client = boto3.client('sns')
+    message = {
+        'task_path': task_path,
+        'args': args,
+        'kwargs': kwargs
+    }
+    return client.publish(
+        TargetArn=ASYNC_SNS_ARN, Message=json.dumps(message),
+    )
+
+
+def task():
+    """
+    Async task decorator for a function.
+    Serialises and dispatches the task to SNS.
+    Lambda subscribes to SNS topic and gets this message
+    Lambda routes the message to the same function
+    Example:
+        @task()
+        def my_async_func(*args, **kwargs):
+            dosomething()
+        my_async_func.delay(*args, **kwargs)
+    """
+    def _delay(func):
+        def _delay_inner(*args, **kwargs):
+            module_path = inspect.getmodule(func).__name__
+            task_path = '{module_path}.{func_name}'.format(
+                module_path=module_path,
+                func_name=func.__name__
+            )
+            if ASYNC_SNS_ARN:
+                return send_async_task(task_path, *args, **kwargs)
+            return func(*args, **kwargs)
+        return _delay_inner
+
+    def _wrap(func):
+        func.delay = _delay(func)
+        return func
+
+    return _wrap

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -907,8 +907,17 @@ class ZappaCLI(object):
                 lambda_arn=function_response['Configuration']['FunctionArn'],
                 lambda_name=self.lambda_name,
                 events=events
-                )
+            )
 
+        # Add async SNS
+        if self.stage_config.get('async_enabled', True):
+            self.lambda_arn = self.zappa.get_lambda_function(
+                function_name=self.lambda_name)
+            topic_arn = self.zappa.create_async_sns_topic(
+                lambda_name=self.lambda_name,
+                lambda_arn=self.lambda_arn
+            )
+            click.echo('SNS Topic created: %s' % topic_arn)
 
     def unschedule(self):
         """

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -224,11 +224,11 @@ class Zappa(object):
         self.iam = self.boto_session.resource('iam')
         self.cloudwatch = self.boto_session.client('cloudwatch')
         self.route53 = self.boto_session.client('route53')
+        self.sns_client = self.boto_session.client('sns')
         self.cf_client = self.boto_session.client('cloudformation')
         self.cf_template = troposphere.Template()
         self.cf_api_resources = []
         self.cf_parameters = {}
-
 
     def cache_param(self, value):
         '''Returns a troposphere Ref to a value cached as a parameter.'''
@@ -1844,6 +1844,35 @@ class Zappa(object):
                 logger.debug('No policy found, must be first run.')
             else:
                 logger.error('Unexpected client error {}'.format(e.message))
+
+    def create_async_sns_topic(self, lambda_name, lambda_arn):
+        topic_name = '%s-zappa-async' % lambda_name
+        # Create SNS topic
+        topic_arn = self.sns_client.create_topic(
+            Name=topic_name)['TopicArn']
+        # Create subscription
+        self.sns_client.subscribe(
+            TopicArn=topic_arn,
+            Protocol='lambda',
+            Endpoint=lambda_arn
+        )
+        # Add Lambda permission for SNS to invoke function
+        self.create_event_permission(
+            lambda_name=lambda_name,
+            principal='sns.amazonaws.com',
+            source_arn=topic_arn
+        )
+        # Add rule for SNS topic as a event source
+        add_event_source(
+            event_source={
+                "arn": topic_arn,
+                "events": ["sns:Publish"]
+            },
+            lambda_arn=lambda_arn,
+            target_function="zappa.async.route_task",
+            boto_session=self.boto_session
+        )
+        return topic_arn
 
     ##
     # CloudWatch Logging


### PR DESCRIPTION
## Description
Just proposing an approach to having async tasks. The implementation is not fully completed.

## TODO
[ ] Undeploy SNS
[ ] Write unit tests
[ ] Refactor create_async_sns_topic, feel kinda not clean to keep adding code to cli.py

## Assumptions

SNS Topic ARN is constructed based on:
- AWS_REGION (lambda reserved env var)
- AWS_LAMBDA_FUNCTION_NAME (lambda reserved env var)
- Derived ACCOUNT_ID (queried from currently running Lambda)
- Topic always ends with `zappa-async`


### How to use

1. in zappa_settings add: `"async_enabled": true`
2. Decorate your func with `@task`

```python
from zappa.async import task
@task
def intensive_func(*args, **kwargs):
     this_takes_a_long_time()
```

3. Invoke the func: `intensive_func.delay(*args, **kwargs)`

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/603

