### PR TITLE
guard failed call to filter_log_events

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -2063,7 +2063,8 @@ class Zappa(object):
                 interleaved=True, # Does this actually improve performance?
                 **extra_args
             )
-            events += response['events']
+            if response and 'events' in response:
+                events += response['events']
 
         return sorted(events, key=lambda k: k['timestamp'])
 


### PR DESCRIPTION
Trivial change so I skipped the issue bits.

This patch guards the response of the call to `logs_client.`[`filter_log_events`](http://boto3.readthedocs.io/en/latest/reference/services/logs.html#CloudWatchLogs.Client.filter_log_events). It can sometimes return an empty dict (though the [docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html) are a bit unclear on this).

One of our devs was `zappa tail`ing from an airplane yesterday and had zappa crash out on him. This should safely guard against this situation.

```
Traceback (most recent call last):
  File "/path/to/venv/lib/python2.7/site-packages/zappa/cli.py", line 2187, in handle
    sys.exit(cli.handle())
  File "/path/to/venv/lib/python2.7/site-packages/zappa/cli.py", line 414, in handle
    self.dispatch_command(self.command, environment)
  File "/path/to/venv/lib/python2.7/site-packages/zappa/cli.py", line 485, in dispatch_command
    filter_pattern=self.vargs['filter'],
  File "/path/to/venv/lib/python2.7/site-packages/zappa/cli.py", line 838, in tail
    filter_pattern=filter_pattern,
  File "/path/to/venv/lib/python2.7/site-packages/zappa/zappa.py", line 2059, in fetch_logs
    events += response['events']
KeyError: 'events'
```

(trace redacted)