### PR TITLE
using the same naming convention for update as for deploy

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -852,7 +852,7 @@ class ZappaCLI(object):
                 raise ClickException("Unable to upload handler to S3. Quitting.")
 
             # Copy the project zip to the current project zip
-            current_project_name = '{0!s}_current_project.tar.gz'.format(self.project_name)
+            current_project_name = '{0!s}_{1!s}_current_project.tar.gz'.format(self.api_stage, self.project_name)
             success = self.zappa.copy_on_s3(src_file_name=self.zip_path, dst_file_name=current_project_name,
                                             bucket_name=self.s3_bucket_name)
             if not success:  # pragma: no cover


### PR DESCRIPTION
Came up on slack, #1094 caused this issue. Needed to add the stage name to the current project variable in the update() as well as deploy()