### PR TITLE
[#1252] - Zappa Undeploy Fails when you have event source as Kinesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2461,7 +2461,7 @@ class Zappa(object):
                     function,
                     self.boto_session
                 )
-                print("Removed event " + name + " (" + str(event_source['events']) + ").")
+                print("Removed event " + name + " (" + str(event_source.get('events', [])) + ").")
 
     ###
     # Async / SNS


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
### Issue 
When you have Kinesis as event source to trigger AWS lambda, while performing "undeploy" , we are having "Key error" and undpeloy is failing.

<!-- Please describe the changes included in this PR --> 
Not every event_resource in the zappa_settings will have "events" in it. For instance Kinesis will have no entry for "events" in the configuration. So in this case, `zappa undeploy` is failing as result of KeyError - 'events'. Please refer to issue [ #1252] for detailed explanation.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

[#1252]

