### PR TITLE
Fix import of django_zappa

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -135,7 +135,7 @@ class LambdaHandler(object):
             else:
 
                 try:  # Support both for tests
-                    from zappa.ext.django import get_django_wsgi
+                    from zappa.ext.django_zappa import get_django_wsgi
                 except ImportError:  # pragma: no cover
                     from django_zappa_app import get_django_wsgi
 


### PR DESCRIPTION
## Description
Correct the import path of `django_zappa` in `handler.py`.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/897
