### PR TITLE
Add global option to disable color

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,9 +14,10 @@ import shutil
 import sys
 import tempfile
 
+from click.globals import resolve_color_default
 from click.exceptions import ClickException
 
-from zappa.cli import ZappaCLI, shamelessly_promote
+from zappa.cli import ZappaCLI, shamelessly_promote, disable_click_colors
 from zappa.ext.django_zappa import get_django_wsgi
 from zappa.letsencrypt import get_cert_and_update_domain, create_domain_key, create_domain_csr, \
     create_chained_certificate, cleanup, parse_account_key, parse_csr, sign_certificate, encode_certificate,\
@@ -65,6 +66,10 @@ class TestZappa(unittest.TestCase):
     def test_zappa(self):
         self.assertTrue(True)
         Zappa()
+
+    def test_disable_click_colors(self):
+        disable_click_colors()
+        assert resolve_color_default() is False
 
     # @mock.patch('zappa.zappa.find_packages')
     # @mock.patch('os.remove')


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
- Add a global --color=auto/never/always flag
Implemented the "never" option by pushing a Click global context onto the stack.  This is normally managed by Click as part of its command nesting and context passing, but since we are currently only using click.echo and click.style, this should be safe for the meantime. If we start implementing Click more generally, this should be provided as options in a more standard way.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1146

