### PR TITLE
More binary package fixes

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -125,8 +125,8 @@ class TestZappa(unittest.TestCase):
 
     def test_get_manylinux_python27(self):
         z = Zappa(runtime='python2.7')
-        self.assertNotEqual(z.get_manylinux_wheel('cffi'), None)
-        self.assertEqual(z.get_manylinux_wheel('derpderpderpderp'), None)
+        self.assertNotEqual(z.get_manylinux_wheel('cffi', '1.10.0'), None)
+        self.assertEqual(z.get_manylinux_wheel('derpderpderpderp', '0.0'), None)
 
         # mock the pip.get_installed_distributions() to include a package in manylinux so that the code
         # for zipping pre-compiled packages gets called
@@ -140,8 +140,8 @@ class TestZappa(unittest.TestCase):
 
     def test_get_manylinux_python36(self):
         z = Zappa(runtime='python3.6')
-        self.assertNotEqual(z.get_manylinux_wheel('psycopg2'), None)
-        self.assertEqual(z.get_manylinux_wheel('derpderpderpderp'), None)
+        self.assertNotEqual(z.get_manylinux_wheel('psycopg2', '2.7.1'), None)
+        self.assertEqual(z.get_manylinux_wheel('derpderpderpderp', '0.0'), None)
 
         # mock the pip.get_installed_distributions() to include a package in manylinux so that the code
         # for zipping pre-compiled packages gets called

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -479,16 +479,27 @@ class Zappa(object):
         # Then the pre-compiled packages..
         if use_precompiled_packages:
             print("Downloading and installing dependencies..")
-            installed_packages_name_set = [package.project_name.lower() for package in
-                                           pip.get_installed_distributions() if package.project_name in package_to_keep or
-                                           package.location in [site_packages, site_packages_64]]
+            installed_packages = {package.project_name.lower(): package.version for package in
+                                  pip.get_installed_distributions() if package.project_name in package_to_keep or
+                                  package.location in [site_packages, site_packages_64]}
+
             # First, try lambda packages
             for name, details in lambda_packages.items():
-                if name.lower() in installed_packages_name_set:
 
-                    # Packages can be compiled for different runtimes
-                    if not self.runtime in details:
+                # Packages can be compiled for different runtimes
+                if self.runtime not in details:
+                    continue
+
+                if name.lower() in installed_packages:
+                    installed_package_name = name.lower()
+                    installed_package_version = installed_packages[installed_package_name]
+
+                    # Binaries can be compiled for different package versions
+                    # Related: https://github.com/Miserlou/Zappa/issues/800
+                    if installed_package_version != details[self.runtime]['version']:
                         continue
+
+                    print("Using lambda-packages binary for %s %s" % (installed_package_name, installed_package_version,))
 
                     tar = tarfile.open(details[self.runtime]['path'], mode="r:gz")
                     for member in tar.getmembers():
@@ -498,24 +509,25 @@ class Zappa(object):
                             continue
                         tar.extract(member, temp_project_path)
 
-            progress = tqdm(total=len(installed_packages_name_set), unit_scale=False, unit='pkg')
-
             # Then try to use manylinux packages from PyPi..
             # Related: https://github.com/Miserlou/Zappa/issues/398
             try:
-                for installed_package_name in installed_packages_name_set:
+                for installed_package_name, installed_package_version in installed_packages.items():
                     if installed_package_name not in lambda_packages:
-                        wheel_url = self.get_manylinux_wheel(installed_package_name)
+                        wheel_url = self.get_manylinux_wheel(installed_package_name, installed_package_version)
+
                         if wheel_url:
-                            resp = requests.get(wheel_url, timeout=2, stream=True)
-                            resp.raw.decode_content = True
-                            zipresp = resp.raw
-                            with zipfile.ZipFile(BytesIO(zipresp.read())) as zfile:
-                                zfile.extractall(temp_project_path)
-                    progress.update()
-            except Exception:
-                pass # XXX - What should we do here?
-            progress.close()
+                            print("Downloading %s" % os.path.basename(wheel_url))
+
+                            with BytesIO() as file_stream:
+                                self.download_url_with_progress(wheel_url, file_stream)
+
+                                with zipfile.ZipFile(file_stream) as zfile:
+                                    zfile.extractall(temp_project_path)
+
+            except Exception as e:
+                print(e)
+                # XXX - What should we do here?
 
         # Then zip it all up..
         print("Packaging project as zip..")
