### PR TITLE
fixing a typo in handler.py ‘Environement’ -> ‘Environment’

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -93,7 +93,7 @@ class LambdaHandler(object):
                 pass
 
             # Set any locally defined env vars
-            # Environement variable keys can't be Unicode
+            # Environment variable keys can't be Unicode
             # https://github.com/Miserlou/Zappa/issues/604
             for key in self.settings.ENVIRONMENT_VARIABLES.keys():
                 os.environ[str(key)] = self.settings.ENVIRONMENT_VARIABLES[key]
@@ -215,7 +215,7 @@ class LambdaHandler(object):
                     key,
                     value
                 ))
-            # Environement variable keys can't be Unicode
+            # Environment variable keys can't be Unicode
             # https://github.com/Miserlou/Zappa/issues/604
             try:
                 os.environ[str(key)] = value


### PR DESCRIPTION
## Description
It's just a typo I found while browsing through zappa's source code.

It's a trivial change, so I haven't opened a ticket for it.
