### PR TITLE
Update docs to reflect lambda name prepended to role_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ to change Zappa's behavior. Use these at your own risk!
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
         "remote_env": "s3://my-project-config-files/filename.json", // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.
-        "role_name": "MyLambdaRole", // Name of Zappa execution role. Default ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
+        "role_name": "MyLambdaRole", // Name of Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
         "slim_handler": false, // Useful if project >50M. Set true to just upload a small handler to Lambda and load actual project from S3 at runtime. Default false.
@@ -838,7 +838,7 @@ To manually define the permissions policy of your Zappa execution role, you must
     "dev": {
         ...
         "manage_roles": false, // Disable Zappa client managing roles.
-        "role_name": "MyLambdaRole", // Name of your Zappa execution role. Default ZappaExecutionRole.
+        "role_name": "MyLambdaRole", // Name of your Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole.
         ...
     },
     ...


### PR DESCRIPTION
## Description
When upgrading from 0.39.1 to 0.40.0 the `ZappaExecutionRole` has changed to `<project_name>-<env>-ZappaExecutionRole` but this is not reflected in the docs.

