### PR TITLE
Set Flask script_name based on domain which the request was made to

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -39,3 +39,91 @@ class TestZappa(unittest.TestCase):
             self.fail('Exception expected')
         except RuntimeError as e:
             pass
+
+    def test_wsgi_script_name_on_aws_url(self):
+        """
+        Ensure that requests to the amazonaws.com host for an API with a
+        domain have the correct request.url
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+
+        event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {
+                'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
+            },
+            'pathParameters': {
+                'proxy': 'return/request/url'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/return/request/url'
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(
+            response['body'],
+            'https://1234567890.execute-api.us-east-1.amazonaws.com/dev/return/request/url'
+        )
+
+    def test_wsgi_script_name_on_domain_url(self):
+        """
+        Ensure that requests to the amazonaws.com host for an API with a
+        domain have the correct request.url
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+
+        event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {
+                'Host': 'example.com',
+            },
+            'pathParameters': {
+                'proxy': 'return/request/url'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/return/request/url'
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(
+            response['body'],
+            'https://example.com/return/request/url'
+        )
+
+    def test_wsgi_script_name_on_test_request(self):
+        """
+        Ensure that requests sent by the "Send test request" button behaves
+        sensibly
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+
+        event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {},
+            'pathParameters': {
+                'proxy': 'return/request/url'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/return/request/url'
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(
+            response['body'],
+            'https://zappa:80/return/request/url'
+        )

--- a/tests/test_wsgi_script_name_app.py
+++ b/tests/test_wsgi_script_name_app.py
@@ -1,0 +1,8 @@
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route('/return/request/url', methods=['GET', 'POST'])
+def return_request_url():
+    return request.url

--- a/tests/test_wsgi_script_name_settings.py
+++ b/tests/test_wsgi_script_name_settings.py
@@ -1,0 +1,11 @@
+API_STAGE = 'dev'
+APP_FUNCTION = 'app'
+APP_MODULE = 'tests.test_wsgi_script_name_app'
+BINARY_SUPPORT = False
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'wsgi_script_name_settings'

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -406,15 +406,30 @@ class LambdaHandler(object):
             # This is a normal HTTP request
             if event.get('httpMethod', None):
 
-                if settings.DOMAIN:
-                    # If we're on a domain, we operate normally
-                    script_name = ''
+                script_name = ''
+                headers = event.get('headers')
+                if headers:
+                    host = headers.get('Host')
                 else:
-                    # But if we're not, then our base URL
-                    # will be something like
-                    # https://blahblahblah.execute-api.us-east-1.amazonaws.com/dev
-                    # So, we need to make sure the WSGI app knows this.
-                    script_name = '/' + settings.API_STAGE
+                    host = None
+
+                if host:
+                    if 'amazonaws.com' in host:
+                        # The path provided in th event doesn't include the
+                        # stage, so we must tell Flask to include the API
+                        # stage in the url it calculates
+                        script_name = '/' + settings.API_STAGE
+                else:
+                    # This is a test request sent from the AWS console
+                    if settings.DOMAIN:
+                        # Assume the requests received will be on the specified
+                        # domain. No special handling is required
+                        pass
+                    else:
+                        # Assume the requests received will be to the
+                        # amazonaws.com endpoint, so tell Flask to include the
+                        # API stage
+                        script_name = '/' + settings.API_STAGE
 
                 # Create the environment for WSGI and handle the request
                 environ = create_wsgi_request(

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -417,7 +417,7 @@ class LambdaHandler(object):
                     if 'amazonaws.com' in host:
                         # The path provided in th event doesn't include the
                         # stage, so we must tell Flask to include the API
-                        # stage in the url it calculates
+                        # stage in the url it calculates. See https://github.com/Miserlou/Zappa/issues/1014
                         script_name = '/' + settings.API_STAGE
                 else:
                     # This is a test request sent from the AWS console


### PR DESCRIPTION
This PR configures the Flask environment properly when requests are made on the `amazonaws.com` URL of an API which has a `domain_name` set.

Fixes #1014.

## Description
Set Flask script_name based on domain which the request was made to, rather than statically based on the settings.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1014
