### PR TITLE
Ability to capture asynchronous responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,11 +535,11 @@ run(your_function, args, kwargs, service='sns') # Using SNS
 ### Remote Invocations
 
 By default, Zappa will use lambda's current function name and current AWS region. If you wish to invoke a lambda with
-  a different function name/region or invoke your lambda from outside of lambda, you must specify the 
-  `remote_aws_lambda_function_name` and `remote_aws_region` arguments so that the application knows which function and 
-  region to use. For example, if some part of our pizza making application had to live on an EC2 instance, but we 
+  a different function name/region or invoke your lambda from outside of lambda, you must specify the
+  `remote_aws_lambda_function_name` and `remote_aws_region` arguments so that the application knows which function and
+  region to use. For example, if some part of our pizza making application had to live on an EC2 instance, but we
   wished to call the make_pie() function on its own Lambda instance, we would do it as follows:
-  
+
  ```python
 @task(remote_aws_lambda_function_name='pizza-pie-prod', remote_aws_region='us-east-1')
 def make_pie():
@@ -848,7 +848,7 @@ if 'SERVERTYPE' in os.environ and os.environ['SERVERTYPE'] == 'AWS Lambda':
     for key, val in env_vars.items():
         os.environ[key] = val
 
-``` 
+```
 
 ##### Remote Environment Variables
 
@@ -898,8 +898,8 @@ If you want to map an API Gateway context variable (http://docs.aws.amazon.com/a
 {
     "dev": {
         ...
-        "context_header_mappings": { 
-            "HTTP_header_name": "API_Gateway_context_variable" 
+        "context_header_mappings": {
+            "HTTP_header_name": "API_Gateway_context_variable"
         }
     },
     ...
@@ -912,7 +912,7 @@ For example, if you want to expose the $context.identity.cognitoIdentityId varia
 {
     "dev": {
         ...
-        "context_header_mappings": { 
+        "context_header_mappings": {
             "CognitoIdentityId": "identity.cognitoIdentityId",
             "APIStage": "stage"
         }

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Example:
 
 ```python
 from zappa.async import task, get_async_response
-from flask import Flask, make_response, abort, url_for, redirect, request
+from flask import Flask, make_response, abort, url_for, redirect, request, jsonify
 from time import sleep
 
 app = Flask(__name__)
@@ -595,7 +595,7 @@ def response(response_id):
         abort(404)
 
     if response['status'] == 'complete':
-        return response['response'], 200, {'Content-Type': 'application/json'}
+        return jsonify(response['response'])
 
     sleep(5)
 

--- a/README.md
+++ b/README.md
@@ -630,6 +630,8 @@ to change Zappa's behavior. Use these at your own risk!
         "async_source": "sns", // Source of async tasks. Defaults to "lambda"
         "async_resources": true, // Create the SNS topic and DynamoDB table to use. Defaults to true.
         "async_response_table": "your_dynamodb_table_name",  // the DynamoDB table name to use for captured async responses; defaults to None (can't capture)
+        "async_response_table_read_capacity": 1,  // DynamoDB table read capacity; defaults to 1
+        "async_response_table_write_capacity": 1,  // DynamoDB table write capacity; defaults to 1
         "aws_environment_variables" : {"your_key": "your_value"}, // A dictionary of environment variables that will be available to your deployed app via AWS Lambdas native environment variables. See also "environment_variables" and "remote_env" . Default {}.
         "aws_kms_key_arn": "your_aws_kms_key_arn", // Your AWS KMS Key ARN
         "aws_region": "aws-region-name", // optional, uses region set in profile or environment variables if not set here,

--- a/README.md
+++ b/README.md
@@ -594,8 +594,8 @@ def response(response_id):
     if response is None:
         abort(404)
 
-    if response['async_status']['S'] == 'complete':
-        return response['async_response']['S'], 200, {'Content-Type': 'application/json'}
+    if response['status'] == 'complete':
+        return response['response'], 200, {'Content-Type': 'application/json'}
 
     sleep(5)
 

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -454,7 +454,10 @@ def get_async_response(response_id):
         TableName=ASYNC_RESPONSE_TABLE,
         Key={'id': {'S': str(response_id)}}
     )
-    try:
-        return response['Item']
-    except KeyError:
+    if 'Item' not in response:
         return None
+
+    return {
+        'status': response['Item']['async_status']['S'],
+        'response': response['Item']['async_response']['S'],
+    }

--- a/zappa/async.py
+++ b/zappa/async.py
@@ -276,7 +276,7 @@ def run_message(message):
                 'id': {'S': str(message['response_id'])},
                 'ttl': {'N': str(int(time.time()+600))},
                 'async_status': {'S': 'in progress'},
-                'async_response': {'S': 'N/A'},
+                'async_response': {'S': str(json.dumps('N/A'))},
             }
         )
 
@@ -459,5 +459,5 @@ def get_async_response(response_id):
 
     return {
         'status': response['Item']['async_status']['S'],
-        'response': response['Item']['async_response']['S'],
+        'response': json.loads(response['Item']['async_response']['S']),
     }

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1079,6 +1079,15 @@ class ZappaCLI(object):
             )
             click.echo('SNS Topic created: %s' % topic_arn)
 
+        # Add async tasks DynamoDB
+        table_name = self.stage_config.get('async_response_table', False)
+        if table_name and self.stage_config.get('async_resources', True):
+            response_table = self.zappa.create_async_dynamodb_table(table_name)
+            if response_table is True:
+                print('DynamoDB table exists: %s' % table_name)
+            else:
+                print('DynamoDB table created: %s' % table_name)
+
     def unschedule(self):
         """
         Given a a list of scheduled functions,
@@ -2207,6 +2216,10 @@ class ZappaCLI(object):
                 base = __file__.rsplit(os.sep, 1)[0]
                 django_py = ''.join(os.path.join(base, 'ext', 'django_zappa.py'))
                 lambda_zip.write(django_py, 'django_zappa_app.py')
+
+            # async response
+            async_response_table = self.stage_config.get('async_response_table', '')
+            settings_s += "ASYNC_RESPONSE_TABLE='{0!s}'\n".format(async_response_table)
 
             # Lambda requires a specific chmod
             temp_settings = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
## Description

Implements a mechanism (`capture_response`) to optionally capture the result of asynchronous tasks to DynamoDB.

Example (see the README for more):

```python
@app.route('/payload')
def payload():
    delay = request.args.get('delay', 60)
    x = longrunner(delay)
    return "Got response_id: {}".format(x.response_id)

@task(capture_response=True)
def longrunner(delay):
    sleep(float(delay))
    return {'MESSAGE': "It took {} seconds to generate this.".format(delay)}
```

Updates settings to allow specification of table name.

Updates README to document this feature, including an example app.

## GitHub Issues
Closes #1060

## Other

I think this can be considered for merge because the functionality is useful right away, but it's missing a few things, longer term:

- ~~DynamoDB table creation uses static values (`5`) for read + write provisioning, which currently costs "$2.91 / month" according to the console. Would be really nice to make this autoscale, but that's much more complicated.~~
- I did not add a test for this. It sounds extremely difficult to write a test that implements this without actually deploying an app during the test suite run.
- Timeout is still limited to the lambda limit (`timeout_seconds` in zappa settings), so there's a hard limit of 300s for these. The DynamoDB records have a TTL of ~600 (+lag) seconds; this is not configurable at this time.
