### PR TITLE
Pull zappa's version into its own python module.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import sys
 from setuptools import setup
 from io import open
+from zappa import __version__
 
 # Set external files
 try:
@@ -18,7 +19,7 @@ with open(os.path.join(os.path.dirname(__file__), 'test_requirements.txt')) as f
 
 setup(
     name='zappa',
-    version='0.42.0',
+    version=__version__,
     packages=['zappa'],
     install_requires=required,
     tests_require=test_required,

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -11,3 +11,5 @@ if (python_major_version, python_minor_version) not in SUPPORTED_VERSIONS:
     err_msg = 'This version of Python ({}.{}) is not supported!\n'.format(python_major_version, python_minor_version) +\
               'Zappa (and AWS Lambda) support the following versions of Python: {}'.format(formatted_supported_versions)
     raise RuntimeError(err_msg)
+
+__version__ = '0.42.0'


### PR DESCRIPTION
Yet another simple PR, but quite effective. 

Currently there is no clean, simple way to know what version of Zappa is contained in a AWS Lamda tarball which can be exported using AWS Console. 

Having the version as part of the python code is one of the recommended options by [Python Packaging User Guide](https://packaging.python.org/single_source_version/) and will enable to determine what Zappa version was running on that specific tarball. Once this PR is merged use one of the followings:
  - the simplest way is to just read the zappa/__init__.pyc file from the tarball. Although bytecode, the version will be easy to read.
```shell
$ cat zappa/__init__.pyc

C�Yc@sdZedkreGHndS(s0.42.0__main__N(t
```
  - or, from the directory containing the unpacked zappa package
```shell
$ python
>> import zappa
>> zappa.__version__
0.42.0
```