### PR TITLE
Lambda from outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,26 @@ run(your_function, args, kwargs) # Using Lambda
 run(your_function, args, kwargs, service='sns') # Using SNS
 ```
 
+### Remote Invocations
+
+By default, Zappa will use lambda's current function name and current aws region. If you wish to invoke a lambda with
+  a different function name/region or invoke your lambda from outside of lambda, you must specify the 
+  `remote_aws_lambda_function_name` and `remote_aws_region` arguments so that the application knows which function and 
+  region to use. For example, if some part of our pizza making application had to live on an EC2 instance, but we 
+  wished to call the make_pie() function on its own Lambda instance, we would do it as follows:
+  
+ ```python
+@task(remote_aws_lambda_function_name='pizza-pie-prod', remote_aws_region='us-east-1')
+def make_pie():
+    """ This takes a long time! """
+    ingredients = get_ingredients()
+    pie = bake(ingredients)
+    deliver(pie)
+
+```
+If those task() parameters were not used, then EC2 would execute the function locally. These same
+ `remote_aws_lambda_function_name` and `remote_aws_region` arguments can be used on the zappa.async.run() function as well.
+
 ### Restrictions
 
 The following restrictions to this feature apply:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 from cgi import parse_qs, escape
 from zappa.async import task
 
+
 def hello_world(environ, start_response):
     parameters = parse_qs(environ.get('QUERY_STRING', ''))
     if 'subject' in parameters:
@@ -13,15 +14,23 @@ def hello_world(environ, start_response):
 
 '''.format(**{'subject': subject})]
 
+
 def schedule_me():
     return "Hello!"
 
 @task
 def async_me(arg1, **kwargs):
-    return "run async when on lambda %s%s" % (arg1, kwargs.get('foo',''))
+    return "run async when on lambda %s%s" % (arg1, kwargs.get('foo', ''))
+
+
+@task(remote_aws_lambda_function_name='test-app-dev', remote_aws_region='us-east-1')
+def remote_async_me(arg1, **kwargs):
+    return "run async always on lambda %s%s" % (arg1, kwargs.get('foo', ''))
+
 
 def callback(self):
     print("this is a callback")
+
 
 def prebuild_me():
     print("this is a prebuild script")

--- a/tests/tests_async.py
+++ b/tests/tests_async.py
@@ -20,13 +20,10 @@ import tempfile
 from click.exceptions import ClickException
 from lambda_packages import lambda_packages
 
-from .test_app import remote_async_me, async_me
-from placebo.utils import placebo_session
 try:
     from mock import patch
 except ImportError:
     from unittest.mock import patch
-
 
 from zappa.async import AsyncException, LambdaAsyncResponse, SnsAsyncResponse
 from zappa.async import import_and_get_task, \
@@ -87,16 +84,3 @@ class TestZappa(unittest.TestCase):
     def test_sync_call(self):
         funk = import_and_get_task("tests.test_app.async_me")
         self.assertEqual(funk.sync('123'), "run async when on lambda 123")
-
-    @placebo_session
-    def test_remote_lambda_call(self, session):
-        """Ensure that we hit lambda to invoke the function even though we're not there"""
-
-        with patch('boto3.Session') as mock_session:
-            mock_session.return_value = session
-
-            res = remote_async_me('456')
-            self.assertTrue(isinstance(res, LambdaAsyncResponse))
-
-            local_res = async_me('123')
-            self.assertEquals(local_res, "run async when on lambda 123")

--- a/tests/tests_async.py
+++ b/tests/tests_async.py
@@ -20,6 +20,13 @@ import tempfile
 from click.exceptions import ClickException
 from lambda_packages import lambda_packages
 
+from .test_app import remote_async_me, async_me
+from placebo.utils import placebo_session
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
+
 
 from zappa.async import AsyncException, LambdaAsyncResponse, SnsAsyncResponse
 from zappa.async import import_and_get_task, \
@@ -80,3 +87,16 @@ class TestZappa(unittest.TestCase):
     def test_sync_call(self):
         funk = import_and_get_task("tests.test_app.async_me")
         self.assertEqual(funk.sync('123'), "run async when on lambda 123")
+
+    @placebo_session
+    def test_remote_lambda_call(self, session):
+        """Ensure that we hit lambda to invoke the function even though we're not there"""
+
+        with patch('boto3.Session') as mock_session:
+            mock_session.return_value = session
+
+            res = remote_async_me('456')
+            self.assertTrue(isinstance(res, LambdaAsyncResponse))
+
+            local_res = async_me('123')
+            self.assertEquals(local_res, "run async when on lambda 123")

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -25,6 +25,7 @@ Discussion of this comes from:
     https://github.com/Miserlou/Zappa/issues/603
     https://github.com/Miserlou/Zappa/pull/694
     https://github.com/Miserlou/Zappa/pull/732
+    https://github.com/Miserlou/Zappa/issues/840
 
 ## Full lifetime of an asynchronous dispatch:
 
@@ -86,7 +87,7 @@ Discussion of this comes from:
 
 import boto3
 import botocore
-from functools import update_wrapper
+from functools import update_wrapper, wraps
 import importlib
 import inspect
 import json
@@ -95,14 +96,12 @@ import traceback
 
 from .utilities import get_topic_name
 
-AWS_REGION = os.environ.get('AWS_REGION') # Set via CLI env var packaging
-AWS_LAMBDA_FUNCTION_NAME = os.environ.get('AWS_LAMBDA_FUNCTION_NAME') # Set by AWS
-
 # Declare these here so they're kept warm.
 try:
-    LAMBDA_CLIENT = boto3.client('lambda')
-    SNS_CLIENT = boto3.client('sns')
-    STS_CLIENT = boto3.client('sts')
+    aws_session = boto3.Session()
+    LAMBDA_CLIENT = aws_session.client('lambda')
+    SNS_CLIENT = aws_session.client('sns')
+    STS_CLIENT = aws_session.client('sts')
 except botocore.exceptions.NoRegionError as e: # pragma: no cover
     # This can happen while testing on Travis, but it's taken care  of
     # during class initialization.
@@ -117,19 +116,23 @@ class AsyncException(Exception): # pragma: no cover
     """ Simple exception class for async tasks. """
     pass
 
+
 class LambdaAsyncResponse(object):
     """
     Base Response Dispatcher class
     Can be used directly or subclassed if the method to send the message is changed.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, lambda_function_name=None, aws_region=None, **kwargs):
         """ """
         if kwargs.get('boto_session'):
             self.client = kwargs.get('boto_session').client('lambda')
-        else: # pragma: no cover
+        else:  # pragma: no cover
             self.client = LAMBDA_CLIENT
 
-    def send(self, task_path, lambda_function, args, kwargs):
+        self.lambda_function_name = lambda_function_name
+        self.aws_region = aws_region
+
+    def send(self, task_path, args, kwargs):
         """
         Create the message object and pass it to the actual sender.
         """
@@ -138,10 +141,10 @@ class LambdaAsyncResponse(object):
                 'args': args,
                 'kwargs': kwargs
             }
-        self._send(message, lambda_function)
+        self._send(message)
         return self
 
-    def _send(self, message, lambda_function):
+    def _send(self, message):
         """
         Given a message, directly invoke the lamdba function for this task.
         """
@@ -150,7 +153,7 @@ class LambdaAsyncResponse(object):
         if len(payload) > 128000: # pragma: no cover
             raise AsyncException("Payload too large for async Lambda call")
         self.response = self.client.invoke(
-                                    FunctionName=lambda_function,
+                                    FunctionName=self.lambda_function_name,
                                     InvocationType='Event', #makes the call async
                                     Payload=payload
                                 )
@@ -177,9 +180,9 @@ class SnsAsyncResponse(LambdaAsyncResponse):
                 sts_client = STS_CLIENT
             AWS_ACCOUNT_ID = sts_client.get_caller_identity()['Account']
             self.arn = 'arn:aws:sns:{region}:{account}:{topic_name}'.format(
-                                    region=AWS_REGION,
+                                    region=self.aws_region,
                                     account=AWS_ACCOUNT_ID,
-                                    topic_name=get_topic_name(AWS_LAMBDA_FUNCTION_NAME)
+                                    topic_name=get_topic_name(self.lambda_function_name)
                                 )
 
     def _send(self, message):
@@ -205,6 +208,7 @@ ASYNC_CLASSES = {
     'sns': SnsAsyncResponse,
 }
 
+
 def route_lambda_task(event, context):
     """
     Deserialises the message from event passed to zappa.handler.run_function
@@ -212,6 +216,7 @@ def route_lambda_task(event, context):
     """
     message = event
     return run_message(message)
+
 
 def route_sns_task(event, context):
     """
@@ -223,6 +228,7 @@ def route_sns_task(event, context):
             record['Sns']['Message']
         )
     return run_message(message)
+
 
 def run_message(message):
     """
@@ -246,8 +252,9 @@ def run_message(message):
 # Execution interfaces and classes
 ##
 
+
 def run(func, args=[], kwargs={}, service='lambda',
-        aws_lambda_function_name_override=None, aws_region_override=None, **task_kwargs):
+        remote_aws_lambda_function_name=None, remote_aws_region=None, **task_kwargs):
     """
     Instead of decorating a function with @task, you can just run it directly.
     If you were going to do func(*args, **kwargs), then you will call this:
@@ -261,18 +268,21 @@ def run(func, args=[], kwargs={}, service='lambda',
 
     and other arguments are similar to @task
     """
+    lambda_function_name = remote_aws_lambda_function_name or os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+    aws_region = remote_aws_region or os.environ.get('AWS_REGION')
+
     task_path = get_func_task_path(func)
-
-    lambda_function = aws_lambda_function_name_override or AWS_LAMBDA_FUNCTION_NAME
-    aws_region = aws_region_override or AWS_REGION
-
-    return ASYNC_CLASSES[service](**task_kwargs).send(task_path, args, kwargs)
+    return ASYNC_CLASSES[service](lambda_function_name=lambda_function_name,
+                                  aws_region=aws_region,
+                                  **task_kwargs).send(task_path, args, kwargs)
 
 
 # Handy:
 # http://stackoverflow.com/questions/10294014/python-decorator-best-practice-using-a-class-vs-a-function
 # However, this needs to pass inspect.getargspec() in handler.py which does not take classes
-def task(func, service='lambda', aws_lambda_function_name_override=None, aws_region_override=None):
+# Wrapper written to take optional arguments
+# http://chase-seibert.github.io/blog/2013/12/17/python-decorator-optional-parameter.html
+def task(*args, **kwargs):
     """Async task decorator so that running
 
     Args:
@@ -281,47 +291,67 @@ def task(func, service='lambda', aws_lambda_function_name_override=None, aws_reg
             func must be an independent top-level function.
                  i.e. not a class method or an anonymous function
         service (str): either 'lambda' or 'sns'
+        remote_aws_lambda_function_name (str): the name of a remote lambda function to call with this task
+        remote_aws_region (str): the name of a remote region to make lambda/sns calls against
 
     Returns:
         A replacement function that dispatches func() to
         run asynchronously through the service in question
     """
-    task_path = get_func_task_path(func)
 
-    lambda_function = aws_lambda_function_name_override or AWS_LAMBDA_FUNCTION_NAME
-    aws_region = aws_region_override or AWS_REGION
+    func = None
+    if len(args) == 1 and callable(args[0]):
+        func = args[0]
 
-    def _run_async(*args, **kwargs):
-        """
-        This is the wrapping async function that replaces the function
-        that is decorated with @task.
-        Args:
-            These are just passed through to @task's func
+    if func:  # Default Values
+        service = 'lambda'
+        lambda_function_name = os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+        aws_region = os.environ.get('AWS_REGION')
 
-        Assuming a valid service is passed to task() and it is run
-        inside a Lambda process (i.e. AWS_LAMBDA_FUNCTION_NAME exists),
-        it dispatches the function to be run through the service variable.
-        Otherwise, it runs the task synchronously.
+    else:  # Arguments were passed
+        service = kwargs.get('service', 'lambda')
+        lambda_function_name = kwargs.get('remote_aws_lambda_function_name') or os.environ.get('AWS_LAMBDA_FUNCTION_NAME')
+        aws_region = kwargs.get('remote_aws_region') or os.environ.get('AWS_REGION')
 
-        Returns:
-            In async mode, the object returned includes state of the dispatch.
-            For instance
+    def func_wrapper(func):
 
-            When outside of Lambda, the func passed to @task is run and we
-            return the actual value.
-        """
-        if (service in ASYNC_CLASSES) and lambda_function:
-            send_result = ASYNC_CLASSES[service](lambda_function, aws_region).send(task_path, args, kwargs)
-            return send_result
-        else:
-            return func(*args, **kwargs)
+        task_path = get_func_task_path(func)
 
-    update_wrapper(_run_async, func)
+        @wraps(func)
+        def _run_async(*args, **kwargs):
+            """
+            This is the wrapping async function that replaces the function
+            that is decorated with @task.
+            Args:
+                These are just passed through to @task's func
 
-    _run_async.service = service
-    _run_async.sync = func
+            Assuming a valid service is passed to task() and it is run
+            inside a Lambda process (i.e. AWS_LAMBDA_FUNCTION_NAME exists),
+            it dispatches the function to be run through the service variable.
+            Otherwise, it runs the task synchronously.
 
-    return _run_async
+            Returns:
+                In async mode, the object returned includes state of the dispatch.
+                For instance
+
+                When outside of Lambda, the func passed to @task is run and we
+                return the actual value.
+            """
+            if (service in ASYNC_CLASSES) and (lambda_function_name):
+                send_result = ASYNC_CLASSES[service](lambda_function_name=lambda_function_name,
+                                                     aws_region=aws_region).send(task_path, args, kwargs)
+                return send_result
+            else:
+                return func(*args, **kwargs)
+
+        update_wrapper(_run_async, func)
+
+        _run_async.service = service
+        _run_async.sync = func
+
+        return _run_async
+
+    return func_wrapper(func) if func else func_wrapper
 
 
 def task_sns(func):
@@ -329,6 +359,7 @@ def task_sns(func):
     SNS-based task dispatcher. Functions the same way as task()
     """
     return task(func, service='sns')
+
 
 ##
 # Utility Functions


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
The task decorator and run function now take optional arguments of `remote_aws_lambda_function_name` and `remote_aws_region`. This allows users to execute functions on discrete lambda instances either in a different region from within lambda, on a different function from within lambda, or from outside of lambda entirely. 

Looking for suggestions for better parameter naming, the "remote" might not be the most accurate all the time. If others can test this would also be good, works for me currently and the added test passes. Further, this might not be the best architecture entirely for supporting this functionality. My main goal was minimal code changes to get this working. 

Lastly, because async uses a warmed boto3 session at the top, I'm not sure the right approach to injecting a placebo session so we can have a unit test for this.

All feedback welcome

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#840 
