### PR TITLE
201704 init venv check fix

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -906,7 +906,7 @@ class TestZappa(unittest.TestCase):
                 }
             } },
             { 'profiles' : {
-                'default' : {
+                'radical' : {
                     'region' : 'us-east-1'
                 },
                 'another' : {
@@ -924,7 +924,7 @@ class TestZappa(unittest.TestCase):
         # Test directly
         zappa_cli = ZappaCLI()
         # Via http://stackoverflow.com/questions/2617057/how-to-supply-stdin-files-and-environment-variable-inputs-to-python-unit-tests
-        inputs = ['dev', 'y', 'lmbda', 'test_settings', 'y', '']
+        inputs = ['dev', 'lmbda', 'test_settings', 'y', '']
 
         def test_for(inputs):
             input_generator = (i for i in inputs)
@@ -935,9 +935,9 @@ class TestZappa(unittest.TestCase):
                 os.remove('zappa_settings.json')
 
         test_for(inputs)
-        test_for(['dev', 'n', 'lmbda', 'test_settings', 'n', ''])
+        test_for(['dev', 'lmbda', 'test_settings', 'n', ''])
         test_for(['dev', 'default', 'lmbda', 'test_settings', '', ''])
-        test_for(['dev', 'another', 'lmbda', 'test_settings', 'p', ''])
+        test_for(['dev', 'radical', 'lmbda', 'test_settings', 'p', ''])
         test_for(['dev', 'lmbda', 'test_settings', 'y', ''])
         test_for(['dev', 'lmbda', 'test_settings', 'p', 'n'])
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1239,21 +1239,12 @@ class ZappaCLI(object):
 
         if not profile_names:
             profile_name, profile = None, None
-            click.echo("\nWe couldn't find an AWS profile to use. Before using Zappa, you'll need to set one up. See here for more info: {}"
+            click.echo("We couldn't find an AWS profile to use. Before using Zappa, you'll need to set one up. See here for more info: {}"
                        .format(click.style(BOTO3_CONFIG_DOCS_URL, fg="blue", underline=True)))
         elif len(profile_names) == 1:
-            default_profile = profile_names[0]
-            while True:
-                use_default_profile = raw_input("\nWe only found one profile: {}. "\
-                                                "Is this okay? (default 'y') [y/n]: "
-                                                .format(default_profile)) or "y"
-                if use_default_profile.lower() in ["y", "yes", "p", "primary"]:
-                    profile_name = default_profile
-                    profile = profiles[default_profile]
-                    break
-                if use_default_profile.lower() in ["n", "no"]:
-                    profile_name, profile = None, None
-                    break
+            profile_name = profile_names[0]
+            profile = profiles[profile_name]
+            click.echo("Using profile {}".format(click.style(profile_name, bold=True)))
         else:
             if "default" in profile_names:
                 default_profile = [p for p in profile_names if p == "default"][0]
@@ -1272,7 +1263,7 @@ class ZappaCLI(object):
                     profile = profiles[profile_name]
                     break
                 else:
-                    click.echo("\nPlease enter a valid name for your AWS profile.")
+                    click.echo("Please enter a valid name for your AWS profile.")
 
         profile_region = profile.get("region") if profile else None
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2151,8 +2151,7 @@ class ZappaCLI(object):
             venv = self.zappa.get_current_venv()
         else:
             # Just for `init`, when we don't have settings yet.
-            temp_zappa = Zappa()
-            venv = temp_zappa.get_current_venv()
+            venv = Zappa.get_current_venv()
         if not venv:
             raise ClickException(
                 click.style("Zappa", bold=True) + " requires an " + click.style("active virtual environment", bold=True, fg="red") + "!\n" +

--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -324,7 +324,9 @@ class Zappa(object):
 
         return ve_path
 
-    def get_current_venv(self):
+    # staticmethod as per https://github.com/Miserlou/Zappa/issues/780
+    @staticmethod
+    def get_current_venv():
         """
         Returns the path to the current virtualenv
         """


### PR DESCRIPTION
Addressing a couple things as per [this issue](https://github.com/Miserlou/Zappa/issues/780).

* Made `get_current_venv` a static method so that init doesn't need to create a temp Zappa instance just to call that
* Added a profile detection bit in init