### PR TITLE
Add --disable_progress command line parameter

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -84,6 +84,7 @@ class ZappaCLI(object):
     zappa = None
     zappa_settings = None
     load_credentials = True
+    disable_progress = False
 
     # Specific settings
     api_stage = None
@@ -420,7 +421,7 @@ class ZappaCLI(object):
 
         self.command = args.command
 
-
+        self.disable_progress = self.vargs.get('disable_progress')
         if self.vargs.get('quiet'):
             self.silence()
 
@@ -656,14 +657,14 @@ class ZappaCLI(object):
 
         # Upload it to S3
         success = self.zappa.upload_to_s3(
-                self.zip_path, self.s3_bucket_name, disable_progress=self.vargs.get('disable_progress'))
+                self.zip_path, self.s3_bucket_name, disable_progress=self.disable_progress)
         if not success: # pragma: no cover
             raise ClickException("Unable to upload to S3. Quitting.")
 
         # If using a slim handler, upload it to S3 and tell lambda to use this slim handler zip
         if self.stage_config.get('slim_handler', False):
             # https://github.com/Miserlou/Zappa/issues/510
-            success = self.zappa.upload_to_s3(self.handler_path, self.s3_bucket_name, disable_progress=self.vargs.get('disable_progress'))
+            success = self.zappa.upload_to_s3(self.handler_path, self.s3_bucket_name, disable_progress=self.disable_progress)
             if not success:  # pragma: no cover
                 raise ClickException("Unable to upload handler to S3. Quitting.")
 
@@ -723,7 +724,7 @@ class ZappaCLI(object):
                                     self.lambda_name,
                                     self.s3_bucket_name,
                                     wait=True,
-                                    disable_progress=self.vargs.get('disable_progress')
+                                    disable_progress=self.disable_progress
                                 )
 
             api_id = self.zappa.get_api_id(self.lambda_name)
@@ -804,14 +805,14 @@ class ZappaCLI(object):
         self.callback('zip')
 
         # Upload it to S3
-        success = self.zappa.upload_to_s3(self.zip_path, self.s3_bucket_name, disable_progress=self.vargs.get('disable_progress'))
+        success = self.zappa.upload_to_s3(self.zip_path, self.s3_bucket_name, disable_progress=self.disable_progress)
         if not success:  # pragma: no cover
             raise ClickException("Unable to upload project to S3. Quitting.")
 
         # If using a slim handler, upload it to S3 and tell lambda to use this slim handler zip
         if self.stage_config.get('slim_handler', False):
             # https://github.com/Miserlou/Zappa/issues/510
-            success = self.zappa.upload_to_s3(self.handler_path, self.s3_bucket_name, disable_progress=self.vargs.get('disable_progress'))
+            success = self.zappa.upload_to_s3(self.handler_path, self.s3_bucket_name, disable_progress=self.disable_progress)
             if not success:  # pragma: no cover
                 raise ClickException("Unable to upload handler to S3. Quitting.")
 
@@ -871,7 +872,7 @@ class ZappaCLI(object):
                                     self.s3_bucket_name,
                                     wait=True,
                                     update_only=True,
-                                    disable_progress=self.vargs.get('disable_progress'))
+                                    disable_progress=self.disable_progress)
 
             api_id = self.zappa.get_api_id(self.lambda_name)
 
@@ -1909,7 +1910,7 @@ class ZappaCLI(object):
                 prefix=self.lambda_name,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
                 exclude=self.stage_config.get('exclude', []),
-                disable_progress=self.vargs.get('disable_progress')
+                disable_progress=self.disable_progress
             )
 
             # Make sure the normal venv is not included in the handler's zip
@@ -1923,7 +1924,7 @@ class ZappaCLI(object):
                 slim_handler=True,
                 exclude=exclude,
                 output=output,
-                disable_progress=self.vargs.get('disable_progress')
+                disable_progress=self.disable_progress
             )
         else:
 
@@ -1960,7 +1961,7 @@ class ZappaCLI(object):
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
                 exclude=exclude,
                 output=output,
-                disable_progress=self.vargs.get('disable_progress')
+                disable_progress=self.disable_progress
             )
 
             # Warn if this is too large for Lambda.

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -375,7 +375,8 @@ class Zappa(object):
                             use_precompiled_packages=True,
                             include=None,
                             venv=None,
