### PR TITLE
Adding attachment of API stage to an existing usage plan and custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
       - [Deploying to a Domain With a Let's Encrypt Certificate (HTTP Auth)](#deploying-to-a-domain-with-a-lets-encrypt-certificate-http-auth)
       - [Deploying to a Domain With Your Own SSL Certs](#deploying-to-a-domain-with-your-own-ssl-certs)
       - [Deploying to a Domain With AWS Certificate Manager](#deploying-to-a-domain-with-aws-certificate-manager)
+      - [Deploying to a Domain With An Existing API Gateway Custom Domain](#deploying-to-a-domain-with-an-existing-api-gateway-custom-domain)
     - [Setting Environment Variables](#setting-environment-variables)
       - [Local Environment Variables](#local-environment-variables)
       - [Remote Environment Variables](#remote-environment-variables)
@@ -436,6 +437,8 @@ to change Zappa's behavior. Use these at your own risk!
         "api_key": "your_api_key_id", // optional, use an existing API key. The option "api_key_required" must be true to apply
         "apigateway_enabled": true, // Set to false if you don't want to create an API Gateway resource. Default true.
         "apigateway_description": "My funky application!", // Define a custom description for the API Gateway console. Default None.
+        "apigateway_custom_domain": "your_apigateway_custom_domain", // optional, add API stge to an existing API Gateway Custom Domain. Default None.
+        "apigateway_custom_domain_base_path": "your_apigateway_custom_domain_base_path", // Required if using apigateway_custom_domain. Base path mapping to use for the API Gateway Custom Domain. May be left blank. Default None. The option "apigateway_custom_domain" must be set to apply
         "assume_policy": "my_assume_policy.json", // optional, IAM assume policy JSON file
         "attach_policy": "my_attach_policy.json", // optional, IAM attach policy JSON file
         "aws_region": "aws-region-name", // optional, uses region set in profile or environment variables if not set here,
@@ -513,6 +516,7 @@ to change Zappa's behavior. Use these at your own risk!
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,
         "timeout_seconds": 30, // Maximum lifespan for the Lambda function (default 30, max 300.)
         "touch": false, // GET the production URL upon initial deployment (default True)
+        "usage_plan_id": "your_usage_plan_id", // optional, use an existing API Gateway usage plan. The option "api_key_required" must be true to apply
         "use_precompiled_packages": true, // If possible, use C-extension packages which have been pre-compiled for AWS Lambda. Default true.
         "vpc_config": { // Optional VPC configuration for Lambda function
             "SubnetIds": [ "subnet-12345678" ], // Note: not all availability zones support Lambda!
@@ -598,7 +602,9 @@ The file's contents should then be sourced in e.g. ~/.bashrc.
 
 ##### API Key
 
-You can use the `api_key_required` setting to generate and assign an API key to all the routes of your API Gateway. After redeployment, you can then pass the provided key as a header called `x-api-key` to access the restricted endpoints. Without the `x-api-key` header, you will receive a 403. You'll also need to manually associate this API key with your usage plan in the AWS console. [More information on API keys in the API Gateway](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html).
+You can use the `api_key_required` setting to generate and assign an API key to all the routes of your API Gateway. After redeployment, you can then pass the provided key as a header called `x-api-key` to access the restricted endpoints. Without the `x-api-key` header, you will receive a 403. 
+
+You can use the `usage_plan_id` setting to associate your API stage with an existing usage plan. If you don't specify this setting you'll need to manually associate this API key with your usage plan in the AWS console. [More information on API keys in the API Gateway](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html).
 
 ##### IAM Policy
 
@@ -658,6 +664,13 @@ However, it's now far easier to use Route 53-based DNS authentication, which wil
 3. Copy the entire ARN of that certificate and place it in the Zappa setting `certificate_arn`.
 4. Set your desired domain in the `domain` setting.
 5. Call `$ zappa certify` to create and associate the API Gateway distribution using that ceritficate.
+
+##### Deploying to a Domain With An Existing API Gateway Custom Domain
+
+1. Create a Custom Domain Name using the API Gateway Console, you can follow [this guide](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html#how-to-custom-domains-console)
+2. Set your domain name and desired base path mapping in the `apigateway_custom_domain` and `apigateway_custom_domain_base_path` settings. Read about base path mappings in these [docs](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html#how-to-custom-domains-mapping-console)
+3. Call `$ zappa deploy` to deploy your API and attach it to the custom domain
+4. Once your Route53 entry created in step 1. has propagated, the API will be available at your custom domain.
 
 #### Setting Environment Variables
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1653,6 +1653,8 @@ class ZappaCLI(object):
         self.api_key_required = self.stage_config.get('api_key_required', False)
         self.api_key = self.stage_config.get('api_key')
         self.usage_plan_id = self.stage_config.get('usage_plan_id', None)
+        self.apigateway_custom_domain = self.stage_config.get('apigateway_custom_domain', None)
+        self.apigateway_custom_domain_base_path = self.stage_config.get('apigateway_custom_domain_base_path', None)
         self.iam_authorization = self.stage_config.get('iam_authorization', False)
         self.cors = self.stage_config.get("cors", None)
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -637,12 +637,18 @@ class ZappaCLI(object):
             endpoint_url = self.deploy_api_gateway(api_id)
             deployment_string = deployment_string + ": {}".format(endpoint_url)
 
-            # Create/link API key
+            # Create/link API key and add to existing usage plan if specified
             if self.api_key_required:
                 if self.api_key is None:
                     self.zappa.create_api_key(api_id=api_id, stage_name=self.api_stage)
                 else:
                     self.zappa.add_api_stage_to_api_key(api_key=self.api_key, api_id=api_id, stage_name=self.api_stage)
+                    if self.usage_plan_id is not None:
+                        self.zappa.add_api_stage_to_usage_plan(usage_plan_id=self.usage_plan_id, api_id=api_id, stage_name=self.api_stage)
+
+            # Add a base path mapping to an existing API gateway custom domain
+            if self.apigateway_custom_domain is not None and self.apigateway_custom_domain_base_path is not None:
+                self.zappa.add_api_stage_to_custom_domain(apigateway_custom_domain=self.apigateway_custom_domain, apigateway_custom_domain_base_path=self.apigateway_custom_domain_base_path, api_id=api_id, stage_name=self.api_stage)
 
             if self.stage_config.get('touch', True):
                 requests.get(endpoint_url)
@@ -1646,6 +1652,7 @@ class ZappaCLI(object):
         self.binary_support = self.stage_config.get('binary_support', True)
         self.api_key_required = self.stage_config.get('api_key_required', False)
         self.api_key = self.stage_config.get('api_key')
+        self.usage_plan_id = self.stage_config.get('usage_plan_id', None)
         self.iam_authorization = self.stage_config.get('iam_authorization', False)
         self.cors = self.stage_config.get("cors", None)
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1192,7 +1192,7 @@ class Zappa(object):
             ]
         )
 
-    def add_api_stage_to_custom_domain(apigateway_custom_domain_name=self.apigateway_custom_domain_name, apigateway_custom_domain_base_path=self.apigateway_custom_domain_base_path, api_id=api_id, stage_name=self.api_stage):
+    def add_api_stage_to_custom_domain(self, apigateway_custom_domain_name=self.apigateway_custom_domain_name, apigateway_custom_domain_base_path=self.apigateway_custom_domain_base_path, api_id=api_id, stage_name=self.api_stage):
         """
         Add api stage to an existing custom domain
         """

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1185,7 +1185,7 @@ class Zappa(object):
             usagePlanId=usage_plan_id,
             patchOperations=[
                 {
-                    'op': 'add'
+                    'op': 'add',
                     'path': '/apiStages',
                     'value': '{}:{}'.format(api_id, stage_name)
                 }

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1176,6 +1176,34 @@ class Zappa(object):
                 apiKey="{}".format(api_key['id'])
             )
 
+    def add_api_stage_to_usage_plan(self, usage_plan_id, api_id, stage_name):
+        """
+        Add api stage to an existing usage plan
+        """
+        print("Adding API to usage plan..")
+        self.apigateway_client.update_usage_plan(
+            usagePlanId=usage_plan_id,
+            patchOperations=[
+                {
+                    'op': 'add'
+                    'path': '/apiStages',
+                    'value': '{}:{}'.format(api_id, stage_name)
+                },
+            ]
+        )
+
+    def add_api_stage_to_custom_domain(apigateway_custom_domain_name=self.apigateway_custom_domain_name, apigateway_custom_domain_base_path=self.apigateway_custom_domain_base_path, api_id=api_id, stage_name=self.api_stage):
+        """
+        Add api stage to an existing custom domain
+        """
+        print("Adding API base path mapping to custom domain..")
+        response = client.create_base_path_mapping(
+            domainName=apigateway_custom_domain_name,
+            basePath=apigateway_custom_domain_base_path,
+            restApiId=api_id,
+            stage=stage_name
+        )
+
     def add_api_stage_to_api_key(self, api_key, api_id, stage_name):
         """
         Add api stage to Api key

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -1188,7 +1188,7 @@ class Zappa(object):
                     'op': 'add'
                     'path': '/apiStages',
                     'value': '{}:{}'.format(api_id, stage_name)
-                },
+                }
             ]
         )
 
@@ -1197,7 +1197,7 @@ class Zappa(object):
         Add api stage to an existing custom domain
         """
         print("Adding API base path mapping to custom domain..")
-        response = client.create_base_path_mapping(
+        self.apigateway_client.create_base_path_mapping(
             domainName=apigateway_custom_domain_name,
             basePath=apigateway_custom_domain_base_path,
             restApiId=api_id,


### PR DESCRIPTION
## Description

Haven't tested this yet, but would appreciate feedback...

This PR is for allowing new settings to specify 1. an existing usage plan ID and 2. an existing API gateway custom domain and a base path mapping. When specified prior to zappa deploy it should attach each to the newly created API and both should be removed as part of the undeploy.

## GitHub Issues
Related - https://github.com/Miserlou/Zappa/issues/707