### PR TITLE
detects if current runtime is py2/3 and adds the appropriate line to …

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1585,6 +1585,7 @@ class ZappaCLI(object):
             env_zappa_settings = {
                 env_name: {
                     's3_bucket': env_bucket,
+                    'runtime': 'python3.6' if sys.version_info[0] == 3 else 'python2.7'
                 }
             }
 


### PR DESCRIPTION
…the zappa_settings.json

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Adds a line to the settings file declaring runtime based on the runtime used in `zappa init`

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1088 
