### PR TITLE
Multiple keep warm

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ to change Zappa's behavior. Use these at your own risk!
             "token_source": "Authorization", // Optional. Default 'Authorization'. The name of a custom authorization header containing the token that clients submit as part of their requests.
             "validation_expression": "^Bearer \\w+$", // Optional. A validation expression for the incoming token, specify a regular expression.
         },
-        "keep_warm": true, // Create CloudWatch events to keep the server warm. Default true.
+        "keep_warm": 1, // Create CloudWatch events to keep the server warm. Default 1 lambda instance.
         "keep_warm_expression": "rate(4 minutes)", // How often to execute the keep-warm, in cron and rate format. Default 4 minutes.
         "lambda_description": "Your Description", // However you want to describe your project for the AWS console. Default "Zappa Deployment".
         "lambda_handler": "your_custom_handler", // The name of Lambda handler. Default: handler.lambda_handler

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -42,7 +42,7 @@ Stages, such as *dev*, *staging*, and *production* are configured in the *zappa_
             "exclude": ["*.gz", "*.pem"],
             "http_methods": ["GET", "POST"],
             "integration_response_codes": [200, 301, 404, 500],
-            "keep_warm": true,
+            "keep_warm": 1,
             "lambda_handler": "your_custom_handler",
             "log_level": "DEBUG",
             "memory_size": 512,
@@ -181,7 +181,7 @@ This should in a formal like *[200, 301, 404, 500]*.
 keep_warm
 =========
 
-This boolean setting is used to specify whether to create CloudWatch events to keep the server warm.
+This integer setting is used to specify the number of lambda containers to keep warm via CloudWatch events.
 
 lambda_handler
 ==============

--- a/example/zappa_settings.json
+++ b/example/zappa_settings.json
@@ -1,7 +1,7 @@
 {
     "dev_event": {
        "project_name": "dev_event_zappa_test_flask_app",
-       "keep_warm": false,
+       "keep_warm": 0,
        "debug": true,
        "log_level": "DEBUG",
        "events": [{
@@ -20,7 +20,7 @@
     },
     "dev_api": {
        "project_name": "dev_api_zappa_test_flask_app",
-       "keep_warm": false,
+       "keep_warm": 0,
        "debug": true,
        "log_level": "DEBUG",
        "aws_region": "us-west-2",

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -999,7 +999,7 @@ class ZappaCLI(object):
         for event in events:
             self.collision_warning(event.get('function'))
 
-        if self.stage_config.get('keep_warm', 1):
+        if self.stage_config.get('keep_warm', 1) > 0:
             if not events:
                 events = []
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -999,7 +999,7 @@ class ZappaCLI(object):
         for event in events:
             self.collision_warning(event.get('function'))
 
-        if self.stage_config.get('keep_warm', True):
+        if self.stage_config.get('keep_warm', 1):
             if not events:
                 events = []
 
@@ -2063,9 +2063,17 @@ class ZappaCLI(object):
                 settings_s += "AUTHORIZER_FUNCTION='{0!s}'\n".format(authorizer_function)
 
             # Keep Warm Setting Needed by Handler
-            keep_warm = self.stage_config.get('keep_warm', True)
+            keep_warm = self.stage_config.get('keep_warm', 1)
             if keep_warm:
-                settings_s += "WARM_LAMBDA_COUNT='{0!s}'\n".format(keep_warm)
+                # Handle legacy configs with boolean values:
+                if keep_warm is True:
+                    kw_val = 1
+                elif keep_warm is False:
+                    kw_val = 0
+                else:
+                    kw_val = keep_warm
+
+                settings_s += "WARM_LAMBDA_COUNT={0:d}\n".format(kw_val)
 
             # Copy our Django app into root of our package.
             # It doesn't work otherwise.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2062,6 +2062,10 @@ class ZappaCLI(object):
             if authorizer_function:
                 settings_s += "AUTHORIZER_FUNCTION='{0!s}'\n".format(authorizer_function)
 
+            # Keep Warm Setting Needed by Handler
+            keep_warm = self.stage_config.get('keep_warm', True)
+            if keep_warm:
+                settings_s += "WARM_LAMBDA_COUNT='{0!s}'\n".format(keep_warm)
 
             # Copy our Django app into root of our package.
             # It doesn't work otherwise.

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -491,7 +491,6 @@ def lambda_handler(event, context):  # pragma: no cover
 def keep_warm_callback(event, context):
     """Method is triggered by the CloudWatch event scheduled when keep_warm setting is set 1 or more."""
 
-    start = time.time()
     # Get the desired warm count out of the settings file.
     settings = importlib.import_module('zappa_settings')
     warm_coount = settings.WARM_LAMBDA_COUNT

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -506,7 +506,6 @@ def keep_warm_callback(event, context):
         _ = mp.get(270)  # Wait 4m30s to get the result. Will die at 5m or `timeout_seconds` in zappa_settings.json
     except Exception as ex:
         print("keep warm pool exception", ex)
-    print("Keeping warm calls took {} seconds".format(time.time() - start))
 
 
 @task


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
The `keep_warm` setting now takes an integer for the number of concurrent containers to keep warm. This is done by the keep_warm_callback in the handler.py file using a thred pool to call zappa async tasks that each initialize the application.

Those initialized applications then wait 30 seconds before returning to allow for other other lambdas to cold start rather than reuse the newly warmed container.

Somewhat arbitrary values were set for the ThreadPool size and the sleep size. If the user has specified a `timeout_seconds` < 30, it will exit sooner. 

The time to run the keep_warm_callback with 200 as the value was 15 seconds. If the time.sleep is too low, then it is possible for some percentage of the keep_warm_lambda_initializers to use warm containers. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#851 
