### PR TITLE
Update Custom IAM policy documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ However, it's now far easier to use Route 53-based DNS authentication, which wil
 
 Amazon also provides their own free alternative to Let's Encrypt called [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (ACM).
 
-1. Verify your domain in the AWS Ceriticate Manager console.
+1. Verify your domain in the AWS Certificate Manager console.
 2. In the console, select the N. Virginia (us-east-1) region and request a certificate for your domain or subdomain (`sub.yourdomain.tld`), or request a wildcard domain (`*.yourdomain.tld`).
 3. Copy the entire ARN of that certificate and place it in the Zappa setting `certificate_arn`.
 4. Set your desired domain in the `domain` setting.


### PR DESCRIPTION
Update Custom IAM policy documentation to be more explicit about what permissions
are granted to the Lambda execution by default

## Description
Update Custom IAM policy documentation.  The documentation now states that the default execution policy applied to the Lambda is very permissive, and likely not appropriate for most production use.  This is my opinion, but I feel the appropriate advice to give to new users of Zappa who want to use this for real applications in production. 

## GitHub Issues
n/a, doc only. 
