### PR TITLE
Async for lambda and SNS -- tackling #603

### DIFF
--- a/zappa/async.py
+++ b/zappa/async.py
@@ -1,0 +1,88 @@
+import os
+import json
+import importlib
+import inspect
+import boto3
+
+AWS_REGION = os.environ.get('AWS_REGION')
+AWS_LAMBDA_FUNCTION_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+
+sts = boto3.client('sts')
+AWS_ACCOUNT_ID = sts.get_caller_identity()['Account']
+ASYNC_SNS_ARN = 'arn:aws:sns:{region}:{account}:{lambda_name}-zappa-async'.format(
+    region=AWS_REGION, account=AWS_ACCOUNT_ID,
+    lambda_name=AWS_LAMBDA_FUNCTION_NAME
+)
+
+
+def import_and_get_task(task_path):
+    """
+    Given a modular path to a function, import that module
+    and return the function.
+    """
+    module, function = task_path.rsplit('.', 1)
+    app_module = importlib.import_module(module)
+    app_function = getattr(app_module, function)
+    return app_function
+
+
+def route_task(event, context):
+    """
+    Gets SNS Message, deserialises the message,
+    imports the function, calls the function with args
+    """
+    record = event['Records'][0]
+    message = json.loads(
+        record['Sns']['Message']
+    )
+    func = import_and_get_task(message['task_path'])
+    return func(
+        *message['args'], **message['kwargs']
+    )
+
+
+def send_async_task(task_path, *args, **kwargs):
+    """
+    Send a SNS message to a specified SNS topic
+    Serialise the func path and arguments
+    """
+    client = boto3.client('sns')
+    message = {
+        'task_path': task_path,
+        'args': args,
+        'kwargs': kwargs
+    }
+    return client.publish(
+        TargetArn=ASYNC_SNS_ARN, Message=json.dumps(message),
+    )
+
+
+def task():
+    """
+    Async task decorator for a function.
+    Serialises and dispatches the task to SNS.
+    Lambda subscribes to SNS topic and gets this message
+    Lambda routes the message to the same function
+    Example:
+        @task()
+        def my_async_func(*args, **kwargs):
+            dosomething()
+        my_async_func.delay(*args, **kwargs)
+    """
+    def _delay(func):
+        def _delay_inner(*args, **kwargs):
+            module_path = inspect.getmodule(func).__name__
+            task_path = '{module_path}.{func_name}'.format(
+                module_path=module_path,
+                func_name=func.__name__
+            )
+            if ASYNC_SNS_ARN:
+                return send_async_task(task_path, *args, **kwargs)
+            return func(*args, **kwargs)
+        return _delay_inner
+
+    def _wrap(func):
+        func.delay = _delay(func)
+        return func
+
+    return _wrap

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -4,16 +4,83 @@ import importlib
 import inspect
 import boto3
 
+
+"""
+Example:
+from zappa.async import task
+
+@task(service='sns')
+def my_async_func(*args, **kwargs):
+    dosomething()
+
+res = my_async_func.delay(*args, **kwargs)
+if res.sent:
+    print('It was dispatched! Who knows what the function result will be!')
+
+For sns, you can also pass an `arn` argument to task() which will specify which SNS path to send it to.
+
+Without service='sns', the default service is 'lambda' which will call the method in an asynchronous
+lambda call.
+
+"""
+
+
 AWS_REGION = os.environ.get('AWS_REGION')
 AWS_LAMBDA_FUNCTION_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
 
-sts = boto3.client('sts')
-AWS_ACCOUNT_ID = sts.get_caller_identity()['Account']
-ASYNC_SNS_ARN = 'arn:aws:sns:{region}:{account}:{lambda_name}-zappa-async'.format(
-    region=AWS_REGION, account=AWS_ACCOUNT_ID,
-    lambda_name=AWS_LAMBDA_FUNCTION_NAME
-)
 
+class LambdaAsyncResponse(object):
+    def __init__(self, **kwargs):
+        self.client = boto3.client('lambda')
+
+    def send(self, task_path, *args, **kwargs):
+        message = {
+            'task_path': task_path,
+            'args': args,
+            'kwargs': kwargs
+        }
+        self._send(message)
+        return self
+
+    def _send(self, message):
+        message['command'] = 'zappa.async.route_lambda_task'
+
+        self.response = self.client.invoke(
+            FunctionName=AWS_LAMBDA_FUNCTION_NAME,
+            InvocationType='Event', #makes the call async
+            Payload=json.dumps(message).encode('utf-8'))
+
+        self.sent = (response.get('StatusCode', 0) == 202)
+
+
+class SnsAsyncResponse(LambdaAsyncResponse):
+    """
+    Send a SNS message to a specified SNS topic
+    Serialise the func path and arguments
+    """
+    def __init__(self, **kwargs):
+        self.client = boto3.client('sns')
+        if kwargs.get('arn'):
+            self.arn = kwargs.get('arn')
+        else:
+            stsclient = boto3.client('sts')
+            AWS_ACCOUNT_ID = stsclient.get_caller_identity()['Account']
+            self.arn = 'arn:aws:sns:{region}:{account}:{lambda_name}-zappa-async'.format(
+                region=AWS_REGION, account=AWS_ACCOUNT_ID,
+                lambda_name=AWS_LAMBDA_FUNCTION_NAME
+            )
+
+    def _send(self, message):
+        self.response = client.publish(
+            TargetArn=self.arn, Message=json.dumps(message),
+        )
+        self.sent = self.response.get('MessageId')
+
+
+ASYNC_CLASSES = {
+    'lambda': LambdaAsyncResponse,
+    'sns': SnsAsyncResponse,
+}
 
 def import_and_get_task(task_path):
     """
@@ -26,7 +93,19 @@ def import_and_get_task(task_path):
     return app_function
 
 
-def route_task(event, context):
+def route_lambda_task(event, context):
+    """
+    Deserialises the message from event passed to zappa.handler.run_function
+    imports the function, calls the function with args
+    """
+    message = event
+    func = import_and_get_task(message['task_path'])
+    return func(
+        *message['args'], **message['kwargs']
+    )
+
+
+def route_sns_task(event, context):
     """
     Gets SNS Message, deserialises the message,
     imports the function, calls the function with args
