### PR TITLE
fixes #1171 don't colorize partial words

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -867,6 +867,14 @@ class TestZappa(unittest.TestCase):
         colorized_string = zappa_cli.colorize_invoke_command(plain_string)
         self.assertEqual(final_string, colorized_string)
 
+    def test_cli_colorize_whole_words_only(self):
+        zappa_cli = ZappaCLI()
+        plain_string = "START RESTART END RENDER report [DEBUG] TEXT[DEBUG]TEXT"
+        final_string = "\x1b[36m\x1b[1m[START]\x1b[0m RESTART \x1b[36m\x1b[1m[END]\x1b[0m RENDER report \x1b[36m\x1b[1m[DEBUG]\x1b[0m TEXT\x1b[36m\x1b[1m[DEBUG]\x1b[0mTEXT"
+
+        colorized_string = zappa_cli.colorize_invoke_command(plain_string)
+        self.assertEqual(final_string, colorized_string)
+
     def test_cli_colorize_invoke_command_bad_string(self):
         zappa_cli = ZappaCLI()
         plain_string = "Hey, I'm a plain string, won't be colorized"

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1269,12 +1269,20 @@ class ZappaCLI(object):
             try:
                 for token in ['START', 'END', 'REPORT', '[DEBUG]']:
                     if token in final_string:
-                        format_string = '{}' if token == '[DEBUG]' else '[{}]'
-                        final_string = final_string.replace(token, click.style(
+                        format_string = '[{}]'
+                        # match whole words only
+                        pattern = r'\b{}\b'
+                        if token == '[DEBUG]':
+                            format_string = '{}'
+                            pattern = re.escape(token)
+                        repl = click.style(
                             format_string.format(token),
                             bold=True,
                             fg='cyan'
-                        ))
+                        )
+                        final_string = re.sub(
+                            pattern.format(token), repl, final_string
+                        )
             except Exception: # pragma: no cover
                 pass
 


### PR DESCRIPTION
Fix for https://github.com/Miserlou/Zappa/issues/1171

Previously words were matched by string, so RENDER became R**END**ER. This PR uses regular expressions to match whole words only. We exclude `[DEBUG]` because a) it already has the square bracket word delimiters attached, and b) `\b` doesn't work the same next to a square bracket, i.e. `re.findall(r'\b\[', ' [')` doesn't match, it needs `re.findall(r'\b\[', 'text[')`.

PS yay for <kbd>[hacktoberfest](https://github.com/Miserlou/Zappa/labels/hacktoberfest)</kbd> :tada: 
