### PR TITLE
Create a deployment UUID file in new deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
     - [Raising AWS Service Limits](#raising-aws-service-limits)
     - [Using Zappa With Docker](#using-zappa-with-docker)
     - [Dead Letter Queues](#dead-letter-queues)
+    - [Unique Deployment ID](#deployment-id)
 - [Zappa Guides](#zappa-guides)
 - [Zappa in the Press](#zappa-in-the-press)
 - [Sites Using Zappa](#sites-using-zappa)
@@ -1156,6 +1157,10 @@ If Docker is part of your team's CI, testing, or deployments, you may want to ch
 If you want to utilise [AWS Lambda's Dead Letter Queue feature](http://docs.aws.amazon.com/lambda/latest/dg/dlq.html) simply add the key `dead_letter_arn`, with the value being the complete ARN to the corresponding SNS topic or SQS queue in your `zappa_settings.json`.
 
 You must have already created the corresponding SNS/SQS topic/queue, and the Lambda function execution role must have been provisioned with read/publish/sendMessage access to the DLQ resource.
+
+### Unique Deployment ID
+
+For monitoring of different deployments, a unique UUID for each deployment is available in "deployment_id.file" in the root directory of your application's path.  You can use this ID or a hash of this file for such things as tracking errors across different deployments, monitoring status of deployments and other such things on services such as Sentry and New Relic.
 
 ## Zappa Guides
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -512,7 +512,10 @@ class Zappa(object):
         # Create deployment ID file and write to temp project path
         deployment_uuid = str(uuid.uuid4())
         deployment_id_file = open(os.path.join(temp_project_path, 'deployment_id.file'), 'w')
-        deployment_id_file.write(deployment_uuid)
+        try:
+            deployment_id_file.write(deployment_uuid)
+        except TypeError:
+            deployment_id_file.write(unicode(deployment_uuid))
         deployment_id_file.close()
 
         # Then, do site site-packages..

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -26,6 +26,7 @@ import time
 import troposphere
 import troposphere.apigateway
 import zipfile
+import uuid
 
 from builtins import int, bytes
 from botocore.exceptions import ClientError
@@ -507,6 +508,12 @@ class Zappa(object):
         if handler_file:
             filename = handler_file.split(os.sep)[-1]
             shutil.copy(handler_file, os.path.join(temp_project_path, filename))
+
+        # Create deployment ID file and write to temp project path
+        deployment_uuid = str(uuid.uuid4())
+        deployment_id_file = open(os.path.join(temp_project_path, 'deployment_id.file'), 'w')
+        deployment_id_file.write(deployment_uuid)
+        deployment_id_file.close()
 
         # Then, do site site-packages..
         egg_links = []


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Create a file with a unique UUID during each deployment which can be accessed directly or hashed to track deployments.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1214
