### PR TITLE
Fix bug with mixed case packages

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -155,14 +155,27 @@ class TestZappa(unittest.TestCase):
         z = Zappa(runtime='python2.7')
 
         # mock pip packages call to be same as what our mocked site packages dir has
-        mock_package = collections.namedtuple('mock_package', ['project_name', 'version'])
-        mock_pip_installed_packages = [mock_package('super_package', '0.1')]
+        mock_package = collections.namedtuple('mock_package', ['project_name', 'version', 'location'])
+        mock_pip_installed_packages = [mock_package('super_package', '0.1', '/venv/site-packages')]
 
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['super_package']):
                 import pip  # this gets called in non-test Zappa mode
                 with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
                     self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
+
+    def test_getting_installed_packages_mixed_case(self, *args):
+        z = Zappa(runtime='python2.7')
+
+        # mock pip packages call to be same as what our mocked site packages dir has
+        mock_package = collections.namedtuple('mock_package', ['project_name', 'version', 'location'])
+        mock_pip_installed_packages = [mock_package('SuperPackage', '0.1', '/venv/site-packages')]
+
+        with mock.patch('os.path.isdir', return_value=True):
+            with mock.patch('os.listdir', return_value=['superpackage']):
+                import pip  # this gets called in non-test Zappa mode
+                with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                    self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
 
     def test_load_credentials(self):
         z = Zappa()

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -679,9 +679,12 @@ class Zappa(object):
         if os.path.isdir(site_packages_64):
             package_to_keep += os.listdir(site_packages_64)
 
+        package_to_keep = [x.lower() for x in package_to_keep]
+
         installed_packages = {package.project_name.lower(): package.version for package in
-                              pip.get_installed_distributions() if package.project_name in package_to_keep or
-                              package.location in [site_packages, site_packages_64]}
+                              pip.get_installed_distributions()
+                              if package.project_name.lower() in package_to_keep
+                              or package.location in [site_packages, site_packages_64]}
 
         return installed_packages
 


### PR DESCRIPTION
## Description
Mixed cases in package names can cause them to not show up in the call to `get_installed_packages`.
An example of a package with this naming is WeasyPrint.


