### PR TITLE
slim_handler reduce /tmp use and enable significantly larger deployments  

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,11 @@ You can also simply handle CORS directly in your application. Your web framework
 
 #### Large Projects
 
-AWS currently limits Lambda zip sizes to 50 megabytes. If your project is larger than that, set `slim_handler: true` in your `zappa_settings.json`. In this case, your fat application package will be replaced with a small handler-only package. The handler file then pulls the rest of the large project down from S3 at run time! The initial load of the large project may add to startup overhead, but the difference should be minimal on a warm lambda function. Note that this will also eat into the _memory_ space of your application function.
+AWS currently limits Lambda zip sizes to 50 megabytes. If your project is larger than that, set `slim_handler: true` in your `zappa_settings.json`. In this case, your heavyweight application package will be replaced with a small handler package. When the Lambda function starts, the handler package downloads your project files from S3, unzips them into `/tmp` storage, and fires up your application! The initial load of the large project may add to startup overhead, but the difference should be minimal on a warm lambda function.
+
+For deployments between 250 and 500 megabytes, the `memory_size` of the Lambda instance will determine if your deployment succeeds. The `/tmp` folder on each Lambda instance has 500 megabytes of free space. When the handler package downloads the zip file containing your project from S3, it attempts to store that file in memory while it unzips it's contents to `/tmp/<your_project>/`. If the `memory_size` of the instance is smaller than the size of your zipped project, the zip file spills onto `/tmp` and eats into the maximum project size that can be unzipped.
+
+As a rule of thumb, if a project directory is between 250 and 500 megabytes on your development machine, set `memory_size` > 650 megabytes and your deployments will never fail due to insufficient resources.
 
 #### Enabling Bash Completion
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -159,13 +159,14 @@ class LambdaHandler(object):
                 boto_session = self.session
 
             # Lambda Function Memory Size in MB
-            server_memory_mb = int(os.environ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])
+            server_memory_mb = int(os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", 128))
 
             # Maximum memory (bytes) to allocate for in-memory tempfile before spilling to disk
             tempfile_size_bytes = (server_memory_mb - 100) * 1024 * 1024
 
             # Related: https://github.com/Miserlou/Zappa/issues/702
-            with tempfile.SpooledTemporaryFile(max_size=tempfile_size_bytes, mode='wb+') as project_zip:
+            with tempfile.SpooledTemporaryFile(max_size=tempfile_size_bytes,
+                                               mode='wb+') as project_zip:
                 # In memory tempfile. Spills to disk once size > max_size. Deletes on close context
 
                 # Download zip file from S3


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Updated slim_handler behavior to:
  - Delete project.zip after it has been extracted
  - Enable significantly larger deployments (see #1020)

Previously:
  - Download project.zip from s3 to /tmp
  - Unzip project.zip to /tmp/project
  - Do not delete project.zip

Now:
  - Download project.zip into an SpooledTemporaryFile
       - SpooledTempfile is in-memory
       - SpooledTempfile has a max_size based on the Lambda function's memory from an env var
       - SpooledTempfile seamlessly dumps to /tmp and continues if max_size is exceeded (safe)
       - SpooledTempfile deletes automatically once it falls out of scope
   - Unzip project.zip to /tmp

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1020
#961
#881 