### PR TITLE
#776 fix for libmysqlclient.so.18 error when using slim_handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ to change Zappa's behavior. Use these at your own risk!
             "Resource": "*"
         }],
         "iam_authorization": true, // optional, use IAM to require request signing. Default false. Note that enabling this will override the authorizer configuration.
+        "include": ["your_special_library_to_load_at_handler_init"], // load special libraries into PYTHONPATH at handler init that certain modules cannot find on path
         "authorizer": {
             "function": "your_module.your_auth_function", // Local function to run for token validation. For more information about the function see below.
             "arn": "arn:aws:lambda:<region>:<account_id>:function:<function_name>", // Existing Lambda function to run for token validation.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1937,7 +1937,8 @@ class ZappaCLI(object):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
 
                 #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
-                settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
+                if len(self.stage_config.get('include', []) >= 1:
+                    settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
 
             # AWS Events function mapping
             event_mapping = {}

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -54,6 +54,7 @@ CUSTOM_SETTINGS = [
     'delete_s3_zip',
     'exclude',
     'extra_permissions',
+    'include',
     'role_name',
     'touch',
 ]
@@ -1934,6 +1935,9 @@ class ZappaCLI(object):
             # If slim handler, path to project zip
             if self.stage_config.get('slim_handler', False):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
+
+                #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
+                settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include')).join(("'","'")) + "]\n"
 
             # AWS Events function mapping
             event_mapping = {}

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1937,7 +1937,7 @@ class ZappaCLI(object):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
 
                 #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
-                settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include')).join(("'","'")) + "]\n"
+                settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
 
             # AWS Events function mapping
             event_mapping = {}

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1936,8 +1936,11 @@ class ZappaCLI(object):
             if self.stage_config.get('slim_handler', False):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
 
-                #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
+                # since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
+                # and tell the handler we are the slim_handler
                 # https://github.com/Miserlou/Zappa/issues/776
+                settings_s += "SLIM_HANDLER=True\n"
+
                 if len(self.stage_config.get('include', [])) >= 1:
                     settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1937,6 +1937,7 @@ class ZappaCLI(object):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
 
                 #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
+                # https://github.com/Miserlou/Zappa/issues/776
                 if len(self.stage_config.get('include', [])) >= 1:
                     settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1937,7 +1937,7 @@ class ZappaCLI(object):
                 settings_s += "ZIP_PATH='s3://{0!s}/{1!s}_current_project.zip'\n".format(self.s3_bucket_name, self.project_name)
 
                 #since includes are for slim handler add the setting here by joining arbitrary list from zappa_settings file
-                if len(self.stage_config.get('include', []) >= 1:
+                if len(self.stage_config.get('include', [])) >= 1:
                     settings_s += "INCLUDE=[" + ','.join(("'","'")).join(self.stage_config.get('include', [])).join(("'","'")) + "]\n"
 
             # AWS Events function mapping

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -120,17 +120,18 @@ class LambdaHandler(object):
 
             # Load compliled library to the PythonPath
             # https://github.com/Miserlou/Zappa/issues/776
-            included_libraries = getattr(self.settings, 'INCLUDE', None)
+            included_libraries = getattr(self.settings, 'INCLUDE', ['libmysqlclient.so.18'])
             if included_libraries:
                 try:
                     from ctypes import cdll, util
                     for library in self.settings.INCLUDE:
                         try:
+
                             cdll.LoadLibrary(os.path.join(os.getcwd(), library))
                         except OSError:
-                            print "Failed to find library...right filename?"
+                            print ("Failed to find library...right filename?")
                 except ImportError:
-                    print "Failed to import cytpes library"
+                    print ("Failed to import cytpes library")
 
             # This is a non-WSGI application
             # https://github.com/Miserlou/Zappa/pull/748

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -119,12 +119,14 @@ class LambdaHandler(object):
 
 
             # Load compliled library to the PythonPath
+            # checks if we are the slim_handler since this is not needed otherwise
             # https://github.com/Miserlou/Zappa/issues/776
-            included_libraries = getattr(self.settings, 'INCLUDE', ['libmysqlclient.so.18'])
-            if included_libraries:
+            is_slim_handler = getattr(self.settings, 'SLIM_HANDLER', False)
+            if is_slim_handler:
+                included_libraries = getattr(self.settings, 'INCLUDE', ['libmysqlclient.so.18'])
                 try:
                     from ctypes import cdll, util
-                    for library in self.settings.INCLUDE:
+                    for library in included_libraries:
                         try:
                             cdll.LoadLibrary(os.path.join(os.getcwd(), library))
                         except OSError:

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -120,7 +120,8 @@ class LambdaHandler(object):
 
             # Load compliled library to the PythonPath
             # https://github.com/Miserlou/Zappa/issues/776
-            if self.settings.INCLUDE:
+            included_libraries = getattr(self.settings, 'INCLUDE', None)
+            if included_libraries:
                 try:
                     from ctypes import cdll, util
                     for library in self.settings.INCLUDE:

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -126,7 +126,6 @@ class LambdaHandler(object):
                     from ctypes import cdll, util
                     for library in self.settings.INCLUDE:
                         try:
-
                             cdll.LoadLibrary(os.path.join(os.getcwd(), library))
                         except OSError:
                             print ("Failed to find library...right filename?")

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -117,6 +117,20 @@ class LambdaHandler(object):
             if project_zip_path:
                 self.load_remote_project_zip(project_zip_path)
 
+
+            # Load compliled library to the PythonPath
+            # https://github.com/Miserlou/Zappa/issues/776
+            if self.settings.INCLUDE:
+                try:
+                    from ctypes import cdll, util
+                    for library in self.settings.INCLUDE:
+                        try:
+                            cdll.LoadLibrary(os.path.join(os.getcwd(), library))
+                        except OSError:
+                            print "Failed to find library...right filename?"
+                except ImportError:
+                    print "Failed to import cytpes library"
+
             # This is a non-WSGI application
             # https://github.com/Miserlou/Zappa/pull/748
             if not hasattr(self.settings, 'APP_MODULE') and not self.settings.DJANGO_SETTINGS:
@@ -169,7 +183,7 @@ class LambdaHandler(object):
 
         # Add to project path
         sys.path.insert(0, project_folder)
-        
+
         # Change working directory to project folder
         # Related: https://github.com/Miserlou/Zappa/issues/702
         os.chdir(project_folder)


### PR DESCRIPTION
Added include to zappa_settings
Added ctypes to handler to load the selected libraries directly to
PYTHONPATH

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
This PR fixes the issue where Django using MySQLdb looks for libmysqlclient.so.18 and could not find it in any path when using the slim_handler.  I creates a setting in the zappa_settings file for the specific library to add at handler init. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/776 