### PR TITLE
Adds Python version warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ __Awesome!__
 
 ## Installation and Configuration
 
-_Before you begin, make sure you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
+_Before you begin, make sure you are running Python 2.7 and you have a valid AWS account and your [AWS credentials file](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) is properly installed._
 
 **Zappa** can easily be installed through pip, like so:
 


### PR DESCRIPTION
## Description
As a brand new Zappa user, I wasted ~2 hours migrating from a local
docker-based environment to Virtual Env only to find out Zappa doesn't
support 3.5  :-(.

It looks like[ others have experienced the same thing too]( https://github.com/Miserlou/Zappa/issues/6), so this PR is
meant to the be a bare minimum notice that Python 3x is not supported.
Down the road, it would be helpful to have a `zappa doctor` type command
to validate/troubleshoot this stuff early on.

Nonetheless, I'm still excited about this project so keep up the good
work!



## GitHub Issues
It looks like there was lots of discussion and consensus to add this notice to the README in #6, but it was never added.
- https://github.com/Miserlou/Zappa/issues/6

