### PR TITLE
Support for manylinux wheels Python 3.6 package downloading.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -123,8 +123,8 @@ class TestZappa(unittest.TestCase):
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
-    def test_get_manylinux(self):
-        z = Zappa()
+    def test_get_manylinux_python27(self):
+        z = Zappa(runtime='python2.7')
         self.assertNotEqual(z.get_manylinux_wheel('pandas'), None)
         self.assertEqual(z.get_manylinux_wheel('derpderpderpderp'), None)
 
@@ -132,6 +132,21 @@ class TestZappa(unittest.TestCase):
         # for zipping pre-compiled packages gets called
         mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name', 'location'])
         mock_return_val = [mock_named_tuple('pandas', '/path')]
+        with mock.patch('pip.get_installed_distributions', return_value=mock_return_val):
+            z = Zappa()
+            path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
+
+    def test_get_manylinux_python36(self):
+        z = Zappa(runtime='python3.6')
+        self.assertNotEqual(z.get_manylinux_wheel('psycopg2'), None)
+        self.assertEqual(z.get_manylinux_wheel('derpderpderpderp'), None)
+
+        # mock the pip.get_installed_distributions() to include a package in manylinux so that the code
+        # for zipping pre-compiled packages gets called
+        mock_named_tuple = collections.namedtuple('mock_named_tuple', ['project_name', 'location'])
+        mock_return_val = [mock_named_tuple('psycopg2', '/path')]
         with mock.patch('pip.get_installed_distributions', return_value=mock_return_val):
             z = Zappa()
             path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1711,7 +1711,8 @@ class ZappaCLI(object):
                             profile_name=self.profile_name,
                             aws_region=self.aws_region,
                             load_credentials=self.load_credentials,
-                            desired_role_name=desired_role_name
+                            desired_role_name=desired_role_name,
+                            runtime=self.runtime
                         )
 
         for setting in CUSTOM_SETTINGS:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -205,8 +205,8 @@ class Zappa(object):
             profile_name=None,
             aws_region=None,
             load_credentials=True,
-            desired_role_name=None
-
+            desired_role_name=None,
+            runtime='python2.7'
         ):
         # Set aws_region to None to use the system's region instead
         if aws_region is None:
@@ -218,6 +218,14 @@ class Zappa(object):
 
         if desired_role_name:
             self.role_name = desired_role_name
+
+        self.runtime = runtime
+
+        if self.runtime == 'python2.7':
+            self.manylinux_wheel_file_suffix = 'cp27mu-manylinux1_x86_64.whl'
+        else:
+            self.manylinux_wheel_file_suffix = 'cp36m-manylinux1_x86_64.whl'
+
 
         # Some common invokations, such as DB migrations,
         # can take longer than the default.
@@ -585,7 +593,7 @@ class Zappa(object):
             data = res.json()
             version = data['info']['version']
             for f in data['releases'][version]:
-                if f['filename'].endswith('cp27mu-manylinux1_x86_64.whl'):
+                if f['filename'].endswith(self.manylinux_wheel_file_suffix):
                     return f['url']
         except Exception as e: # pragma: no cover
             return None


### PR DESCRIPTION
## Description

Since AWS Lambda and Zappa now support Python 3.6 this change makes sure that the correct version of the manylinux-wheels package is downloaded depending on the target runtime. 

## GitHub Issues

Addresses https://github.com/Miserlou/Zappa/issues/800.
A separate change will be required once work to fix lambda-packages to be runtime aware is done here https://github.com/Miserlou/lambda-packages/issues/43.