### PR TITLE
API Gateway only supports ACM certs from one region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ However, it's now far easier to use Route 53-based DNS authentication, which wil
 ##### Deploying to a Domain With AWS Certificate Manager
 
 1. Verify your domain in the AWS Ceriticate Manager console.
-2. In the console, request a certificate for your domain or subdomain (`sub.yourdomain.tld`), or request a wildcard domain (`*.yourdomain.tld`).
+2. In the console, select the N. Virginia (us-east-1) region and request a certificate for your domain or subdomain (`sub.yourdomain.tld`), or request a wildcard domain (`*.yourdomain.tld`).
 3. Copy the entire ARN of that certificate and place it in the Zappa setting `certificate_arn`.
 4. Set your desired domain in the `domain` setting.
 5. Call `$ zappa certify` to create and associate the API Gateway distribution using that ceritficate.


### PR DESCRIPTION
To help people following the guide, we should clarify this so they do
not create a cert in their default region, only to find that it's
unusable.

[AWS docs](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html) state:  

> To use an ACM Certificate with API Gateway, you must request or import the certificate in the US East (N. Virginia) (us-east-1) Region.

If you follow the guide as written, you may encounter an error such as this when running `zappa certify`:

    botocore.errorfactory.BadRequestException: An error occurred (BadRequestException) when calling the CreateDomainName operation: Invalid certificate ARN: redacted. Certificate must be in 'us-east-1'.