### PR TITLE
Package custom modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ to change Zappa's behavior. Use these at your own risk!
         "manage_roles": true, // Have Zappa automatically create and define IAM execution roles and policies. Default true. If false, you must define your own IAM Role and role_name setting.
         "memory_size": 512, // Lambda function memory in MB. Default 512.
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
+        "package_custom_modules": ["your_module1, your_module2"], // zappa finds your module path (if it is importable, so if it is in sys.path or PYTHONPATH) and pack the whole module directory into zip
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'. Removing this setting will use the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables instead.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
         "remote_env": "s3://my-project-config-files/filename.json", // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2110,6 +2110,11 @@ class ZappaCLI(object):
             inspect.getfile(inspect.currentframe())))
         handler_file = os.sep.join(current_file.split(os.sep)[0:]) + os.sep + 'handler.py'
 
+        # Include packages from sys.path
+        include = list()
+        for module_name in self.stage_config.get('package_custom_modules', []):
+            include.append(os.path.dirname(importlib.import_module(module_name).__file__))
+
         # Create the zip file(s)
         if self.stage_config.get('slim_handler', False):
             # Create two zips. One with the application and the other with just the handler.
@@ -2131,6 +2136,7 @@ class ZappaCLI(object):
                 venv=self.zappa.create_handler_venv(),
                 handler_file=handler_file,
                 slim_handler=True,
+                include=include,
                 exclude=exclude,
                 output=output,
                 disable_progress=self.disable_progress
@@ -2168,6 +2174,7 @@ class ZappaCLI(object):
                 prefix=self.lambda_name,
                 handler_file=handler_file,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
+                include=include,
                 exclude=exclude,
                 output=output,
                 disable_progress=self.disable_progress

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2122,6 +2122,7 @@ class ZappaCLI(object):
             self.zip_path = self.zappa.create_lambda_zip(
                 prefix=self.lambda_name,
                 use_precompiled_packages=self.stage_config.get('use_precompiled_packages', True),
+                include=include,
                 exclude=self.stage_config.get('exclude', []),
                 disable_progress=self.disable_progress,
                 archive_format='tarball'
@@ -2136,7 +2137,6 @@ class ZappaCLI(object):
                 venv=self.zappa.create_handler_venv(),
                 handler_file=handler_file,
                 slim_handler=True,
-                include=include,
                 exclude=exclude,
                 output=output,
                 disable_progress=self.disable_progress

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -468,6 +468,10 @@ class Zappa(object):
         if exclude is None:
             exclude = list()
 
+        # Directories that should be included into zip
+        if include is None:
+            include = list()
+
         # Exclude the zip itself
         exclude.append(archive_path)
 
@@ -629,6 +633,13 @@ class Zappa(object):
             except Exception as e:
                 print(e)
                 # XXX - What should we do here?
+
+        # Then explicitly included directories
+        for directory in include:
+            copytree(   directory,
+                        os.path.join(temp_project_path, os.path.basename(directory)),
+                        symlinks=False
+                    )
 
         # Then archive it all up..
         if archive_format == 'zip':


### PR DESCRIPTION
## Description
new setting: list of module names that will be packaged into zip

## Motivation
I have many flask apps in my repository that shares common module. This module is available in the PYTHONPATH env variable which points into directory where my common module directory is. I had to copy the common module before every `zappa update` into the flask app directory to be packed into distribution zip. But with this feature I just list the common modules and they are packaged into zip automatically if they can be imported in my environment.

Now I use my custom pypi package `timo-zappa`, but I will be happy If it could be in official zappa package. I tested it on Linux, py2.7, py3.6 and as 3.6 lambda.

This is my first pull request, be gentle :)