### PR TITLE
Fix #937 - Use get_data

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -445,7 +445,7 @@ class LambdaHandler(object):
                         else:
                             zappa_returndict['body'] = response.data
                     else:
-                        zappa_returndict['body'] = response.data
+                        zappa_returndict['body'] = response.get_data(as_text=True)
 
                 zappa_returndict['statusCode'] = response.status_code
                 zappa_returndict['headers'] = {}


### PR DESCRIPTION
## Description
When not in binary_support mode, use get_data on the response instead of .data to get the response data as a text instead of binary. In python 3 this binary data would fail json parsing.
Note that response.data says it shouldn't be used and will be deprecated, get_data should be used in its place.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/937