### PR TITLE
allows wrapped function to be called synchronously as well with func.sync()

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,6 @@ def hello_world(environ, start_response):
         subject = escape(parameters['subject'][0])
     else:
         subject = 'World'
-    schedule_me()
     start_response('200 OK', [('Content-Type', 'text/html')])
     return ['''Hello {subject!s}
     Hello {subject!s}!

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+from zappa.async import task
 from cgi import parse_qs, escape
 
 def hello_world(environ, start_response):
@@ -6,12 +7,14 @@ def hello_world(environ, start_response):
         subject = escape(parameters['subject'][0])
     else:
         subject = 'World'
+    schedule_me()
     start_response('200 OK', [('Content-Type', 'text/html')])
     return ['''Hello {subject!s}
     Hello {subject!s}!
 
 '''.format(**{'subject': subject})]
 
+@task
 def schedule_me():
     return "Hello!"
 

--- a/tests/tests_async.py
+++ b/tests/tests_async.py
@@ -29,8 +29,7 @@ from zappa.async import import_and_get_task, \
                         route_lambda_task, \
                         route_sns_task, \
                         run, \
-                        task, \
-                        is_from_router
+                        task
 
 from zappa.cli import ZappaCLI, shamelessly_promote
 from zappa.zappa import Zappa, \
@@ -75,7 +74,7 @@ class TestZappa(unittest.TestCase):
     def test_nofails_funcs(self):
         funk = import_and_get_task("tests.test_app.schedule_me")
         get_func_task_path(funk)
-        is_from_router()
+        funk.sync
 
     ##
     # Functional tests

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -30,6 +30,7 @@ Discussion of this comes from:
 
 import boto3
 import botocore
+from functools import update_wrapper
 import importlib
 import inspect
 import json
@@ -215,6 +216,7 @@ class task(object):
     def __init__(self, func):
         self.func = func
         self.service = "lambda"
+        update_wrapper(self, func)
 
     def __call__(self, *args, **kwargs):
         """

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -154,12 +154,7 @@ def route_lambda_task(event, context):
     imports the function, calls the function with args
     """
     message = event
-    func = import_and_get_task(message['task_path'])
-    return func(
-            *message['args'],
-            **message['kwargs']
-        )
-
+    return run_message(message)
 
 def route_sns_task(event, context):
     """
@@ -170,11 +165,21 @@ def route_sns_task(event, context):
     message = json.loads(
             record['Sns']['Message']
         )
+    return run_message(message)
+
+def run_message(message):
     func = import_and_get_task(message['task_path'])
-    return func(
+    if hasattr(func, 'sync'):
+        return func.sync(
             *message['args'],
             **message['kwargs']
         )
+    else:
+        return func(
+            *message['args'],
+            **message['kwargs']
+        )
+
 
 ##
 # Execution interfaces and classes
@@ -219,13 +224,15 @@ class task(object):
         """
 
         task_path = get_func_task_path(self.func)
-        routed = is_from_router()
 
-        if (self.service in ASYNC_CLASSES) and (AWS_LAMBDA_FUNCTION_NAME) and (not routed):
+        if (self.service in ASYNC_CLASSES) and (AWS_LAMBDA_FUNCTION_NAME):
             send_result = ASYNC_CLASSES[self.service]().send(task_path, args, kwargs)
             return send_result
         else:
             return self.func(*args, **kwargs)
+
+    def sync(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
 
 class task_sns(task):
     """
@@ -260,18 +267,3 @@ def get_func_task_path(func):
                                         func_name=func.__name__
                                     )
     return task_path
-
-def is_from_router():
-    """
-    Detect if this stack is being executed from the router
-    """
-
-    tb = traceback.extract_stack()
-    for line in tb:
-        for item in line:
-            if 'route_lambda_task' in line:
-                return True
-            if 'route_sns_task' in line:
-                return True
-
-    return False

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -1,18 +1,19 @@
 from __future__ import unicode_literals
 
+import base64
+import collections
 import datetime
 import importlib
-import logging
-import traceback
-import os
-import json
 import inspect
-import collections
+import json
+import logging
+import os
+import sys
+import traceback
+import types
 import zipfile
-import base64
 
 import boto3
-import sys
 from werkzeug.wrappers import Response
 
 # This file may be copied into a project's root,
@@ -277,7 +278,12 @@ class LambdaHandler(object):
         Given a function and event context,
         detect signature and execute, returning any result.
         """
-        args, varargs, keywords, defaults = inspect.getargspec(app_function)
+        if not callable(app_function):
+            raise RuntimeError("Function passed to run is not callable")
+        if isinstance(app_function, types.InstanceType):
+            args, varargs, keywords, defaults = inspect.getargspec(app_function.__call__)
+        else:
+            args, varargs, keywords, defaults = inspect.getargspec(app_function)
         num_args = len(args)
         if num_args == 0:
             result = app_function(event, context) if varargs else app_function()


### PR DESCRIPTION
…sync() -- also removes need to trace stack to route things

## Description
* Use case: func = zappa.async.task(func) called synchronously.  now doable with func.sync()
* Also removes stack tracing requirement to route properly

## GitHub Issues
#603 evolution
