### PR TITLE
Bug fix for empty aws_environment_variables setting wiping remote Lambda env vars on update

### DIFF
--- a/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.GetFunctionConfiguration_1.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Thu, 20 Jul 2017 17:54:59 GMT",
+                "x-amzn-requestid": "8cd3e440-6d74-11e7-9ebd-693a5cc9b121",
+                "content-length": "609",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "zappa-ttt888",
+        "FunctionArn": "arn:aws:lambda:us-east-1:004396165043:function:zappa-ttt888",
+        "Runtime": "python3.6",
+        "Role": "arn:aws:iam::004396165043:role/zappa-ttt888-ZappaLambdaExecutionRole",
+        "Handler": "handler.lambda_handler",
+        "CodeSize": 16975308,
+        "Description": "Zappa Deployment",
+        "Timeout": 30,
+        "MemorySize": 512,
+        "LastModified": "2017-07-20T17:54:59.235+0000",
+        "CodeSha256": "0pOcmP7sDoO6mLbZKmtH5z0XyjT8wuu/1VenHLgu/MU=",
+        "Version": "$LATEST",
+        "Environment": {
+            "Variables": {}
+        }
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -309,6 +309,15 @@ class TestZappa(unittest.TestCase):
             end_result_should_be = {"REMOTE_ONLY": "AAA", "CHANGED_REMOTE" : "ZZ", "LOCAL_ONLY" : "YY"}
             self.assertEqual(mock_client.update_function_configuration.call_args[1]["Environment"], { "Variables": end_result_should_be})
 
+        with mock.patch.object(z, "lambda_client") as mock_client:
+            # Simulate already having some AWS env vars remotely but none set in aws_environment_variables
+            mock_client.get_function_configuration.return_value = {
+                "Environment": {"Variables": {"REMOTE_ONLY_1": "AAA", "REMOTE_ONLY_2": "BBB"}}}
+            z.update_lambda_configuration("test", "test", "test")
+            end_result_should_be = {"REMOTE_ONLY_1": "AAA", "REMOTE_ONLY_2": "BBB"}
+            self.assertEqual(mock_client.update_function_configuration.call_args[1]["Environment"],
+                             {"Variables": end_result_should_be})
+
     def test_update_empty_aws_env_hash(self):
         z = Zappa()
         z.credentials_arn = object()

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -900,7 +900,7 @@ class Zappa(object):
                                         publish=True,
                                         vpc_config=None,
                                         runtime='python2.7',
-                                        aws_environment_variables={},
+                                        aws_environment_variables=None,
                                         aws_kms_key_arn=None
                                     ):
         """
@@ -914,6 +914,8 @@ class Zappa(object):
             self.get_credentials_arn()
         if not aws_kms_key_arn:
             aws_kms_key_arn = ''
+        if not aws_environment_variables:
+            aws_environment_variables = {}
 
         # Check if there are any remote aws lambda env vars so they don't get trashed.
         # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -900,7 +900,7 @@ class Zappa(object):
                                         publish=True,
                                         vpc_config=None,
                                         runtime='python2.7',
-                                        aws_environment_variables=None,
+                                        aws_environment_variables={},
                                         aws_kms_key_arn=None
                                     ):
         """
@@ -915,18 +915,15 @@ class Zappa(object):
         if not aws_kms_key_arn:
             aws_kms_key_arn = ''
 
-        if not aws_environment_variables:
-            aws_environment_variables = {}
-        else:
-            # Check if there are any remote aws lambda env vars so they don't get trashed.
-            # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765
-            lambda_aws_config = self.lambda_client.get_function_configuration(FunctionName=function_name)
-            if "Environment" in lambda_aws_config:
-                lambda_aws_environment_variables = lambda_aws_config["Environment"].get("Variables", {})
-                # Append keys that are remote but not in settings file
-                for key, value in lambda_aws_environment_variables.items():
-                    if key not in aws_environment_variables:
-                        aws_environment_variables[key] = value
+        # Check if there are any remote aws lambda env vars so they don't get trashed.
+        # https://github.com/Miserlou/Zappa/issues/987,  Related: https://github.com/Miserlou/Zappa/issues/765
+        lambda_aws_config = self.lambda_client.get_function_configuration(FunctionName=function_name)
+        if "Environment" in lambda_aws_config:
+            lambda_aws_environment_variables = lambda_aws_config["Environment"].get("Variables", {})
+            # Append keys that are remote but not in settings file
+            for key, value in lambda_aws_environment_variables.items():
+                if key not in aws_environment_variables:
+                    aws_environment_variables[key] = value
 
         response = self.lambda_client.update_function_configuration(
             FunctionName=function_name,


### PR DESCRIPTION
Issue: https://github.com/Miserlou/Zappa/issues/1010

