### PR TITLE
Fix API Gateway test button (the bolt button)

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -544,6 +544,51 @@ class TestZappa(unittest.TestCase):
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
         response = response_tuple(200, 'hello')
 
+
+    def test_wsgi_from_apigateway_testbutton(self):
+        """
+        API Gateway resources have a "test bolt" button on methods.
+        This button sends some empty dicts as 'null' instead of '{}'.
+        """
+        event = {
+            "resource": "/",
+            "path": "/",
+            "httpMethod": "GET",
+            "headers": None,
+            "queryStringParameters": None,
+            "pathParameters": None,
+            "stageVariables": None,
+            "requestContext":{
+                "accountId": "0123456",
+                "resourceId": "qwertyasdf",
+                "stage": "test-invoke-stage",
+                "requestId": "test-invoke-request",
+                "identity":{
+                    "cognitoIdentityPoolId": None,
+                    "accountId": "0123456",
+                    "cognitoIdentityId": None,
+                    "caller": "MYCALLERID",
+                    "apiKey": "test-invoke-api-key",
+                    "sourceIp": "test-invoke-source-ip",
+                    "accessKey": "MYACCESSKEY",
+                    "cognitoAuthenticationType": None,
+                    "cognitoAuthenticationProvider": None,
+                    "userArn": "arn:aws:iam::fooo:user/my.username",
+                    "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_112)",
+                    "user": "MYCALLERID"
+                },
+                "resourcePath": "/",
+                "httpMethod": "GET",
+                "apiId": "myappid"
+            },
+            "body": None,
+            "isBase64Encoded": False
+        }
+
+        environ = create_wsgi_request(event, trailing_slash=False)
+        response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
+        response = response_tuple(200, 'hello')
+
     ##
     # Handler
     ##

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -15,11 +15,10 @@ def create_wsgi_request(event_info, server_name='zappa', script_name=None,
         Given some event_info,
         create and return a valid WSGI request environ.
         """
-
         method = event_info['httpMethod']
         params = event_info['pathParameters']
         query = event_info['queryStringParameters']
-        headers = event_info['headers']
+        headers = event_info['headers'] or {}
 
         # Extract remote user from context if Authorizer is enabled
         remote_user = None


### PR DESCRIPTION
## Description

The API Gateway have a test button, but it always fails because it sends an event with ``headers:null``. This PR fixes by falling back the ``null`` with an empty dict on python side.

A test was baked from the logs, replacing sensive information of my account.

Screenshot of the test button:
![screen shot 2017-03-22 at 17 12 44](https://cloud.githubusercontent.com/assets/155623/24218677/e527ca86-0f22-11e7-980f-24247c4abe3f.png)


Partial log of the error:
```
Wed Mar 22 19:27:35 UTC 2017 : Method response body after transformations: {
    "message": "An uncaught exception happened while servicing this request. You can investigate this with the `zappa tail` command.", 
    "traceback": [
        "Traceback (most recent call last):\n", 
        "  File \"/var/task/handler.py\", line 441, in handler\n    binary_support=settings.BINARY_SUPPORT\n", 
        "  File \"/Users/alanjds/.virtualenvs/zappa/lib/python2.7/site-packages/zappa/wsgi.py\", line 49, in create_wsgi_request\n", 
        "AttributeError: 'NoneType' object has no attribute 'keys'\n"
    ]
}
```