### PR TITLE
use io.open() and specify encoding utf-8 to fix python3/windows encod…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 import os
 import sys
 from setuptools import setup
+from io import open
 
 # Set external files
 try:
     from pypandoc import convert
     README = convert('README.md', 'rst')
 except ImportError:
-    README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
+    README = open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r', encoding="utf-8").read()
 
 with open(os.path.join(os.path.dirname(__file__), 'requirements.txt')) as f:
     required = f.read().splitlines()


### PR DESCRIPTION
## Description
<!-- Please describe the changes included in this PR --> 
Fixes the windows/python3 decoding error when installing setup.py . This issue is caused by the differences in how Python2/Python3 handle data. The fix is compatible with Python 2 and 3 on windows and linux.

more info on this error:
https://ncoghlan-devs-python-notes.readthedocs.io/en/latest/python3/text_file_processing.html#what-changed-in-python-3

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/809
