### PR TITLE
fix/Include six

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2042,7 +2042,6 @@ class ZappaCLI(object):
                                         "dateutil",
                                         "botocore",
                                         "s3transfer",
-                                        "six.py",
                                         "jmespath",
                                         "concurrent"
                                     ])


### PR DESCRIPTION
## Description
This PR fixes https://github.com/Miserlou/Zappa/issues/845 by including `six` in the uploaded Lambda. The original problem is that deploying on Python 3.6 gives the following error `ImportError: No module named six.moves.http_client`

Miserlou said that the inclusion of six was the problem in https://github.com/requests/requests/issues/3985#issuecomment-296244685


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/845

