### PR TITLE
Fix #998 - Make environment variable keys strings instead of byte arrays in python 3.6

### DIFF
--- a/tests/test_non_ascii_environment_var_key.json
+++ b/tests/test_non_ascii_environment_var_key.json
@@ -1,0 +1,18 @@
+{
+    "ttt888": {
+       "touch": false,
+       "s3_bucket": "lmbda",
+       "app_function": "tests.test_app.hello_world",
+       "callbacks": {
+           "settings": "test_settings.callback",
+           "post": "test_settings.callback",
+           "zip": "test_settings.callback"
+       },
+       "delete_local_zip": true,
+       "debug": true,
+       "parameter_depth": 2,
+        "environment_variables": {
+            "REMOTE_HOST☣": "example.net"
+        },
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1653,7 +1653,7 @@ USE_TZ = True
 
             # validate environment variables
             self.assertIn('ENVIRONMENT_VARIABLES', settings)
-            self.assertEqual(settings['ENVIRONMENT_VARIABLES'][b'TEST_ENV_VAR'], "test_value")
+            self.assertEqual(settings['ENVIRONMENT_VARIABLES']['TEST_ENV_VAR'], "test_value")
 
             # validate Context header mappings
             self.assertIn('CONTEXT_HEADER_MAPPINGS', settings)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1662,6 +1662,14 @@ USE_TZ = True
 
         zappa_cli.remove_local_zip()
 
+    def test_only_ascii_env_var_allowed(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+        zappa_cli.load_settings('tests/test_non_ascii_environment_var_key.json')
+        with self.assertRaises(ValueError) as context:
+            zappa_cli.create_package()
+        self.assertEqual('Environment variable keys must be ascii.', str(context.exception))
+
 
 
 if __name__ == '__main__':

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2140,9 +2140,9 @@ class ZappaCLI(object):
             # Environment variable keys can't be Unicode
             # https://github.com/Miserlou/Zappa/issues/604
             try:
-                env_dict = dict((k.encode('ascii'), v) for (k, v) in env_dict.items())
+                env_dict = dict((k.encode('ascii').decode('ascii'), v) for (k, v) in env_dict.items())
             except Exception: # pragma: no cover
-                    raise ValueError("Environment variable keys must not be unicode.")
+                raise ValueError("Environment variable keys must not be unicode.")
 
             settings_s = settings_s + "ENVIRONMENT_VARIABLES={0}\n".format(
                     env_dict

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2137,12 +2137,12 @@ class ZappaCLI(object):
                 env_dict['AWS_REGION'] = self.aws_region
             env_dict.update(dict(self.environment_variables))
 
-            # Environment variable keys can't be Unicode
+            # Environment variable keys must be ascii
             # https://github.com/Miserlou/Zappa/issues/604
             try:
                 env_dict = dict((k.encode('ascii').decode('ascii'), v) for (k, v) in env_dict.items())
-            except Exception: # pragma: no cover
-                raise ValueError("Environment variable keys must not be unicode.")
+            except Exception:
+                raise ValueError("Environment variable keys must be ascii.")
 
             settings_s = settings_s + "ENVIRONMENT_VARIABLES={0}\n".format(
                     env_dict


### PR DESCRIPTION
Fixes #998 by decoding the ascii encoded byte array back into a string before writing it to zappa_settings.py

Tested environment variables in python 2.7 and 3.6

