### PR TITLE
first pass at iam policy example for deploy user

### DIFF
--- a/example/policy/deploy.json
+++ b/example/policy/deploy.json
@@ -25,7 +25,7 @@
             ]
         },
         {
-            "Sid": "CoreLambda",
+            "Sid": "Core",
             "Effect": "Allow",
             "Action": [
                 "lambda:AddPermission",
@@ -46,7 +46,8 @@
                 "cloudformation:UpdateStack",
                 "logs:DescribeLogStreams",
                 "logs:DeleteLogGroup",
-                "logs:FilterLogEvents"
+                "logs:FilterLogEvents",
+                "s3:CreateBucket"
             ],
             "Resource": [
                 "*"

--- a/example/policy/deploy.json
+++ b/example/policy/deploy.json
@@ -1,0 +1,151 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "RoleManager",
+            "Effect": "Allow",
+            "Action": [
+                "iam:AttachRolePolicy",
+                "iam:CreateRole",
+                "iam:GetRole",
+                "iam:PutRolePolicy"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "RoleDelegation",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::<account_id>:role/*-ZappaLambdaExecutionRole"
+            ]
+        },
+        {
+            "Sid": "CoreLambda",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:AddPermission",
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:GetFunction",
+                "lambda:GetPolicy",
+                "lambda:InvokeFunction",
+                "lambda:ListVersionsByFunction",
+                "lambda:RemovePermission",
+                "lambda:UpdateFunctionCode",
+                "lambda:UpdateFunctionConfiguration",
+                "cloudformation:CreateStack",
+                "cloudformation:DeleteStack",
+                "cloudformation:DescribeStackResource",
+                "cloudformation:DescribeStacks",
+                "cloudformation:ListStackResources",
+                "cloudformation:UpdateStack",
+                "logs:DescribeLogStreams",
+                "logs:DeleteLogGroup",
+                "logs:FilterLogEvents"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "CoreS3List",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<s3_bucket from zappa_settings.json>"
+            ]
+        },
+        {
+            "Sid": "CoreS3Object",
+            "Effect": "Allow",
+            "Action": [
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+                "s3:ListBucketMultipartUploads"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<s3_bucket from zappa_settings.json>/*"
+            ]
+        },
+        {
+            "Sid": "APIGateway",
+            "Effect": "Allow",
+            "Action": [
+                "apigateway:OPTIONS",
+                "apigateway:DELETE",
+                "apigateway:GET",
+                "apigateway:PATCH",
+                "apigateway:POST",
+                "apigateway:PUT"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "Domain",
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets",
+                "route53:ChangeResourceRecordSets",
+                "route53:GetHostedZone"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "Events",
+            "Effect": "Allow",
+            "Action": [
+                "events:DeleteRule",
+                "events:DescribeRule",
+                "events:ListRules",
+                "events:ListTargetsByRule",
+                "events:ListRuleNamesByTarget",
+                "events:PutRule",
+                "events:PutTargets",
+                "events:RemoveTargets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "SNS",
+            "Effect": "Allow",
+            "Action": [
+                "SNS:ListSubscriptionsByTopic",
+                "SNS:Unsubscribe",
+                "SNS:Subscribe"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "VPCSecurity",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcsRequest"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is basically a collection from #244

- Started from https://github.com/Miserlou/Zappa/issues/244#issuecomment-303697308 @audiolion @MihaZelnik
- Removed "s3:CreateMultipartUpload" because it is not needed
- Added "route53:ListResourceRecordSets" and "apigateway:OPTIONS" for zappa certify @aehlke 
- Added some SNS rules for events @bxm156
- Added some EC2 rules for security groups @eely22
- Added "lambda:InvokeFunction" for command @bartvds

I split it up into statements so people can remove chunks easily. The policy lingo is a bit limited and the only way to comment a Statement is a Sid value (with only CamelCase value).

Anyway, I'm by no means an expert on zappa or IAM and this is cargo culted so please review. 

Maybe this should be provided with some example (patterns) to make it more specific? Put in markdown instead of JSON?