### PR TITLE
not hitting pypi twice and adding transparency on cached storage

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -123,8 +123,8 @@ class TestZappa(unittest.TestCase):
 
     def test_get_manylinux_python27(self):
         z = Zappa(runtime='python2.7')
-        self.assertTrue(z.have_correct_manylinux_package_version('cffi', '1.10.0'))
-        self.assertFalse(z.have_correct_manylinux_package_version('derpderpderpderp', '0.0'))
+        self.assertIsNotNone(z.get_cached_manylinux_wheel('cffi', '1.10.0'))
+        self.assertIsNone(z.get_cached_manylinux_wheel('derpderpderpderp', '0.0'))
 
         # mock with a known manylinux wheel package so that code for downloading them gets invoked
         mock_installed_packages = { 'cffi' : '1.10.0' }
@@ -136,8 +136,8 @@ class TestZappa(unittest.TestCase):
 
     def test_get_manylinux_python36(self):
         z = Zappa(runtime='python3.6')
-        self.assertTrue(z.have_correct_manylinux_package_version('psycopg2', '2.7.1'))
-        self.assertFalse(z.have_correct_manylinux_package_version('derpderpderpderp', '0.0'))
+        self.assertIsNotNone(z.get_cached_manylinux_wheel('psycopg2', '2.7.1'))
+        self.assertIsNone(z.get_cached_manylinux_wheel('derpderpderpderp', '0.0'))
 
         # mock with a known manylinux wheel package so that code for downloading them gets invoked
         mock_installed_packages = {'psycopg2': '2.7.1'}

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -487,15 +487,13 @@ class Zappa(object):
                         print("Using lambda_packages binary for %s %s" % (installed_package_name, installed_package_version,))
                         self.extract_lambda_package(installed_package_name, temp_project_path)
 
-                    elif self.have_correct_manylinux_package_version(installed_package_name, installed_package_version):
+                    cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version) 
+                    if cached_wheel_path:
                         # Otherwise try to use manylinux packages from PyPi..
                         # Related: https://github.com/Miserlou/Zappa/issues/398
-                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name,
-                                                                            installed_package_version)
-                        if cached_wheel_path:
-                            shutil.rmtree(os.path.join(temp_project_path, installed_package_name), ignore_errors=True)
-                            with zipfile.ZipFile(cached_wheel_path) as zfile:
-                                zfile.extractall(temp_project_path)
+                        shutil.rmtree(os.path.join(temp_project_path, installed_package_name), ignore_errors=True)
+                        with zipfile.ZipFile(cached_wheel_path) as zfile:
+                            zfile.extractall(temp_project_path)
 
                     elif self.have_any_lambda_package_version(installed_package_name):
                         # Finally see if we may have at least one version of the package in lambda packages
@@ -677,7 +675,7 @@ class Zappa(object):
             with open(wheel_path, 'wb') as f:
                 self.download_url_with_progress(wheel_url, f)
         else:
-            print("{} - Locally Cached".format(package_name))
+            print("{} - Locally Cached at {}".format(package_name, wheel_path))
 
         return wheel_path
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -631,12 +631,6 @@ class Zappa(object):
         """
         return lambda_packages.get(package_name, {}).get(self.runtime) is not None
 
-    def have_correct_manylinux_package_version(self, package_name, package_version):
-        """
-        Checks if a given package version binary should be downlaoded from PyPi manylinux wheel
-        """
-        return self.get_cached_manylinux_wheel(package_name, package_version) is not None
-
     @staticmethod
     def download_url_with_progress(url, stream):
         """

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -486,22 +486,22 @@ class Zappa(object):
                     if self.have_correct_lambda_package_version(installed_package_name, installed_package_version):
                         print("Using lambda_packages binary for %s %s" % (installed_package_name, installed_package_version,))
                         self.extract_lambda_package(installed_package_name, temp_project_path)
+                    else:
+                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version)
+                        if cached_wheel_path:
+                            # Otherwise try to use manylinux packages from PyPi..
+                            # Related: https://github.com/Miserlou/Zappa/issues/398
+                            shutil.rmtree(os.path.join(temp_project_path, installed_package_name), ignore_errors=True)
+                            with zipfile.ZipFile(cached_wheel_path) as zfile:
+                                zfile.extractall(temp_project_path)
 
-                    cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version) 
-                    if cached_wheel_path:
-                        # Otherwise try to use manylinux packages from PyPi..
-                        # Related: https://github.com/Miserlou/Zappa/issues/398
-                        shutil.rmtree(os.path.join(temp_project_path, installed_package_name), ignore_errors=True)
-                        with zipfile.ZipFile(cached_wheel_path) as zfile:
-                            zfile.extractall(temp_project_path)
-
-                    elif self.have_any_lambda_package_version(installed_package_name):
-                        # Finally see if we may have at least one version of the package in lambda packages
-                        # Related: https://github.com/Miserlou/Zappa/issues/855
-                        lambda_version = lambda_packages[installed_package_name][self.runtime]['version']
-                        print("Warning! You require pre-compiled %s version %s but will use %s that is in "
-                              "lambda_packages. " % (installed_package_name, installed_package_version, lambda_version, ))
-                        self.extract_lambda_package(installed_package_name, temp_project_path)
+                        elif self.have_any_lambda_package_version(installed_package_name):
+                            # Finally see if we may have at least one version of the package in lambda packages
+                            # Related: https://github.com/Miserlou/Zappa/issues/855
+                            lambda_version = lambda_packages[installed_package_name][self.runtime]['version']
+                            print("Warning! You require pre-compiled %s version %s but will use %s that is in "
+                                  "lambda_packages. " % (installed_package_name, installed_package_version, lambda_version, ))
+                            self.extract_lambda_package(installed_package_name, temp_project_path)
 
             except Exception as e:
                 print(e)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
No longer hits pypi twice. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#574 and #862 
