### PR TITLE
Add cli option to alias lambda on deploy/update

### DIFF
--- a/tests/placebo/TestZappa.test_cli_aws/lambda.CreateAlias_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.CreateAlias_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 201,
+  "data": {
+    "AliasArn": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt666:some_alias",
+    "FunctionVersion": "3",
+    "Name": "some_alias",
+    "Description": ""
+  }
+}

--- a/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateAlias_1.json
+++ b/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateAlias_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 201,
+  "data": {
+    "AliasArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:some_alias",
+    "FunctionVersion": "1",
+    "Name": "some_alias",
+    "Description": ""
+  }
+}

--- a/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateAlias_2.json
+++ b/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateAlias_2.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 201,
+  "data": {
+    "AliasArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:updated_alias",
+    "FunctionVersion": "1",
+    "Name": "updated_alias",
+    "Description": ""
+  }
+}

--- a/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateFunction_1.json
+++ b/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.CreateFunction_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 201,
+    "data": {
+        "CodeSha256": "q4duEOI611sqtkU+YbdNkjH5qGRlgmvc9+FhpdykYuk=",
+        "FunctionName": "test_lmbda_function55",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 201,
+            "RequestId": "12b75ef1-e226-11e5-84a2-ad7ddc64ad40"
+        },
+        "CodeSize": 26585626,
+        "MemorySize": 512,
+        "FunctionArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55",
+        "Version": "1",
+        "Role": "arn:aws:iam::12345:role/ZappaLambdaExecution",
+        "Timeout": 30,
+        "LastModified": "2016-03-04T16:28:06.633+0000",
+        "Handler": "runme.lambda_handler",
+        "Runtime": "python2.7",
+        "Description": "Zappa Deployment"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.UpdateFunctionCode_1.json
+++ b/tests/placebo/TestZappa.test_create_aliased_lambda_function/lambda.UpdateFunctionCode_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "CodeSha256": "q4duEOI611sqtkU+YbdNkjH5qGRlgmvc9+FhpdykYuk=", 
+        "FunctionName": "test_lmbda_function55", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "153e09be-e226-11e5-a3b8-7b263f053e5a"
+        }, 
+        "CodeSize": 26585626, 
+        "MemorySize": 512, 
+        "FunctionArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:1", 
+        "Version": "1", 
+        "Role": "arn:aws:iam::12345:role/ZappaLambdaExecution", 
+        "Timeout": 30, 
+        "LastModified": "2016-03-04T16:28:06.633+0000", 
+        "Handler": "runme.lambda_handler", 
+        "Runtime": "python2.7", 
+        "Description": "Zappa Deployment"
+    }
+}

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -110,6 +110,31 @@ class TestZappa(unittest.TestCase):
         )
 
     @placebo_session
+    def test_create_aliased_lambda_function(self, session):
+        bucket_name = 'lmbda'
+        zip_path = 'Spheres-dev-1454694878.zip'
+
+        z = Zappa(session)
+        z.aws_region = 'us-east-1'
+        z.load_credentials(session)
+        z.credentials_arn = 'arn:aws:iam::12345:role/ZappaLambdaExecution'
+
+        arn = z.create_lambda_function(
+            bucket=bucket_name,
+            s3_key=zip_path,
+            function_name='test_lmbda_function55',
+            handler='runme.lambda_handler',
+            alias="some_alias"
+        )
+
+        arn = z.update_lambda_function(
+            bucket=bucket_name,
+            s3_key=zip_path,
+            function_name='test_lmbda_function55',
+            alias="updated_alias"
+        )
+
+    @placebo_session
     def test_rollback_lambda_function_version(self, session):
         z = Zappa(session)
         z.credentials_arn = 'arn:aws:iam::724336686645:role/ZappaLambdaExecution'
@@ -393,7 +418,7 @@ class TestZappa(unittest.TestCase):
         zappa_cli.load_settings('test_settings.json', session)
         zappa_cli.zappa.credentials_arn = 'arn:aws:iam::12345:role/ZappaLambdaExecution'
         zappa_cli.deploy()
-        zappa_cli.update()
+        zappa_cli.update(alias="some_alias")
         zappa_cli.rollback(1)
         zappa_cli.tail(since=0, filter_pattern='', keep_open=False)
         zappa_cli.schedule()


### PR DESCRIPTION
## Description
Add optional `--alias` parameter to CLI so that versions can have an alias associated with them as they are created.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/700
