### PR TITLE
Remove setLevel call from common_log logger

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -159,7 +159,6 @@ def common_log(environ, response, response_time=None):
     """
 
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
 
     if response_time:
         formatter = ApacheFormatter(with_response_time=True)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

Remove call to `setLevel` in `wsgi.common_log`, because this overrides the log level set in the `log_level` zappa setting.

**To reproduce:**
* Set log_level to ERROR
* Deploy the example flask app

Before this patch: Note that requests are still logged to cloudwatch, even though they are on INFO level

After this patch: Only ERROR logs will be logged, as expected

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

Addresses #1057