### PR TITLE
Fixes non-wsgi function initialization.

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -118,7 +118,7 @@ class LambdaHandler(object):
                 self.load_remote_project_zip(project_zip_path)
 
             # This is a non-WSGI application
-            if not hasattr(self.settings, 'APP_MODULE') and not hasattr(self.settings, 'DJANGO_SETTINGS'):
+            if not hasattr(self.settings, 'APP_MODULE') and not self.settings.DJANGO_SETTINGS:
                 self.app_module = None
                 wsgi_app_function = None
             # This is probably a normal WSGI app


### PR DESCRIPTION
## Description
DJANGO_SETTINGS attribute is set unconditionally, so `hasatrr` would always resolve to True. Check actual value instead. 
