### PR TITLE
zapp manage use --settings_file

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -313,6 +313,10 @@ class ZappaCLI(object):
             '--no-color', action='store_true',
             help=("Don't color the output")
         )
+        # This is explicitly added here because this is the only subcommand that doesn't inherit from env_parser
+        manage_parser.add_argument(
+            '-s', '--settings_file', help='The path to a Zappa settings file.'
+        )
 
         ##
         # Rollback

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -314,6 +314,7 @@ class ZappaCLI(object):
             help=("Don't color the output")
         )
         # This is explicitly added here because this is the only subcommand that doesn't inherit from env_parser
+        # https://github.com/Miserlou/Zappa/issues/1002
         manage_parser.add_argument(
             '-s', '--settings_file', help='The path to a Zappa settings file.'
         )


### PR DESCRIPTION
## Description
This is a trivial change that allows the `zappa manage` sub command to properly handle custom `--settings_file` command line argument.  This is required because this is the only sub command that does not inherit from `env_parser`.  No tests have been written as this is simply copy/paste from a parent argument parser.

I investigated changing the sub command to inherit from env_parser, but saw [this comment](https://github.com/SoprisApps/Zappa/blob/manage-settings-file/zappa/cli.py#L429-L436) in the code that outlined why the `zappa manage` sub command cannot inherit from env_parser.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1002
