### PR TITLE
Fixes Miserlou/Zappa#992 - except BotoCoreError before general exception in zappa.cli.update

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -797,6 +797,9 @@ class ZappaCLI(object):
             conf = function_response['Configuration']
             last_updated = parser.parse(conf['LastModified'])
             last_updated_unix = time.mktime(last_updated.timetuple())
+        except botocore.exceptions.BotoCoreError as e:
+            click.echo(click.style(type(e).__name__, fg="red") + ": " + e.args[0])
+            sys.exit(-1)
         except Exception as e:
             click.echo(click.style("Warning!", fg="red") + " Couldn't get function " + self.lambda_name +
                        " in " + self.zappa.aws_region + " - have you deployed yet?")


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Except a BotoCoreError instead of a generic Exception for more verbose logging in `zappa.cli.update`.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/992

