### PR TITLE
Added override_default_exclude config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ to change Zappa's behavior. Use these at your own risk!
         ],
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
         "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
+        "override_default_exclude": [], // A list of UNIX filename-style globs to block default exclusions. More details in [docs/config.rst](docs/config.rst).
         "extends": "stage_name", // Duplicate and extend another stage's settings. For example, `dev-asia` could extend from `dev-common` with a different `s3_bucket` value.
         "extra_permissions": [{ // Attach any extra permissions to this policy. Default None
             "Effect": "Allow",

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -162,6 +162,29 @@ exclude
 
 This is an array of regex string patterns to exclude from the archive.
 
+override_default_exclude
+================
+
+Some modules are excluded by default from the archive because they are already provided by AWS in the Lambda environment. This settings lets you provide a list of UNIX filename-style globs to filter that list. For example ``["boto*"]`` would prevent ``boto3`` from being excluded, and thus allow overriding the version that is provided by AWS (e.g. when it lags behind a version that's needed for a bug fix).
+
+The default excluded modules for Python 2.x are:
+
+- ``boto3``
+- ``dateutil``
+- ``botocore``
+- ``s3transfer``
+- ``six.py``
+- ``jmespath``
+- ``concurrent``
+
+For Python 3+ they are:
+
+- ``boto3``
+- ``dateutil``
+- ``botocore``
+- ``s3transfer``
+- ``concurrent``
+
 
 http_methods
 ============

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -20,6 +20,7 @@ import pkgutil
 import botocore
 import click
 import collections
+import fnmatch
 import hjson as json
 import inspect
 import importlib
@@ -1973,6 +1974,15 @@ class ZappaCLI(object):
                 except ValueError: # pragma: no cover
                     raise ValueError("Unable to load the Zappa settings JSON. It may be malformed.")
 
+    def override_excludes(self, defaults):
+        """
+        Returns a list of excludes filtered by any overrides that might be provided. `fnmatch` is
+        is used to support globs, such as `boto*` removing `boto3`.
+        """
+        overrides = self.stage_config.get('override_default_exclude', [])
+        return [default for default in defaults if all(not fnmatch.fnmatch(default, override) for override in overrides)]
+
+
     def create_package(self, output=None):
         """
         Ensure that the package can be properly configured,
@@ -2017,7 +2027,7 @@ class ZappaCLI(object):
                 # Exclude packages already builtin to the python lambda environment
                 # Related: https://github.com/Miserlou/Zappa/issues/556
                 exclude = self.stage_config.get(
-                        'exclude', [
+                        'exclude', self.override_excludes([
                                         "boto3",
                                         "dateutil",
                                         "botocore",
@@ -2025,17 +2035,17 @@ class ZappaCLI(object):
                                         "six.py",
                                         "jmespath",
                                         "concurrent"
-                                    ])
+                                    ]))
             else:
                 # This could be python3.6 optimized.
                 exclude = self.stage_config.get(
-                        'exclude', [
+                        'exclude', self.override_excludes([
                                         "boto3",
                                         "dateutil",
                                         "botocore",
                                         "s3transfer",
                                         "concurrent"
-                                    ])
+                                    ]))
 
             # Create a single zip that has the handler and application
             self.zip_path = self.zappa.create_lambda_zip(


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Added a new config parameter `override_default_exclude ` that allows overriding the default excludes, as per the discussion in #965 . The main use is to allow using versions of boto newer than what Amazon provides, but could have additional utility.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#965 

