### PR TITLE
slim_handler=true change working directory

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -168,6 +168,9 @@ class LambdaHandler(object):
 
         # Add to project path
         sys.path.insert(0, project_folder)
+        
+        # Change working directory to project folder
+        os.chdir(project_folder)
         return True
 
     def load_remote_settings(self, remote_bucket, remote_file):


### PR DESCRIPTION
When using slim_handler=true, set working directory to the project's root folder to preserve relative file paths.

## Description
slim_handler=true sets file paths relative to the handler. The 1-line update sets the working directory to the project root.


## GitHub Issues
Resolves #702 

