### PR TITLE
Check Python version upon import

### DIFF
--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -1,0 +1,13 @@
+
+import sys
+
+SUPPORTED_VERSIONS = [(2, 7), (3, 6)]
+
+python_major_version = sys.version_info[0]
+python_minor_version = sys.version_info[1]
+
+if (python_major_version, python_minor_version) not in SUPPORTED_VERSIONS:
+    formatted_supported_versions = ['{}.{}'.format(mav, miv) for mav, miv in SUPPORTED_VERSIONS]
+    err_msg = 'This version of Python ({}.{}) is not supported!\n'.format(python_major_version, python_minor_version) +\
+              'Zappa (and AWS Lambda) support the following versions of Python: {}'.format(formatted_supported_versions)
+    raise RuntimeError(err_msg)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description

Check the current Python interpreter version to be either 2.7 or 3.6 (as required in the Zappa documentation).

If the version is different, e.g. 3.5 (which is the default python3 in 17.04), print a helpful error message.


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
Problem notified in #911 

