### PR TITLE
Keep Warm defaults to 15 minute Intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ to change Zappa's behavior. Use these at your own risk!
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
         },
         "keep_warm": true, // Create CloudWatch events to keep the server warm. Default true.
-        "keep_warm_expression": "rate(4 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 4 minutes.
+        "keep_warm_expression": "rate(15 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 15 minutes.
         "lambda_description": "Your Description", // However you want to describe your project for the AWS console. Default "Zappa Deployment".
         "lambda_handler": "your_custom_handler", // The name of Lambda handler. Default: handler.lambda_handler
         "lets_encrypt_key": "s3://your-bucket/account.key", // Let's Encrypt account key path. Can either be an S3 path or a local file path.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1003,7 +1003,7 @@ class ZappaCLI(object):
             if not events:
                 events = []
 
-            keep_warm_rate = self.stage_config.get('keep_warm_expression', "rate(4 minutes)")
+            keep_warm_rate = self.stage_config.get('keep_warm_expression', "rate(15 minutes)")
             events.append({'name': 'zappa-keep-warm',
                            'function': 'handler.keep_warm_callback',
                            'expression': keep_warm_rate,


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Based on this guy's analysis: https://robertvojta.com/aws-journey-api-gateway-lambda-vpc-performance-452c6932093b

It appears keep_warm only needs to occur once every 15 minutes. Currently every 4 minutes results in too many function calls. This could become a cost issue at scale if #851 is implemented.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#858 