@@ -41,48 +120,32 @@ def route_task(event, context):
     )
 
 
-def send_async_task(task_path, *args, **kwargs):
-    """
-    Send a SNS message to a specified SNS topic
-    Serialise the func path and arguments
-    """
-    client = boto3.client('sns')
-    message = {
-        'task_path': task_path,
-        'args': args,
-        'kwargs': kwargs
-    }
-    return client.publish(
-        TargetArn=ASYNC_SNS_ARN, Message=json.dumps(message),
-    )
-
-
-def task():
+def task(service='lambda', **task_kwargs):
     """
     Async task decorator for a function.
     Serialises and dispatches the task to SNS.
     Lambda subscribes to SNS topic and gets this message
     Lambda routes the message to the same function
     Example:
-        @task()
+        @task(service='sns')
         def my_async_func(*args, **kwargs):
             dosomething()
         my_async_func.delay(*args, **kwargs)
     """
-    def _delay(func):
+    def _delay(func, task_path):
         def _delay_inner(*args, **kwargs):
-            module_path = inspect.getmodule(func).__name__
-            task_path = '{module_path}.{func_name}'.format(
-                module_path=module_path,
-                func_name=func.__name__
-            )
-            if ASYNC_SNS_ARN:
-                return send_async_task(task_path, *args, **kwargs)
+            if service in ASYNC_CLASSES:
+                return ASYNC_CLASSES[service](**task_kwargs).send(task_path, *args, **kwargs)
             return func(*args, **kwargs)
         return _delay_inner
 
     def _wrap(func):
-        func.delay = _delay(func)
+        module_path = inspect.getmodule(func).__name__
+        task_path = '{module_path}.{func_name}'.format(
+            module_path=module_path,
+            func_name=func.__name__
+        )
+        func.delay = _delay(func, task_path)
         return func
 
     return _wrap

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -984,6 +984,12 @@ class ZappaCLI(object):
             events=events,
             )
 
+        # Remove async SNS
+        if self.stage_config.get('async_source', False) == 'sns' \
+           and self.stage_config.get('async_resources', True):
+            removed_arns = self.zappa.remove_async_sns_topic(self.lambda_name)
+            click.echo('SNS Topic removed: %s' % ', '.join(removed_arns))
+
 
     def invoke(self, function_name, raw_python=False, command=None):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -942,8 +942,17 @@ class ZappaCLI(object):
                 lambda_arn=function_response['Configuration']['FunctionArn'],
                 lambda_name=self.lambda_name,
                 events=events
-                )
+            )
 
+        # Add async SNS
+        if self.stage_config.get('async_enabled', True):
+            self.lambda_arn = self.zappa.get_lambda_function(
+                function_name=self.lambda_name)
+            topic_arn = self.zappa.create_async_sns_topic(
+                lambda_name=self.lambda_name,
+                lambda_arn=self.lambda_arn
+            )
+            click.echo('SNS Topic created: %s' % topic_arn)
 
     def unschedule(self):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -945,7 +945,8 @@ class ZappaCLI(object):
             )
 
         # Add async SNS
-        if self.stage_config.get('async_enabled', True):
+        if self.stage_config.get('async_source', False) == 'sns' \
+           and self.stage_config.get('async_resources', True):
             self.lambda_arn = self.zappa.get_lambda_function(
                 function_name=self.lambda_name)
             topic_arn = self.zappa.create_async_sns_topic(

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1992,6 +1992,15 @@ class Zappa(object):
         )
         return topic_arn
 
+    def remove_async_sns_topic(self, lambda_name):
+        topic_name = '%s-zappa-async' % lambda_name
+        removed_arns = []
+        for sub in self.sns_client.list_subscriptions()['Subscriptions']:
+            if topic_name in sub['TopicArn']:
+                self.sns_client.delete_topic(TopicArn=sub['TopicArn'])
+                removed_arns.append(sub['TopicArn'])
+        return removed_arns
+
     ##
     # CloudWatch Logging
     ##


### PR DESCRIPTION
## Description
(based on @geeknam 's work) For SNS, you need to set `"async_resource": "sns"` (If you don't want it to auto-create then do `"async_resources": false`
The rest is documented at the top of zappa/async.py

This rebases @geeknam 's work, and then adds a commit.

I added a bit of abstraction for the async stuff, so that the caller can find out what happened, and if we want to add, e.g. fallback options into the `task()` call (e.g. fallback to synchronous, etc), then it's ready for such things.

This code is untested, so that's what I'm going to do next, but feedback (or testing) welcome.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/603

