### PR TITLE
Fix for Zappa no longer creating Route53 records for AWS  issue #762

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1459,7 +1459,8 @@ class ZappaCLI(object):
                     self.api_stage,
                     self.domain,
                     clean_up,
-                    manual
+                    manual,
+                    route53_enabled=self.stage_config.get('route53_enabled', True)
                 )
 
             # Deliberately undocumented feature (for now, at least.)

--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -47,6 +47,7 @@ def get_cert_and_update_domain(
                                 domain=None,
                                 clean_up=True,
                                 manual=False,
+                                route53_enabled=True
                             ):
     """
     Main cert installer path.
@@ -70,7 +71,7 @@ def get_cert_and_update_domain(
         if not manual:
             if domain:
                 if not zappa_instance.get_domain_name(domain):
-                    zappa_instance.create_domain_name(
+                    dns_name = zappa_instance.create_domain_name(
                         domain_name=domain,
                         certificate_name=domain + "-Zappa-LE-Cert",
                         certificate_body=certificate_body,
@@ -81,6 +82,8 @@ def get_cert_and_update_domain(
                         stage=api_stage
                     )
                     print("Created a new domain name. Please note that it can take up to 40 minutes for this domain to be created and propagated through AWS, but it requires no further work on your part.")
+                    if route53_enabled:
+                        zappa_instance.update_route53_records(domain, dns_name)
                 else:
                     zappa_instance.update_domain_name(
                         domain_name=domain,


### PR DESCRIPTION
Original Author: Aneesh Kumar, anush0247
Applied to latest commit on Zappa master and tested by bitshark

This is a fix for Zappa issue #762.  Zappa is not creating and
persisting the appropriate CNAME records in AWS Route 53, when using
an AWS Hosted Zone with Let's Encrypt certificates (via zappa certify)

Zappa creates the Custom Domain Name properly in API gateway, and it
also properly creates the let's encrypt certification DNS records, but
it does not create and persist the correct Route 53 CNAME records for the app

This fix resolves the issue and has been tested locally to confirm the fix

Full details:
https://github.com/Miserlou/Zappa/issues/762
https://github.com/anush0247/Zappa/commit/8ea4ecf2cc70e3fcbc39824d12eb77fa82c38ff1


## Description
This fixes the Route53 certification issues described in issue #762.  It is a simple change, only two or three lines total across two files.   The original author is Aneesh, who's commit is linked above.  I've just ported it to master and submitted it as a pull request after confirming it resolves my issue as well.

## GitHub Issues
Issue #762
