### PR TITLE
Addressing #909: Don't load credentials for 'package' command

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1508,6 +1508,25 @@ USE_TZ = True
             # cleanup
             os.remove(zappa_cli.zip_path)
 
+    def test_package_does_not_load_credentials(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+
+        with mock.patch('zappa.core.Zappa.load_credentials') as LoadCredentialsMock:
+            # load_credentials is set in ZappaCLI.handler; simulates 'zappa package'
+            zappa_cli.load_credentials = False
+            zappa_cli.load_settings('test_settings.json')
+            zappa_cli.package()
+            zappa_cli.on_exit()  # simulate the command exits
+
+            # credentials should not be loaded for package command
+            self.assertFalse(zappa_cli.load_credentials)
+            self.assertFalse(LoadCredentialsMock.called)
+
+        # cleanup
+        os.remove(zappa_cli.zip_path)
+
+
     def test_flask_logging_bug(self):
         """
         This checks whether Flask can write errors sanely.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -414,6 +414,9 @@ class ZappaCLI(object):
         else:
             self.stage_env = self.vargs.get('stage_env')
 
+        if args.command == 'package':
+            self.load_credentials = False
+
         self.command = args.command
 
 
@@ -2102,14 +2105,16 @@ class ZappaCLI(object):
                 # Need to keep the project zip as the slim handler uses it.
                 self.zappa.remove_from_s3(self.handler_path, self.s3_bucket_name)
 
-
     def on_exit(self):
         """
         Cleanup after the command finishes.
         Always called: SystemExit, KeyboardInterrupt and any other Exception that occurs.
         """
         if self.zip_path:
-            self.remove_uploaded_zip()
+            # Only try to remove uploaded zip if we're running a command that has loaded credentials
+            if self.load_credentials:
+                self.remove_uploaded_zip()
+
             self.remove_local_zip()
 
     def print_logs(self, logs, colorize=True, http=False, non_http=False):

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -250,20 +250,22 @@ class Zappa(object):
         if load_credentials:
             self.load_credentials(boto_session, profile_name)
 
-        self.s3_client = self.boto_session.client('s3')
-        self.lambda_client = self.boto_session.client('lambda', config=long_config)
-        self.events_client = self.boto_session.client('events')
-        self.apigateway_client = self.boto_session.client('apigateway')
-        # acm certificates need to be created from us-east-1 to be used by API gateway
-        east_config = botocore.client.Config(region_name='us-east-1')
-        self.acm_client = self.boto_session.client('acm', config=east_config)
-        self.logs_client = self.boto_session.client('logs')
-        self.iam_client = self.boto_session.client('iam')
-        self.iam = self.boto_session.resource('iam')
-        self.cloudwatch = self.boto_session.client('cloudwatch')
-        self.route53 = self.boto_session.client('route53')
-        self.sns_client = self.boto_session.client('sns')
-        self.cf_client = self.boto_session.client('cloudformation')
+            # Initialize clients
+            self.s3_client = self.boto_session.client('s3')
+            self.lambda_client = self.boto_session.client('lambda', config=long_config)
+            self.events_client = self.boto_session.client('events')
+            self.apigateway_client = self.boto_session.client('apigateway')
+            # acm certificates need to be created from us-east-1 to be used by API gateway
+            east_config = botocore.client.Config(region_name='us-east-1')
+            self.acm_client = self.boto_session.client('acm', config=east_config)
+            self.logs_client = self.boto_session.client('logs')
+            self.iam_client = self.boto_session.client('iam')
+            self.iam = self.boto_session.resource('iam')
+            self.cloudwatch = self.boto_session.client('cloudwatch')
+            self.route53 = self.boto_session.client('route53')
+            self.sns_client = self.boto_session.client('sns')
+            self.cf_client = self.boto_session.client('cloudformation')
+   
         self.cf_template = troposphere.Template()
         self.cf_api_resources = []
         self.cf_parameters = {}


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

- Changes the `zappa package` command so it doesn't load AWS credentials.
- Adds test that `zappa package` doesn't load credentials.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

#909 
