### PR TITLE
fix compatibility for py2/py3 in certify command

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1574,7 +1574,7 @@ class ZappaCLI(object):
 
         # Let's Encrypt
         if not cert_location and not cert_arn:
-            from zappa.letsencrypt import get_cert_and_update_domain, cleanup
+            from .letsencrypt import get_cert_and_update_domain, cleanup
             cert_success = get_cert_and_update_domain(
                     self.zappa,
                     self.lambda_name,

--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -284,7 +284,7 @@ def get_cert(zappa_instance, log=LOGGER, CA=DEFAULT_CA):
         # notify challenge are met
         code, result = _send_signed_request(challenge['uri'], {
             "resource": "challenge",
-            "keyAuthorization": keyauthorization,
+            "keyAuthorization": str(keyauthorization),
         })
         if code != 202:
             raise ValueError("Error triggering challenge: {0} {1}".format(code, result))


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Fixes issue https://github.com/Miserlou/Zappa/issues/818

- Updates import of zappa.letsencrypt to use explicit relative imports as previously it fails in python2
- Coerce keyauthorization to str as python3 was sending a bytes object to json raising "is not JSON serializable"

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/818
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