-                            output=None
+                            output=None,
+                            disable_progress=False
                         ):
         """
         Create a Lambda-ready zip file of the current virtualenvironment and working directory.
@@ -490,7 +491,7 @@ class Zappa(object):
                         print(" - %s==%s: Using precompiled lambda package " % (installed_package_name, installed_package_version,))
                         self.extract_lambda_package(installed_package_name, temp_project_path)
                     else:
-                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version)
+                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version, disable_progress)
                         if cached_wheel_path:
                             # Otherwise try to use manylinux packages from PyPi..
                             # Related: https://github.com/Miserlou/Zappa/issues/398
@@ -636,7 +637,7 @@ class Zappa(object):
         return lambda_packages.get(package_name, {}).get(self.runtime) is not None
 
     @staticmethod
-    def download_url_with_progress(url, stream):
+    def download_url_with_progress(url, stream, disable_progress):
         """
         Downloads a given url in chunks and writes to the provided stream (can be any io stream).
         Displays the progress bar for the download.
@@ -644,7 +645,7 @@ class Zappa(object):
         resp = requests.get(url, timeout=2, stream=True)
         resp.raw.decode_content = True
 
-        progress = tqdm(unit="B", unit_scale=True, total=int(resp.headers.get('Content-Length', 0)))
+        progress = tqdm(unit="B", unit_scale=True, total=int(resp.headers.get('Content-Length', 0)), disable=disable_progress)
         for chunk in resp.iter_content(chunk_size=1024):
             if chunk:
                 progress.update(len(chunk))
@@ -652,7 +653,7 @@ class Zappa(object):
 
         progress.close()
 
-    def get_cached_manylinux_wheel(self, package_name, package_version):
+    def get_cached_manylinux_wheel(self, package_name, package_version, disable_progress=False):
         """
         Gets the locally stored version of a manylinux wheel. If one does not exist, the function downloads it.
         """
@@ -671,7 +672,7 @@ class Zappa(object):
 
             print(" - {}=={}: Downloading".format(package_name, package_version))
             with open(wheel_path, 'wb') as f:
-                self.download_url_with_progress(wheel_url, f)
+                self.download_url_with_progress(wheel_url, f, disable_progress)
         else:
             print(" - {}=={}: Using locally cached manylinux wheel".format(package_name, package_version))
 
@@ -700,7 +701,7 @@ class Zappa(object):
     # S3
     ##
 
-    def upload_to_s3(self, source_path, bucket_name):
+    def upload_to_s3(self, source_path, bucket_name, disable_progress=False):
         r"""
         Given a file, upload it to S3.
         Credentials should be stored in environment variables or ~/.aws/credentials (%USERPROFILE%\.aws\credentials on Windows).
@@ -732,7 +733,7 @@ class Zappa(object):
         try:
             source_size = os.stat(source_path).st_size
             print("Uploading {0} ({1})..".format(dest_path, human_size(source_size)))
-            progress = tqdm(total=float(os.path.getsize(source_path)), unit_scale=True, unit='B')
+            progress = tqdm(total=float(os.path.getsize(source_path)), unit_scale=True, unit='B', disable=disable_progress)
 
             # Attempt to upload to S3 using the S3 meta client with the progress bar.
             # If we're unable to do that, try one more time using a session client,
@@ -1492,7 +1493,7 @@ class Zappa(object):
                                         )
         return self.cf_template
 
-    def update_stack(self, name, working_bucket, wait=False, update_only=False):
+    def update_stack(self, name, working_bucket, wait=False, update_only=False, disable_progress=False):
         """
         Update or create the CF stack managed by Zappa.
         """
@@ -1502,7 +1503,7 @@ class Zappa(object):
         with open(template, 'wb') as out:
             out.write(bytes(self.cf_template.to_json(indent=None, separators=(',',':')), "utf-8"))
 
-        self.upload_to_s3(template, working_bucket)
+        self.upload_to_s3(template, working_bucket, disable_progress=disable_progress)
 
         url = 'https://s3.amazonaws.com/{0}/{1}'.format(working_bucket, template)
         tags = [{'Key':'ZappaProject','Value':name}]
@@ -1540,7 +1541,7 @@ class Zappa(object):
             total_resources = len(self.cf_template.resources)
             current_resources = 0
             sr = self.cf_client.get_paginator('list_stack_resources')
-            progress = tqdm(total=total_resources, unit='res')
+            progress = tqdm(total=total_resources, unit='res', disable=disable_progress)
             while True:
                 time.sleep(3)
                 result = self.cf_client.describe_stacks(StackName=name)


### PR DESCRIPTION
Was needed to prevent zappa commands from writing to stderr.

https://github.com/Miserlou/Zappa/issues/891

