### PR TITLE
Exit with non 0 error code on failed zappa invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,10 @@ You can also invoke interpretable Python 2.7 or Python 3.6 strings directly by u
 
     $ zappa invoke production "print 1 + 2 + 3" --raw
 
+If you want the zappa command to fail if the invoked command fails add the `--exit-code` argument:
+
+  $ zappa invoke production "raise Exception()" --raw --exit-code
+
 ### Django Management Commands
 
 As a convenience, Zappa can also invoke remote Django 'manage.py' commands with the `manage` command. For instance, to perform the basic Django status check:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -303,6 +303,10 @@ class ZappaCLI(object):
             '--no-color', action='store_true',
             help=("Don't color the output")
         )
+        invoke_parser.add_argument(
+            '--exit-code', action='store_true',
+            help=("Return a non 0 exit code if invoked function fails")
+        )
         invoke_parser.add_argument('command_rest')
 
         ##
@@ -319,6 +323,10 @@ class ZappaCLI(object):
         manage_parser.add_argument(
             '--no-color', action='store_true',
             help=("Don't color the output")
+        )
+        manage_parser.add_argument(
+            '--exit-code', action='store_true',
+            help=("Return a non 0 exit code if invoked function fails")
         )
         # This is explicitly added here because this is the only subcommand that doesn't inherit from env_parser
         # https://github.com/Miserlou/Zappa/issues/1002
@@ -559,6 +567,7 @@ class ZappaCLI(object):
                 self.vargs['command_rest'],
                 raw_python=self.vargs['raw'],
                 no_color=self.vargs['no_color'],
+                exit_code=self.vargs['exit_code'],
             )
         elif command == 'manage': # pragma: no cover
 
@@ -581,6 +590,7 @@ class ZappaCLI(object):
                 command,
                 command="manage",
                 no_color=self.vargs['no_color'],
+                exit_code=self.vargs['exit_code'],
             )
 
         elif command == 'tail': # pragma: no cover
@@ -1199,7 +1209,7 @@ class ZappaCLI(object):
             removed_arns = self.zappa.remove_async_sns_topic(self.lambda_name)
             click.echo('SNS Topic removed: %s' % ', '.join(removed_arns))
 
-    def invoke(self, function_name, raw_python=False, command=None, no_color=False):
+    def invoke(self, function_name, raw_python=False, command=None, no_color=False, exit_code=False):
         """
         Invoke a remote function.
         """
@@ -1233,6 +1243,11 @@ class ZappaCLI(object):
                 print(colorized)
         else:
             print(response)
+        # For a successful request FunctionError is not in response.
+        if exit_code and 'FunctionError' in response:
+            raise ClickException(
+                "{} error occured while invoking command.".format(response['FunctionError'])
+            )
 
     def format_invoke_command(self, string):
         """


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
We use `zappa invoke` in our CI. Right now if the invoked command fails the error is printed, but no exit code is given. This PR adds a CLI argument (`--exit-code`) which will result in the invoke command failing if the invoked function failed. This was added as an extra CLI argument to keep the current behavior for people depending on it.

This PR still misses a test, I'd love some help guiding me in the right direction on how I would write one for this.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

