### PR TITLE
Implement context header mappings - Feature Request Issue #939

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
     - [Setting Environment Variables](#setting-environment-variables)
       - [Local Environment Variables](#local-environment-variables)
       - [Remote Environment Variables](#remote-environment-variables)
+    - [API Gateway Context Variables](#api-gateway-context-variables)
     - [Catching Unhandled Exceptions](#catching-unhandled-exceptions)
     - [Using Custom AWS IAM Roles and Policies](#using-custom-aws-iam-roles-and-policies)
     - [Globally Available Server-less Architectures](#globally-available-server-less-architectures)
@@ -582,6 +583,7 @@ to change Zappa's behavior. Use these at your own risk!
         "django_settings": "your_project.production_settings", // The modular path to your Django project's settings. For Django projects only.
         "domain": "yourapp.yourdomain.com", // Required if you're using a domain
         "environment_variables": {"your_key": "your_value"}, // A dictionary of environment variables that will be available to your deployed app. See also "remote_env". Default {}.
+        "context_header_mappings": { "HTTP_header_name": "API_Gateway_context_variable" }, // A dictionary mapping HTTP header names to API Gateway context variables
         "events": [
             {   // Recurring events
                 "function": "your_module.your_recurring_function", // The function to execute
@@ -837,6 +839,37 @@ Now in your application you can use:
 ```python
 import os
 db_string = os.environ.get('DB_CONNECTION_STRING')
+```
+
+#### API Gateway Context Variables
+
+If you want to map an API Gateway context variable (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html) to an HTTP header you can set up the mapping in `zappa_settings.json`:
+
+```javascript
+{
+    "dev": {
+        ...
+        "context_header_mappings": { 
+            "HTTP_header_name": "API_Gateway_context_variable" 
+        }
+    },
+    ...
+}
+```
+
+For example, if you want to expose the $context.identity.cognitoIdentityId variable as the HTTP header CognitoIdentityId, and $context.stage as APIStage, you would have:
+
+```javascript
+{
+    "dev": {
+        ...
+        "context_header_mappings": { 
+            "CognitoIdentityId": "identity.cognitoIdentityId",
+            "APIStage": "stage"
+        }
+    },
+    ...
+}
 ```
 
 #### Catching Unhandled Exceptions

--- a/test_settings.json
+++ b/test_settings.json
@@ -13,6 +13,13 @@
        "debug": true,
        "parameter_depth": 2,
        "prebuild_script": "tests.test_app.prebuild_me",
+       "environment_variables": {
+           "TEST_ENV_VAR": "test_value"
+       },
+       "context_header_mappings": {
+           "CognitoIdentityId": "identity.cognitoIdentityId",
+           "APIStage": "stage"
+       },
        "events": [
            {
                "function": "tests.test_app.schedule_me",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1615,6 +1615,28 @@ USE_TZ = True
         self.assertTrue(conflicts_with_a_neighbouring_module('tests/data/test1'))
         self.assertFalse(conflicts_with_a_neighbouring_module('tests/data/test2'))
 
+    def test_settings_py_generation(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+        zappa_cli.load_settings('test_settings.json')
+        zappa_cli.create_package()
+        with zipfile.ZipFile(zappa_cli.zip_path, 'r') as lambda_zip:
+            content = lambda_zip.read('zappa_settings.py').decode("utf-8")
+            settings = {}
+            exec(content, globals(), settings)
+
+            # validate environment variables
+            self.assertIn('ENVIRONMENT_VARIABLES', settings)
+            self.assertEqual(settings['ENVIRONMENT_VARIABLES'][b'TEST_ENV_VAR'], "test_value")
+
+            # validate Context header mappings
+            self.assertIn('CONTEXT_HEADER_MAPPINGS', settings)
+            self.assertEqual(settings['CONTEXT_HEADER_MAPPINGS']['CognitoIdentityId'], "identity.cognitoIdentityId")
+            self.assertEqual(settings['CONTEXT_HEADER_MAPPINGS']['APIStage'], "stage")
+
+        zappa_cli.remove_local_zip()
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -110,6 +110,7 @@ class ZappaCLI(object):
     environment_variables = None
     authorizer = None
     aws_kms_key_arn = ''
+    context_header_mappings = None
 
     stage_name_env_pattern = re.compile('^[a-zA-Z0-9_]+$')
 
@@ -1892,6 +1893,7 @@ class ZappaCLI(object):
         self.authorizer = self.stage_config.get('authorizer', {})
         self.runtime = self.stage_config.get('runtime', get_runtime_from_python_version())
         self.aws_kms_key_arn = self.stage_config.get('aws_kms_key_arn', '')
+        self.context_header_mappings = self.stage_config.get('context_header_mappings', {})
 
         desired_role_name = self.lambda_name + "-ZappaLambdaExecutionRole"
         self.zappa = Zappa( boto_session=session,
@@ -2085,6 +2087,12 @@ class ZappaCLI(object):
                 settings_s = settings_s + "BINARY_SUPPORT=True\n"
             else:
                 settings_s = settings_s + "BINARY_SUPPORT=False\n"
+
+            head_map_dict = {}
+            head_map_dict.update(dict(self.context_header_mappings))
+            settings_s = settings_s + "CONTEXT_HEADER_MAPPINGS={0}\n".format(
+                head_map_dict
+            )
 
             # If we're on a domain, we don't need to define the /<<env>> in
             # the WSGI PATH

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -421,7 +421,8 @@ class LambdaHandler(object):
                     event,
                     script_name=script_name,
                     trailing_slash=self.trailing_slash,
-                    binary_support=settings.BINARY_SUPPORT
+                    binary_support=settings.BINARY_SUPPORT,
+                    context_header_mappings=settings.CONTEXT_HEADER_MAPPINGS
                 )
 
                 # We are always on https on Lambda, so tell our wsgi app that.

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -29,7 +29,8 @@ def create_wsgi_request(event_info,
                         server_name='zappa',
                         script_name=None,
                         trailing_slash=True,
-                        binary_support=False
+                        binary_support=False,
+                        context_header_mappings={}
                         ):
         """
         Given some event_info via API Gateway,
@@ -39,6 +40,19 @@ def create_wsgi_request(event_info,
         params = event_info['pathParameters']
         query = event_info['queryStringParameters'] # APIGW won't allow multiple entries, ex ?id=a&id=b
         headers = event_info['headers'] or {} # Allow for the AGW console 'Test' button to work (Pull #735)
+
+        if context_header_mappings:
+            for key, value in context_header_mappings.items():
+                parts = value.split('.')
+                header_val = event_info['requestContext']
+                for part in parts:
+                    if part not in header_val:
+                        header_val = None
+                        break
+                    else:
+                        header_val = header_val[part]
+                if header_val is not None:
+                    headers[key] = header_val
 
         # Extract remote user from context if Authorizer is enabled
         remote_user = None


### PR DESCRIPTION
## Description
Adds a setting that allows mapping an API Gateway context variable to an HTTP header. Document the feature in the readme and add unit tests.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/939

