### PR TITLE
Fix reversed args in README example for invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ For commands which have their own arguments, you can also pass the command in as
 
     $ zappa manage production "shell --version"
 
-Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `zappa <env> invoke --raw`.
+Commands which require direct user input, such as `createsuperuser`, should be [replaced by commands](http://stackoverflow.com/a/26091252) which use `zappa invoke <env> --raw`.
 
 _(Please note that commands which take over 30 seconds to execute may time-out. See [this related issue](https://github.com/Miserlou/Zappa/issues/205#issuecomment-236391248) for a work-around.)_
 


### PR DESCRIPTION
## Description

Fixes reversed args in example snippet in README for invoking remote commands.

This is my first contribution here and it seemed like it would be more helpful to open this PR than create an issue first; if the latter is still preferable I'm happy to do so. Let me know!