@@ -588,7 +600,19 @@ class Zappa(object):
 
         return zip_fname
 
-    def get_manylinux_wheel(self, package):
+    def download_url_with_progress(self, url, file_stream):
+        resp = requests.get(url, timeout=2, stream=True)
+        resp.raw.decode_content = True
+
+        progress = tqdm(unit="B", unit_scale=True, total=int(resp.headers.get('Content-Length', 0)))
+        for chunk in resp.iter_content(chunk_size=1024):
+            if chunk:
+                progress.update(len(chunk))
+                file_stream.write(chunk)
+
+        progress.close()
+
+    def get_manylinux_wheel(self, package_name, package_version):
         """
         For a given package name, returns a link to the download URL,
         else returns None.
@@ -596,12 +620,11 @@ class Zappa(object):
         Related: https://github.com/Miserlou/Zappa/issues/398
         Examples here: https://gist.github.com/perrygeo/9545f94eaddec18a65fd7b56880adbae
         """
-        url = 'https://pypi.python.org/pypi/{}/json'.format(package)
+        url = 'https://pypi.python.org/pypi/{}/json'.format(package_name)
         try:
             res = requests.get(url, timeout=1.5)
             data = res.json()
-            version = data['info']['version']
-            for f in data['releases'][version]:
+            for f in data['releases'][package_version]:
                 if f['filename'].endswith(self.manylinux_wheel_file_suffix):
                     return f['url']
         except Exception as e: # pragma: no cover

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -513,17 +513,22 @@ class Zappa(object):
             # Related: https://github.com/Miserlou/Zappa/issues/398
             try:
                 for installed_package_name, installed_package_version in installed_packages.items():
-                    if installed_package_name not in lambda_packages:
-                        wheel_url = self.get_manylinux_wheel(installed_package_name, installed_package_version)
 
-                        if wheel_url:
-                            print("Downloading %s" % os.path.basename(wheel_url))
+                    # Ignore any packages we had in lambda-packages. User package version during check.
+                    # Related: https://github.com/Miserlou/Zappa/issues/800
+                    if installed_package_name in lambda_packages and lambda_packages[installed_package_name] == installed_package_version:
+                        continue
 
-                            with BytesIO() as file_stream:
-                                self.download_url_with_progress(wheel_url, file_stream)
+                    wheel_url = self.get_manylinux_wheel(installed_package_name, installed_package_version)
 
-                                with zipfile.ZipFile(file_stream) as zfile:
-                                    zfile.extractall(temp_project_path)
+                    if wheel_url:
+                        print("Downloading %s" % os.path.basename(wheel_url))
+
+                        with BytesIO() as file_stream:
+                            self.download_url_with_progress(wheel_url, file_stream)
+
+                            with zipfile.ZipFile(file_stream) as zfile:
+                                zfile.extractall(temp_project_path)
 
             except Exception as e:
                 print(e)


### PR DESCRIPTION
* Zappa now checks package version when deciding if it has the correct lambda-package, or which wheels version to pull down. Before you would silently get the latest version no matter what version you had in your virtual env. Fixes https://github.com/Miserlou/Zappa/issues/800 (again) and probably https://github.com/Miserlou/Zappa/issues/841

* Changed how the progress bars work when downloading manylinux packages. You now get one per package. There is also some logging to let you know whether a lambda-packages or wheels version of the package is used, along with which version. Here an example:

```
zappa package test
Calling package for environment test..
Downloading and installing dependencies..
Downloading cffi-1.10.0-cp27-cp27mu-manylinux1_x86_64.whl
100%|████████████████████████████████████████████████████████████████████████████████████████████████| 393K/393K [00:00<00:00, 2.34MB/s]
Using lambda-packages binary for psycopg2 2.6.1
Downloading grpcio-1.3.0-cp27-cp27mu-manylinux1_x86_64.whl
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 5.31M/5.31M [00:01<00:00, 4.49MB/s]
Downloading protobuf-3.3.0-cp27-cp27mu-manylinux1_x86_64.whl
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 5.72M/5.72M [00:01<00:00, 4.08MB/s]
Packaging project as zip..
```

* Refactored the binary package code into one loop.

* Changed a few unit tests for manylinux wheels and lambda packages that were in fact doing nothing 🙀 

* Tested on both Python 2.7 and Python 3.6