### PR TITLE
Fix content-type headers not passing through on DELETE

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -106,7 +106,7 @@ def create_wsgi_request(event_info,
         }
 
         # Input processing
-        if method in ["POST", "PUT", "PATCH"]:
+        if method in ["POST", "PUT", "PATCH", "DELETE"]:
             if 'Content-Type' in headers:
                 environ['CONTENT_TYPE'] = headers['Content-Type']
 


### PR DESCRIPTION
Zappa is incorrectly stripping the `content-type` header for `DELETE` requests
