### PR TITLE
Setting for excluding files from .py trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ to change Zappa's behavior. Use these at your own risk!
         ],
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
         "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
+        "exclude_py_removal": [], // A list of files for which to include the .py version of the lambda zip file even if a .pyc/.pyo version of the file exists
         "extends": "stage_name", // Duplicate and extend another stage's settings. For example, `dev-asia` could extend from `dev-common` with a different `s3_bucket` value.
         "extra_permissions": [{ // Attach any extra permissions to this policy. Default None
             "Effect": "Allow",

--- a/test_settings.json
+++ b/test_settings.json
@@ -88,5 +88,9 @@
       "delete_local_zip": true,
       "use_precompiled_packages": false,
       "delete_s3_zip": false
+    },
+    "exclude_py_removal": {
+      "extends": "ttt888",
+      "exclude_py_removal": "test_app"
     }
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1528,6 +1528,15 @@ USE_TZ = True
         dirs = []
         self.assertFalse(contains_python_files_or_subdirs(dirs, files))
 
+    def test_exclude_py_removal(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'exclude_py_removal'
+        zappa_cli.load_settings('test_settings.json')
+        zappa_cli.create_package()
+
+        with zipfile.ZipFile(zappa_cli.zip_path) as lambda_zip:
+            self.assertIn('tests/test_app.py', lambda_zip.namelist())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1806,7 +1806,8 @@ class ZappaCLI(object):
             self.zip_path = self.zappa.create_lambda_zip(
                 prefix=self.lambda_name,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
-                exclude=self.stage_config.get('exclude', [])
+                exclude=self.stage_config.get('exclude', []),
+                exclude_py_removal=self.stage_config.get('exclude_py_removal')
             )
 
             # Make sure the normal venv is not included in the handler's zip
@@ -1818,7 +1819,8 @@ class ZappaCLI(object):
                 venv=self.zappa.create_handler_venv(),
                 handler_file=handler_file,
                 slim_handler=True,
-                exclude=exclude
+                exclude=exclude,
+                exclude_py_removal=self.stage_config.get('exclude_py_removal')
             )
         else:
 
@@ -1853,7 +1855,8 @@ class ZappaCLI(object):
                 prefix=self.lambda_name,
                 handler_file=handler_file,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
-                exclude=exclude
+                exclude=exclude,
+                exclude_py_removal=self.stage_config.get('exclude_py_removal')
             )
 
             # Warn if this is too large for Lambda.

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -362,7 +362,8 @@ class Zappa(object):
                             exclude=None,
                             use_precompiled_packages=True,
                             include=None,
-                            venv=None
+                            venv=None,
+                            exclude_py_removal=None
                         ):
         """
         Create a Lambda-ready zip file of the current virtualenvironment and working directory.
@@ -384,6 +385,10 @@ class Zappa(object):
         # Files that should be excluded from the zip
         if exclude is None:
             exclude = list()
+
+        # .py Files that should be included even if a .pyc/.pyo file exists
+        if exclude_py_removal is None:
+            exclude_py_removal = list()
 
         # Exclude the zip itself
         exclude.append(zip_path)
@@ -522,7 +527,8 @@ class Zappa(object):
                 # If there is a .pyc file in this package,
                 # we can skip the python source code as we'll just
                 # use the compiled bytecode anyway..
-                if filename[-3:] == '.py' and root[-10:] != 'migrations':
+                # (Unless it's included in exclude_py_removal)
+                if filename[-3:] == '.py' and root[-10:] != 'migrations' and filename[:-3] not in exclude_py_removal:
                     abs_filname = os.path.join(root, filename)
                     abs_pyc_filename = abs_filname + 'c'
                     if os.path.isfile(abs_pyc_filename):


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
* Adds new `exclude_py_removal` setting. Files included in this list will have their `.py` files included in the Lambda Zip file even if a `.pyo` or `.pyc` file of the same name exists.
* Adds a test for the above changes

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#635 
