### PR TITLE
Fix SNS async

### DIFF
--- a/zappa/async.py
+++ b/zappa/async.py
@@ -163,7 +163,10 @@ class SnsAsyncResponse(LambdaAsyncResponse):
     Send a SNS message to a specified SNS topic
     Serialise the func path and arguments
     """
-    def __init__(self, **kwargs):
+    def __init__(self, lambda_function_name=None, aws_region=None, **kwargs):
+
+        self.lambda_function_name = lambda_function_name
+        self.aws_region = aws_region
 
         if kwargs.get('boto_session'):
             self.client = kwargs.get('boto_session').client('sns')


### PR DESCRIPTION
## Description
Poking around in the async call mechanism, I found that (non-arn) SNS invocations were failing due to unset local variables for `aws_region` and `lambda_function_name`.

This fixes that.
