### PR TITLE
Add config for dead letter queue

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -167,3 +167,20 @@ Now in your application you can use:
 
     import os
     db_string = os.environ.get('DB_CONNECTION_STRING')
+
+Linking to a Dead Letter Queue
+==============================
+
+If you want to utilise `AWS Lambda's Dead Letter Queue feature <http://docs.aws.amazon.com/lambda/latest/dg/dlq.html>`_, you can set them in your ``zappa_settings.json``:
+
+::
+ 
+    {
+        "dev": {
+            ...
+            "dead_letter_arn": "your_sns_or_sqs_arn"
+        },
+        ...
+    }
+
+You must have already created the corresponding SNS/SQS topic/queue, and the Lambda function execution role must have been provisioned with read/publish/sendMessage access to the DLQ resource.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -20,9 +20,7 @@ Stages, such as *dev*, *staging*, and *production* are configured in the *zappa_
                 "zip": "my_app.zip_callback", // After creating the package
                 "post": "my_app.post_callback", // After command has excuted
             },
-            "dead_letter_config": { // Optional Dead Letter configuration for when Lambda async invoke fails thrice
-                "target_arn": "arn:aws:<sns/sqs>:::my-queue" // The ARN of the SNS/SQS topic/queue to use as the DLQ
-            },
+            "dead_letter_arn": "arn:aws:<sns/sqs>:::my-topic/queue", // Optional Dead Letter configuration for when Lambda async invoke fails thrice
             "debug": true
             "delete_zip": true
             "domain": "yourapp.yourdomain.com",

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -20,6 +20,9 @@ Stages, such as *dev*, *staging*, and *production* are configured in the *zappa_
                 "zip": "my_app.zip_callback", // After creating the package
                 "post": "my_app.post_callback", // After command has excuted
             },
+            "dead_letter_config": { // Optional Dead Letter configuration for when Lambda async invoke fails thrice
+                "target_arn": "arn:aws:<sns/sqs>:::my-queue" // The ARN of the SNS/SQS topic/queue to use as the DLQ
+            },
             "debug": true
             "delete_zip": true
             "domain": "yourapp.yourdomain.com",

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -602,6 +602,7 @@ class ZappaCLI(object):
                 handler=self.lambda_handler,
                 description=self.lambda_description,
                 vpc_config=self.vpc_config,
+                dead_letter_config=self.dead_letter_config,
                 timeout=self.timeout_seconds,
                 memory_size=self.memory_size
             )
@@ -1613,6 +1614,7 @@ class ZappaCLI(object):
         # Load environment-specific settings
         self.s3_bucket_name = self.stage_config.get('s3_bucket', "zappa-" + ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(9)))
         self.vpc_config = self.stage_config.get('vpc_config', {})
+        self.dead_letter_config = self.stage_config.get('dead_letter_config', {})
         self.memory_size = self.stage_config.get('memory_size', 512)
         self.app_function = self.stage_config.get('app_function', None)
         self.exception_handler = self.stage_config.get('exception_handler', None)

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1614,7 +1614,6 @@ class ZappaCLI(object):
         # Load environment-specific settings
         self.s3_bucket_name = self.stage_config.get('s3_bucket', "zappa-" + ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(9)))
         self.vpc_config = self.stage_config.get('vpc_config', {})
-        self.dead_letter_config = self.stage_config.get('dead_letter_config', {})
         self.memory_size = self.stage_config.get('memory_size', 512)
         self.app_function = self.stage_config.get('app_function', None)
         self.exception_handler = self.stage_config.get('exception_handler', None)
@@ -1625,6 +1624,8 @@ class ZappaCLI(object):
         self.log_level = self.stage_config.get('log_level', "DEBUG")
         self.domain = self.stage_config.get('domain', None)
         self.timeout_seconds = self.stage_config.get('timeout_seconds', 30)
+        dead_letter_arn = self.stage_config.get('dead_letter_arn', '')
+        self.dead_letter_config = {'TargetArn': dead_letter_arn} if dead_letter_arn else {}
 
         # Provide legacy support for `use_apigateway`, now `apigateway_enabled`.
         # https://github.com/Miserlou/Zappa/issues/490

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -700,13 +700,15 @@ class Zappa(object):
                                 memory_size=512,
                                 publish=True,
                                 vpc_config=None,
-                                dead_letter_config={}
+                                dead_letter_config=None
                             ):
         """
         Given a bucket and key of a valid Lambda-zip, a function name and a handler, register that Lambda function.
         """
         if not vpc_config:
             vpc_config = {}
+        if not dead_letter_config:
+            dead_letter_config = {}
         if not self.credentials_arn:
             self.get_credentials_arn()
 

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -699,7 +699,8 @@ class Zappa(object):
                                 timeout=30,
                                 memory_size=512,
                                 publish=True,
-                                vpc_config=None
+                                vpc_config=None,
+                                dead_letter_config=None
                             ):
         """
         Given a bucket and key of a valid Lambda-zip, a function name and a handler, register that Lambda function.
@@ -722,7 +723,8 @@ class Zappa(object):
             Timeout=timeout,
             MemorySize=memory_size,
             Publish=publish,
-            VpcConfig=vpc_config
+            VpcConfig=vpc_config,
+            DeadLetterConfig=dead_letter_config
         )
 
         return response['FunctionArn']

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -700,7 +700,7 @@ class Zappa(object):
                                 memory_size=512,
                                 publish=True,
                                 vpc_config=None,
-                                dead_letter_config=None
+                                dead_letter_config={}
                             ):
         """
         Given a bucket and key of a valid Lambda-zip, a function name and a handler, register that Lambda function.


### PR DESCRIPTION
## Description
Add config option in `zappa_settings.json` to allow configuration of DLQ when Lambda async call fails thrice.

I've decided to use the dictionary format config that the boto3 client uses instead of `<key>: <ARN>(String)` to be consistent.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/738 Add an entry in zappa_settings to configure the Dead Letter Queue to which triple failed async invokes are sent to
