### PR TITLE
fixes #882 remove downtime during certificate updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,6 @@ If your domain is located within an AWS Route 53 Hosted Zone and you've defined 
 
 And your domain will be verified, certified and registered!
 
-Please note that this can take around 45 minutes to take effect. You can avoid this by using the `certify --manual` and then copying the values presented into the AWS Console.
-
 More detailed instructions are available [in this handy guide](https://github.com/Miserlou/Zappa/blob/master/docs/domain_with_free_ssl_dns.md) and lower down in this README file.
 
 ## Executing in Response to AWS Events

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1502,9 +1502,6 @@ class ZappaCLI(object):
             raise ClickException("Can't certify a domain without " + click.style("domain", fg="red", bold=True) + " configured!")
 
         if not no_confirm: # pragma: no cover
-            if not manual and self.zappa.get_domain_name(self.domain):
-                click.echo(click.style("Warning!", fg="red", bold=True) + " If you have already certified this domain and are calling certify again, you may incur downtime.")
-                click.echo("You can avoid this downtime by calling certify with " + click.style("--manual", bold=True) + " and rotating your certificate yourself through the AWS console.")
             confirm = input("Are you sure you want to certify? [y/n] ")
             if confirm != 'y':
                 return

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1741,6 +1741,15 @@ class Zappa(object):
 
         It returns the resulting new domain information including the new certificate's ARN
         if created during this process.
+
+        Previously, this method involved downtime that could take up to 40 minutes
+        because the API Gateway api only allowed this by deleting, and then creating it.
+
+        Related issues:     https://github.com/Miserlou/Zappa/issues/590
+                            https://github.com/Miserlou/Zappa/issues/588
+                            https://github.com/Miserlou/Zappa/pull/458
+                            https://github.com/Miserlou/Zappa/issues/882
+                            https://github.com/Miserlou/Zappa/pull/883
         """
 
         print("Updating domain name!")


### PR DESCRIPTION
## Description
uses update_domain_name in amazon boto instead of delete/create

## GitHub Issues
#882 

