### PR TITLE
Fixes syntax error from merge

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1586,7 +1586,7 @@ class ZappaCLI(object):
             env_zappa_settings = {
                 env_name: {
                     's3_bucket': env_bucket,
-                    'runtime': 'python3.6' if sys.version_info[0] == 3 else 'python2.7'
+                    'runtime': 'python3.6' if sys.version_info[0] == 3 else 'python2.7',
                     'project_name': self.get_project_name()
                 }
             }


### PR DESCRIPTION
Seems that two recent merges both added keys to this section and thus it was missing a comma causing a syntax error when running from latest master.