### PR TITLE
add support for multiple expressions when scheduling functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ And now your scheduled event rules are deleted.
 
 See the [example](example/) for more details.
 
+##### Advanced Scheduling
+
+Sometimes a function needs multiple expressions to describe its schedule. To set multiple expressions, simply list your functions, and the list of expressions to schedule them using [cron or rate syntax](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) in your *zappa_settings.json* file:
+
+```javascript
+{
+    "production": {
+       ...
+       "events": [{
+           "function": "your_module.your_function", // The function to execute
+           "expressions": ["cron(0 20-23 ? * SUN-THU *)", "cron(0 0-8 ? * MON-FRI *)"] // When to execute it (in cron or rate format)
+       }],
+       ...
+    }
+}
+```
+
+This can be used to deal with issues arising from the UTC timezone crossing midnight during business hours in your local timezone.
+
+It should be noted that overlapping expressions will not throw a warning, and should be checked for, to prevent duplicate triggering of functions.
+
 #### Undeploy
 
 If you need to remove the API Gateway and Lambda function that you have previously published, you can simply:


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?
- [x] 
* If this is a non-trivial commit, did you **open a ticket** for discussion?
- [x] 
* Did you **put the URL for that ticket in a comment** in the code?
- [ ] 
* Did you write a test for your new code?
- [ ] - no tests exist for scheduling events 
* Did you **make sure this code actually works on Lambda**, as well as locally?
- [x] 
* Did you test this code with both **Python 2.7** and **Python 3.6**? 
- [x] 
If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Adds a check for an `"expressions"` key when parsing `"events"` function list. If `"expression"` is found, it is inserted into a one element list. The scheduled event generator then iterates through each expression, resulting in `n` iterations for `n` expressions.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/876

Pre-emptive pull request given the relative triviality of the code changes.

