### PR TITLE
Don't always create a __init__.py file for any folder where it doesn't exist

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,7 +30,7 @@ from zappa.letsencrypt import get_cert_and_update_domain, create_domain_key, cre
 from zappa.util import (detect_django_settings, copytree, detect_flask_apps,
                         add_event_source, remove_event_source,
                         get_event_source_status, parse_s3_url, human_size, string_to_timestamp,
-                        validate_name, InvalidAwsLambdaName)
+                        validate_name, InvalidAwsLambdaName, contains_python_files_or_subdirs)
 from zappa.wsgi import create_wsgi_request, common_log
 from zappa.zappa import Zappa, ASSUME_POLICY, ATTACH_POLICY
 
@@ -1472,6 +1472,18 @@ USE_TZ = True
                 with self.assertRaises(InvalidAwsLambdaName) as exc:
                     validate_name(value)
 
+    def test_contains_python_files_or_subdirs(self):
+        files = ['foo.py']
+        dirs = []
+        self.assertTrue(contains_python_files_or_subdirs(dirs, files))
+
+        files = []
+        dirs = ['subfolder']
+        self.assertTrue(contains_python_files_or_subdirs(dirs, files))
+
+        files = ['somefile.txt']
+        dirs = []
+        self.assertFalse(contains_python_files_or_subdirs(dirs, files))
 
 
 if __name__ == '__main__':

--- a/zappa/util.py
+++ b/zappa/util.py
@@ -341,3 +341,10 @@ def validate_name(name, maxlen=80):
         msg = "Name can only contain characters from a-z, A-Z, 0-9, _ and -"
         raise InvalidAwsLambdaName(msg)
     return name
+
+
+def contains_python_files_or_subdirs(dirs, files):
+    """
+    checks if len of dirs greater 0 or if there are any files ending on .py or .pyc in files
+    """
+    return len(dirs) > 0 or len([filename for filename in files if filename.endswith('.py') or filename.endswith('.pyc')]) > 0

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -26,7 +26,7 @@ from setuptools import find_packages
 from tqdm import tqdm
 
 # Zappa imports
-from util import copytree, add_event_source, remove_event_source, human_size, get_topic_name
+from util import copytree, add_event_source, remove_event_source, human_size, get_topic_name, contains_python_files_or_subdirs
 
 ##
 # Logging Config
@@ -344,10 +344,6 @@ class Zappa(object):
             return None
         return venv
 
-    @staticmethod
-    def contains_python_files_or_subdirs(dirs, files):
-        return len(dirs) > 0 or len([filename for filename in files if filename.endswith('.py') or filename.endswith('.pyc')]) > 0
-
     def create_lambda_zip(  self,
                             prefix='lambda_package',
                             handler_file=None,
@@ -542,7 +538,10 @@ class Zappa(object):
                 with open(os.path.join(root, filename), 'rb') as f:
                     zipf.writestr(zipi, f.read(), compression_method)
 
-            if '__init__.py' not in files and self.contains_python_files_or_subdirs(dirs, files):
+            # Create python init file if it does not exist
+            # Only do that if there are sub folders or python files
+            # Related: https://github.com/Miserlou/Zappa/issues/766
+            if '__init__.py' not in files and contains_python_files_or_subdirs(dirs, files):
                 tmp_init = os.path.join(temp_project_path, '__init__.py')
                 open(tmp_init, 'a').close()
                 os.chmod(tmp_init,  0o755)

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -344,6 +344,9 @@ class Zappa(object):
             return None
         return venv
 
+    def contains_python_files_or_subdirs(self, filename, dirs, files):
+        return len(dirs) > 0 or len([filename for filename in files if filename.endswith('.py') or filename.endswith('.pyc')]) > 0
+
     def create_lambda_zip(  self,
                             prefix='lambda_package',
                             handler_file=None,
@@ -538,7 +541,7 @@ class Zappa(object):
                 with open(os.path.join(root, filename), 'rb') as f:
                     zipf.writestr(zipi, f.read(), compression_method)
 
-            if '__init__.py' not in files:
+            if '__init__.py' not in files and self.contains_python_files_or_subdirs(filename, dirs, files):
                 tmp_init = os.path.join(temp_project_path, '__init__.py')
                 open(tmp_init, 'a').close()
                 os.chmod(tmp_init,  0o755)

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -344,7 +344,8 @@ class Zappa(object):
             return None
         return venv
 
-    def contains_python_files_or_subdirs(self, filename, dirs, files):
+    @staticmethod
+    def contains_python_files_or_subdirs(dirs, files):
         return len(dirs) > 0 or len([filename for filename in files if filename.endswith('.py') or filename.endswith('.pyc')]) > 0
 
     def create_lambda_zip(  self,
@@ -541,7 +542,7 @@ class Zappa(object):
                 with open(os.path.join(root, filename), 'rb') as f:
                     zipf.writestr(zipi, f.read(), compression_method)
 
-            if '__init__.py' not in files and self.contains_python_files_or_subdirs(filename, dirs, files):
+            if '__init__.py' not in files and self.contains_python_files_or_subdirs(dirs, files):
                 tmp_init = os.path.join(temp_project_path, '__init__.py')
                 open(tmp_init, 'a').close()
                 os.chmod(tmp_init,  0o755)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
As described in issue 766 the way `__init__.py` files are created in libraries can lead to problems. In my case a folder named ssl becomes a python module overwriting the standard ssl module and thus breaking the library I'm trying to use.
This change disables the creation of `__init__.py` files if there are no sub folders and no .py/.pyc files in the folder we are looking at.
As I was not sure why the `__init__.py` files are even created, I don't know if this change is satisfactory. For me this would fix my problems with the client library.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/766

