### PR TITLE
Fix pyenv causing failure on zappa init

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -342,7 +342,7 @@ class Zappa(object):
             venv = os.environ['VIRTUAL_ENV']
         elif os.path.exists('.python-version'):  # pragma: no cover
             try:
-                subprocess.check_output('pyenv', stderr=subprocess.STDOUT)
+                subprocess.check_output('pyenv help', stderr=subprocess.STDOUT)
             except OSError:
                 print("This directory seems to have pyenv's local venv"
                       "but pyenv executable was not found.")


### PR DESCRIPTION
## Description
Running `pyenv` by itself returns an exit code of 1, causing `subprocess.check_output` to fail when getting the current venv during init.

Changing this to `pyenv help` is functionally the same (no-op) but returns an exit code of 0.

