### PR TITLE
events take kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,26 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
        ]
 ```
 
+Events can also take keyword arguments.
+```javascript
+       "events": [
+            {
+                "function": "your_module.your_recurring_function", // The function to execute
+                "kwargs": {"key": "val", "key2": "val2"},  // Keyword arguments to pass. These are available in the event
+                "expression": "rate(1 minute)" // When to execute it (in cron or rate format)
+            }    
+       ]
+```
+
+To get the keyword arguments you will need to look inside the event dict.
+
+```python
+def your_recurring_function(event, context):
+    my_kwargs = event.get(kwargs)  # dict of kwargs given in zappa_settings file
+
+```
+
+
 You can find more [example event sources here](http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html).
 
 ## Asynchronous Task Execution

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2140,6 +2140,7 @@ class Zappa(object):
                                      '}' % json.dumps(kwargs)
 
                     # Create the CloudWatch event ARN for this function.
+                    # https://github.com/Miserlou/Zappa/issues/359
                     target_response = self.events_client.put_targets(
                         Rule=rule_name,
                         Targets=[

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2136,6 +2136,7 @@ class Zappa(object):
                                      '"detail": <detail>, ' \
                                      '"version": <version>,' \
                                      '"resources": <resources>,' \
+                                     '"id": <id>,' \
                                      '"kwargs": %s' \
                                      '}' % json.dumps(kwargs)
 
@@ -2156,7 +2157,8 @@ class Zappa(object):
                                         'region': '$.region',
                                         'detail': '$.detail',
                                         'version': '$.version',
-                                        'resources': '$.resources'
+                                        'resources': '$.resources',
+                                        'id': '$.id'
                                     },
                                     'InputTemplate': input_template
                                 }


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
This allows events to take keyword arguments. The event sent to CloudWatch is recreated through the InputTransformer parameter and then modified to include the kwargs argument. 

The kwargs can then be obtained through

`kwargs = event.get('kwargs')`

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#359
