### PR TITLE
Add role_arn settings variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.45.1
 * Make `package_info.json` consistent across Python versions
 * Fixes to `task_sns`
+* Add `role_arn` settings variable
 
 ## 0.45.0
 * Add support for SQLite on Python 3.6 (LP bump)

--- a/README.md
+++ b/README.md
@@ -750,6 +750,7 @@ to change Zappa's behavior. Use these at your own risk!
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
         "remote_env": "s3://my-project-config-files/filename.json", // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.
         "role_name": "MyLambdaRole", // Name of Zappa execution role. Default <project_name>-<env>-ZappaExecutionRole. To use a different, pre-existing policy, you must also set manage_roles to false.
+        "role_arn": "arn:aws:iam::12345:role/app-ZappaLambdaExecutionRole", // ARN of Zappa execution role. Default to None. To use a different, pre-existing policy, you must also set manage_roles to false. This overrides role_name. Use with temporary credentials via GetFederationToken.
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
         "runtime": "python2.7", // Python runtime to use on Lambda. Can be one of "python2.7" or "python3.6". Defaults to whatever the current Python being used is.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2002,6 +2002,7 @@ class ZappaCLI(object):
         self.aws_kms_key_arn = self.stage_config.get('aws_kms_key_arn', '')
         self.context_header_mappings = self.stage_config.get('context_header_mappings', {})
         self.xray_tracing = self.stage_config.get('xray_tracing', False)
+        self.desired_role_arn = self.stage_config.get('role_arn')
 
         # Additional tags
         self.tags = self.stage_config.get('tags', {})
@@ -2012,6 +2013,7 @@ class ZappaCLI(object):
                             aws_region=self.aws_region,
                             load_credentials=self.load_credentials,
                             desired_role_name=desired_role_name,
+                            desired_role_arn=self.desired_role_arn,
                             runtime=self.runtime,
                             tags=self.tags,
                             endpoint_urls=self.stage_config.get('aws_endpoint_urls',{}),

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -230,6 +230,7 @@ class Zappa(object):
             aws_region=None,
             load_credentials=True,
             desired_role_name=None,
+            desired_role_arn=None,
             runtime='python2.7', # Detected at runtime in CLI
             tags=(),
             endpoint_urls={},
@@ -249,6 +250,9 @@ class Zappa(object):
 
         if desired_role_name:
             self.role_name = desired_role_name
+
+        if desired_role_arn:
+            self.credentials_arn = desired_role_arn
 
         self.runtime = runtime
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Adds the role_arn settings variable to avoid any use of the IAM API, which is normally used to resolve a role name to an ARN.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1218 - Support user auth with GetFederationToken
