### PR TITLE
Add support for AWS Cognito Triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,13 @@ to change Zappa's behavior. Use these at your own risk!
         "cloudwatch_log_level": "OFF", // Enables/configures a level of logging for the given staging. Available options: "OFF", "INFO", "ERROR", default "OFF". C
         "cloudwatch_data_trace": false, // Logs all data about received events. Default false.
         "cloudwatch_metrics_enabled": false, // Additional metrics for the API Gateway. Default false.
+        "cognito": {
+            "user_pool": "user-pool-id", // User pool ID from AWS Cognito
+            "triggers": [{"source": "PreSignUp_SignUp", // triggerSource from http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-pre-signup
+                          "function": "my_app.pre_signup_function"
+                         }
+                        ]
+                    }
         "context_header_mappings": { "HTTP_header_name": "API_Gateway_context_variable" }, // A dictionary mapping HTTP header names to API Gateway context variables
         "cors": false, // Enable Cross-Origin Resource Sharing. Default false. If true, simulates the "Enable CORS" button on the API Gateway console. Can also be a dictionary specifying lists of "allowed_headers", "allowed_methods", and string of "allowed_origin"
         "dead_letter_arn": "arn:aws:<sns/sqs>:::my-topic/queue", // Optional Dead Letter configuration for when Lambda async invoke fails thrice

--- a/test_settings.json
+++ b/test_settings.json
@@ -34,7 +34,15 @@
                    ]
                }
            }
-       ]
+       ],
+       "cognito": {
+           "user_pool": "user-pool-id",
+           "triggers": [
+                {"source": "PreSignUp_SignUp",
+                 "function": "test.tasks.pre_signup_function"
+                }
+            ]
+      }
     },
     "devor": {
        "s3_bucket": "lmbda",

--- a/tests/placebo/TestZappa.test_cli_aws/cognito-idp.DescribeUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/cognito-idp.DescribeUserPool_1.json
@@ -1,0 +1,280 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserPool": {
+            "Id": "us-east-1_9jUv74DH8",
+            "Name": "Zappa-Test",
+            "Policies": {
+                "PasswordPolicy": {
+                    "MinimumLength": 8,
+                    "RequireUppercase": true,
+                    "RequireLowercase": true,
+                    "RequireNumbers": true,
+                    "RequireSymbols": true
+                }
+            },
+            "LambdaConfig": {
+                "PreSignUp": "arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test"
+            },
+            "LastModifiedDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 23,
+                "second": 34,
+                "microsecond": 969000
+            },
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 15,
+                "second": 36,
+                "microsecond": 195000
+            },
+            "SchemaAttributes": [
+                {
+                    "Name": "sub",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": false,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "1",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "given_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "family_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "middle_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "nickname",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "preferred_username",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "profile",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "picture",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "website",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "gender",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "birthdate",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "10",
+                        "MaxLength": "10"
+                    }
+                },
+                {
+                    "Name": "zoneinfo",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "locale",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "address",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "updated_at",
+                    "AttributeDataType": "Number",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "NumberAttributeConstraints": {
+                        "MinValue": "0"
+                    }
+                }
+            ],
+            "AutoVerifiedAttributes": [
+                "email"
+            ],
+            "VerificationMessageTemplate": {
+                "DefaultEmailOption": "CONFIRM_WITH_CODE"
+            },
+            "MfaConfiguration": "OFF",
+            "EstimatedNumberOfUsers": 0,
+            "EmailConfiguration": {},
+            "UserPoolTags": {},
+            "AdminCreateUserConfig": {
+                "AllowAdminCreateUserOnly": false,
+                "UnusedAccountValidityDays": 7
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:31 GMT",
+                "x-amzn-requestid": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+                "content-length": "4132",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_aws/cognito-idp.UpdateUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/cognito-idp.UpdateUserPool_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT",
+                "x-amzn-requestid": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+                "content-length": "2",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_aws/lambda.AddPermission_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.AddPermission_1.json
@@ -1,10 +1,18 @@
 {
-    "status_code": 201, 
+    "status_code": 201,
     "data": {
-        "Statement": "{\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:events:us-east-1:724336686645:rule/zappa-keep-warm-zappa-ttt666\"}},\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt666\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Sid\":\"D168VLOG\"}", 
         "ResponseMetadata": {
-            "HTTPStatusCode": 201, 
-            "RequestId": "53ac22de-28f4-11e6-9feb-e32cbf4d45d4"
-        }
+            "RequestId": "ae983eab-d365-11e7-ba13-8135763ed363",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "date": "Mon, 27 Nov 2017 11:25:33 GMT",
+                "content-type": "application/json",
+                "content-length": "361",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "ae983eab-d365-11e7-ba13-8135763ed363"
+            },
+            "RetryAttempts": 0
+        },
+        "Statement": "{\"Sid\":\"9UFS02MW\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cognito-idp.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test\",\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:cognito-idp:us-east-1:12345:userpool/us-east-1_9jUv74DH8\"}}}"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sts.GetCallerIdentity_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sts.GetCallerIdentity_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "RANDOMSTRING12314",
+        "Account": "12345",
+        "Arn": "arn:aws:iam::12345:user/test",
+        "ResponseMetadata": {
+            "RequestId": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+                "content-type": "text/xml",
+                "content-length": "401",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_cognito_triggers/cognito-idp.DescribeUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cli_cognito_triggers/cognito-idp.DescribeUserPool_1.json
@@ -1,0 +1,280 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserPool": {
+            "Id": "us-east-1_9jUv74DH8",
+            "Name": "Zappa-Test",
+            "Policies": {
+                "PasswordPolicy": {
+                    "MinimumLength": 8,
+                    "RequireUppercase": true,
+                    "RequireLowercase": true,
+                    "RequireNumbers": true,
+                    "RequireSymbols": true
+                }
+            },
+            "LambdaConfig": {
+                "PreSignUp": "arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test"
+            },
+            "LastModifiedDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 23,
+                "second": 34,
+                "microsecond": 969000
+            },
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 15,
+                "second": 36,
+                "microsecond": 195000
+            },
+            "SchemaAttributes": [
+                {
+                    "Name": "sub",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": false,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "1",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "given_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "family_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "middle_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "nickname",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "preferred_username",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "profile",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "picture",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "website",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "gender",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "birthdate",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "10",
+                        "MaxLength": "10"
+                    }
+                },
+                {
+                    "Name": "zoneinfo",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "locale",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "address",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "updated_at",
+                    "AttributeDataType": "Number",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "NumberAttributeConstraints": {
+                        "MinValue": "0"
+                    }
+                }
+            ],
+            "AutoVerifiedAttributes": [
+                "email"
+            ],
+            "VerificationMessageTemplate": {
+                "DefaultEmailOption": "CONFIRM_WITH_CODE"
+            },
+            "MfaConfiguration": "OFF",
+            "EstimatedNumberOfUsers": 0,
+            "EmailConfiguration": {},
+            "UserPoolTags": {},
+            "AdminCreateUserConfig": {
+                "AllowAdminCreateUserOnly": false,
+                "UnusedAccountValidityDays": 7
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:31 GMT",
+                "x-amzn-requestid": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+                "content-length": "4132",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_cognito_triggers/cognito-idp.UpdateUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cli_cognito_triggers/cognito-idp.UpdateUserPool_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT",
+                "x-amzn-requestid": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+                "content-length": "2",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_cognito_triggers/lambda.AddPermission_1.json
+++ b/tests/placebo/TestZappa.test_cli_cognito_triggers/lambda.AddPermission_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "ae983eab-d365-11e7-ba13-8135763ed363",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "date": "Mon, 27 Nov 2017 11:25:33 GMT",
+                "content-type": "application/json",
+                "content-length": "361",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "ae983eab-d365-11e7-ba13-8135763ed363"
+            },
+            "RetryAttempts": 0
+        },
+        "Statement": "{\"Sid\":\"9UFS02MW\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cognito-idp.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test\",\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:cognito-idp:us-east-1:12345:userpool/us-east-1_9jUv74DH8\"}}}"
+    }
+}

--- a/tests/placebo/TestZappa.test_cli_cognito_triggers/sts.GetCallerIdentity_1.json
+++ b/tests/placebo/TestZappa.test_cli_cognito_triggers/sts.GetCallerIdentity_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "RANDOMSTRING12314",
+        "Account": "12345",
+        "Arn": "arn:aws:iam::12345:user/test",
+        "ResponseMetadata": {
+            "RequestId": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+                "content-type": "text/xml",
+                "content-length": "401",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger/cognito-idp.DescribeUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger/cognito-idp.DescribeUserPool_1.json
@@ -1,0 +1,280 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserPool": {
+            "Id": "us-east-1_9jUv74DH8",
+            "Name": "Zappa-Test",
+            "Policies": {
+                "PasswordPolicy": {
+                    "MinimumLength": 8,
+                    "RequireUppercase": true,
+                    "RequireLowercase": true,
+                    "RequireNumbers": true,
+                    "RequireSymbols": true
+                }
+            },
+            "LambdaConfig": {
+                "PreSignUp": "arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test"
+            },
+            "LastModifiedDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 23,
+                "second": 34,
+                "microsecond": 969000
+            },
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 15,
+                "second": 36,
+                "microsecond": 195000
+            },
+            "SchemaAttributes": [
+                {
+                    "Name": "sub",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": false,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "1",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "given_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "family_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "middle_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "nickname",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "preferred_username",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "profile",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "picture",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "website",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "gender",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "birthdate",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "10",
+                        "MaxLength": "10"
+                    }
+                },
+                {
+                    "Name": "zoneinfo",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "locale",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "address",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "updated_at",
+                    "AttributeDataType": "Number",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "NumberAttributeConstraints": {
+                        "MinValue": "0"
+                    }
+                }
+            ],
+            "AutoVerifiedAttributes": [
+                "email"
+            ],
+            "VerificationMessageTemplate": {
+                "DefaultEmailOption": "CONFIRM_WITH_CODE"
+            },
+            "MfaConfiguration": "OFF",
+            "EstimatedNumberOfUsers": 0,
+            "EmailConfiguration": {},
+            "UserPoolTags": {},
+            "AdminCreateUserConfig": {
+                "AllowAdminCreateUserOnly": false,
+                "UnusedAccountValidityDays": 7
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:31 GMT",
+                "x-amzn-requestid": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+                "content-length": "4132",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger/cognito-idp.UpdateUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger/cognito-idp.UpdateUserPool_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT",
+                "x-amzn-requestid": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+                "content-length": "2",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger/lambda.AddPermission_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger/lambda.AddPermission_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "ae983eab-d365-11e7-ba13-8135763ed363",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "date": "Mon, 27 Nov 2017 11:25:33 GMT",
+                "content-type": "application/json",
+                "content-length": "361",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "ae983eab-d365-11e7-ba13-8135763ed363"
+            },
+            "RetryAttempts": 0
+        },
+        "Statement": "{\"Sid\":\"9UFS02MW\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cognito-idp.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test\",\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:cognito-idp:us-east-1:12345:userpool/us-east-1_9jUv74DH8\"}}}"
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger/sts.GetCallerIdentity_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger/sts.GetCallerIdentity_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "RANDOMSTRING12314",
+        "Account": "12345",
+        "Arn": "arn:aws:iam::12345:user/test",
+        "ResponseMetadata": {
+            "RequestId": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+                "content-type": "text/xml",
+                "content-length": "401",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger_existing/cognito-idp.DescribeUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger_existing/cognito-idp.DescribeUserPool_1.json
@@ -1,0 +1,283 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserPool": {
+            "Id": "us-east-1_9jUv74DH8",
+            "Name": "Zappa-Test",
+            "Policies": {
+                "PasswordPolicy": {
+                    "MinimumLength": 8,
+                    "RequireUppercase": true,
+                    "RequireLowercase": true,
+                    "RequireNumbers": true,
+                    "RequireSymbols": true
+                }
+            },
+            "LambdaConfig": {
+                "PreSignUp": "arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test"
+            },
+            "LastModifiedDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 23,
+                "second": 34,
+                "microsecond": 969000
+            },
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 11,
+                "day": 27,
+                "hour": 11,
+                "minute": 15,
+                "second": 36,
+                "microsecond": 195000
+            },
+            "SchemaAttributes": [
+                {
+                    "Name": "sub",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": false,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "1",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "given_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "family_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "middle_name",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "nickname",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "preferred_username",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "profile",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "picture",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "website",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": true,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "email_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "gender",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "birthdate",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "10",
+                        "MaxLength": "10"
+                    }
+                },
+                {
+                    "Name": "zoneinfo",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "locale",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "phone_number_verified",
+                    "AttributeDataType": "Boolean",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false
+                },
+                {
+                    "Name": "address",
+                    "AttributeDataType": "String",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "StringAttributeConstraints": {
+                        "MinLength": "0",
+                        "MaxLength": "2048"
+                    }
+                },
+                {
+                    "Name": "updated_at",
+                    "AttributeDataType": "Number",
+                    "DeveloperOnlyAttribute": false,
+                    "Mutable": true,
+                    "Required": false,
+                    "NumberAttributeConstraints": {
+                        "MinValue": "0"
+                    }
+                }
+            ],
+            "AutoVerifiedAttributes": [
+                "email"
+            ],
+            "VerificationMessageTemplate": {
+                "DefaultEmailOption": "CONFIRM_WITH_CODE"
+            },
+            "MfaConfiguration": "OFF",
+            "EstimatedNumberOfUsers": 0,
+            "EmailConfiguration": {},
+            "UserPoolTags": {},
+            "AdminCreateUserConfig": {
+                "AllowAdminCreateUserOnly": false,
+                "UnusedAccountValidityDays": 7
+            },
+            "LambdaConfig": [
+                {"PreSignUp": "arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test"}
+            ]
+        },
+        "ResponseMetadata": {
+            "RequestId": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:31 GMT",
+                "x-amzn-requestid": "ada5049e-d365-11e7-9a5a-2b0966933efa",
+                "content-length": "4132",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger_existing/cognito-idp.UpdateUserPool_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger_existing/cognito-idp.UpdateUserPool_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT",
+                "x-amzn-requestid": "adc3afdf-d365-11e7-b51f-abb88dfb5619",
+                "content-length": "2",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger_existing/lambda.AddPermission_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger_existing/lambda.AddPermission_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "ae983eab-d365-11e7-ba13-8135763ed363",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "date": "Mon, 27 Nov 2017 11:25:33 GMT",
+                "content-type": "application/json",
+                "content-length": "361",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "ae983eab-d365-11e7-ba13-8135763ed363"
+            },
+            "RetryAttempts": 0
+        },
+        "Statement": "{\"Sid\":\"9UFS02MW\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cognito-idp.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test\",\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:cognito-idp:us-east-1:12345:userpool/us-east-1_9jUv74DH8\"}}}"
+    }
+}

--- a/tests/placebo/TestZappa.test_cognito_trigger_existing/sts.GetCallerIdentity_1.json
+++ b/tests/placebo/TestZappa.test_cognito_trigger_existing/sts.GetCallerIdentity_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "RANDOMSTRING12314",
+        "Account": "12345",
+        "Arn": "arn:aws:iam::12345:user/test",
+        "ResponseMetadata": {
+            "RequestId": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ae5ff039-d365-11e7-ba9b-9d9eb3cc14f8",
+                "content-type": "text/xml",
+                "content-length": "401",
+                "date": "Mon, 27 Nov 2017 11:25:32 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -127,3 +127,26 @@ class TestZappa(unittest.TestCase):
             response['body'],
             'https://zappa:80/return/request/url'
         )
+
+    def test_wsgi_script_on_cognito_event_request(self):
+        """
+        Ensure that requests sent by cognito behave sensibly
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+
+        event = {'version': '1',
+                 'region': 'eu-west-1',
+                 'userPoolId': 'region_poolID',
+                 'userName': 'uuu-id-here',
+                 'callerContext': {'awsSdkVersion': 'aws-sdk-js-2.149.0',
+                                   'clientId': 'client-id-here'},
+                 'triggerSource': 'PreSignUp_SignUp',
+                 'request': {'userAttributes':
+                             {'email': 'email@example.com'}, 'validationData': None},
+                 'response': {'autoConfirmUser': False,
+                              'autoVerifyEmail': False,
+                              'autoVerifyPhone': False}}
+
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['response']['autoConfirmUser'], False)

--- a/tests/test_wsgi_script_name_settings.py
+++ b/tests/test_wsgi_script_name_settings.py
@@ -9,3 +9,4 @@ DOMAIN = 'api.example.com'
 ENVIRONMENT_VARIABLES = {}
 LOG_LEVEL = 'DEBUG'
 PROJECT_NAME = 'wsgi_script_name_settings'
+COGNITO_TRIGGER_MAPPING = {}

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -465,5 +465,11 @@ class TestZappa(unittest.TestCase):
         remove_event_source(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
         # get_event_source_status(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
 
+    @placebo_session
+    def test_cognito_trigger(self, session):
+        z = Zappa(session)
+        z.update_cognito('Zappa-Trigger-Test', 'us-east-1_9jUv74DH8', {'PreSignUp': 'test.tasks.pre_signup'}, 'arn:aws:lambda:us-east-1:575873786340:function:Zappa-Trigger-Test')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -468,7 +468,23 @@ class TestZappa(unittest.TestCase):
     @placebo_session
     def test_cognito_trigger(self, session):
         z = Zappa(session)
-        z.update_cognito('Zappa-Trigger-Test', 'us-east-1_9jUv74DH8', {'PreSignUp': 'test.tasks.pre_signup'}, 'arn:aws:lambda:us-east-1:575873786340:function:Zappa-Trigger-Test')
+        z.update_cognito('Zappa-Trigger-Test', 'us-east-1_9jUv74DH8', {'PreSignUp': 'test.tasks.pre_signup'}, 'arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test')
+
+    @placebo_session
+    def test_cognito_trigger_existing(self, session):
+        z = Zappa(session)
+        z.update_cognito('Zappa-Trigger-Test', 'us-east-1_9jUv74DH8', {'PreSignUp': 'test.tasks.pre_signup'}, 'arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test')
+
+    @placebo_session
+    def test_cli_cognito_triggers(self, session):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+        zappa_cli.api_key_required = True
+        zappa_cli.load_settings('test_settings.json', session)
+        zappa_cli.lambda_arn = 'arn:aws:lambda:us-east-1:12345:function:Zappa-Trigger-Test'
+        zappa_cli.update_cognito_triggers()
+
+
 
 
 if __name__ == '__main__':

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -989,13 +989,7 @@ class ZappaCLI(object):
 
         # Update any cognito pool with the lambda arn
         # do this after schedule as schedule clears the lambda policy and we need to add one
-        if self.cognito:
-            user_pool = self.cognito.get('user_pool')
-            triggers = self.cognito.get('triggers', [])
-            lambda_configs = set()
-            for trigger in triggers:
-                lambda_configs.add(trigger['source'].split('_')[0])
-            self.zappa.update_cognito(self.lambda_name, user_pool, lambda_configs, self.lambda_arn)
+        self.update_cognito_triggers()
 
         self.callback('post')
 
@@ -1101,6 +1095,18 @@ class ZappaCLI(object):
             self.zappa.remove_lambda_function_logs(self.lambda_name)
 
         click.echo(click.style("Done", fg="green", bold=True) + "!")
+
+    def update_cognito_triggers(self):
+        """
+        Update any cognito triggers
+        """
+        if self.cognito:
+            user_pool = self.cognito.get('user_pool')
+            triggers = self.cognito.get('triggers', [])
+            lambda_configs = set()
+            for trigger in triggers:
+                lambda_configs.add(trigger['source'].split('_')[0])
+            self.zappa.update_cognito(self.lambda_name, user_pool, lambda_configs, self.lambda_arn)
 
     def schedule(self):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -987,6 +987,16 @@ class ZappaCLI(object):
 
         self.schedule()
 
+        # Update any cognito pool with the lambda arn
+        # do this after schedule as schedule clears the lambda policy and we need to add one
+        if self.cognito:
+            user_pool = self.cognito.get('user_pool')
+            triggers = self.cognito.get('triggers', [])
+            lambda_configs = set()
+            for trigger in triggers:
+                lambda_configs.add(trigger['source'].split('_')[0])
+            self.zappa.update_cognito(self.lambda_name, user_pool, lambda_configs, self.lambda_arn)
+
         self.callback('post')
 
         if endpoint_url and 'https://' not in endpoint_url:
@@ -1971,6 +1981,7 @@ class ZappaCLI(object):
         self.timeout_seconds = self.stage_config.get('timeout_seconds', 30)
         dead_letter_arn = self.stage_config.get('dead_letter_arn', '')
         self.dead_letter_config = {'TargetArn': dead_letter_arn} if dead_letter_arn else {}
+        self.cognito = self.stage_config.get('cognito', None)
 
         # Provide legacy support for `use_apigateway`, now `apigateway_enabled`.
         # https://github.com/Miserlou/Zappa/issues/490
@@ -2292,6 +2303,17 @@ class ZappaCLI(object):
                 if arn and function:
                     event_mapping[arn] = function
             settings_s = settings_s + "AWS_EVENT_MAPPING={0!s}\n".format(event_mapping)
+
+            # Map cognito triggers
+            cognito_trigger_mapping = {}
+            cognito_config = self.stage_config.get('cognito', {})
+            triggers = cognito_config.get('triggers', [])
+            for trigger in triggers:
+                source = trigger.get('source')
+                function = trigger.get('function')
+                if source and function:
+                    cognito_trigger_mapping[source] = function
+            settings_s = settings_s + "COGNITO_TRIGGER_MAPPING={0!s}\n".format(cognito_trigger_mapping)
 
             # Authorizer config
             authorizer_function = self.authorizer.get('function', None)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -296,6 +296,8 @@ class Zappa(object):
             self.sns_client = self.boto_client('sns')
             self.cf_client = self.boto_client('cloudformation')
             self.dynamodb_client = self.boto_client('dynamodb')
+            self.cognito_client = self.boto_client('cognito-idp')
+            self.sts_client = self.boto_client('sts')
 
         self.tags = tags
         self.cf_template = troposphere.Template()
@@ -1697,6 +1699,42 @@ class Zappa(object):
                     self.get_patch_op('metrics/enabled', cloudwatch_metrics_enabled),
                 ]
             )
+
+    def update_cognito(self, lambda_name, user_pool, lambda_configs, lambda_arn):
+        LambdaConfig = {}
+        for config in lambda_configs:
+            LambdaConfig[config] = lambda_arn
+        description = self.cognito_client.describe_user_pool(UserPoolId=user_pool)
+        description_kwargs = {}
+        for key, value in description['UserPool'].items():
+            if key in ('UserPoolId', 'Policies', 'AutoVerifiedAttributes', 'SmsVerificationMessage',
+                       'EmailVerificationMessage', 'EmailVerificationSubject', 'VerificationMessageTemplate',
+                       'SmsAuthenticationMessage', 'MfaConfiguration', 'DeviceConfiguration',
+                       'EmailConfiguration', 'SmsConfiguration', 'UserPoolTags',
+                       'AdminCreateUserConfig'):
+                description_kwargs[key] = value
+            elif key is 'LambdaConfig':
+                for lckey, lcvalue in value.items():
+                    if lckey in LambdaConfig:
+                        value[lckey] = LambdaConfig[lckey]
+                print("value", value)
+                description_kwargs[key] = value
+        if 'LambdaConfig' not in description_kwargs:
+            description_kwargs['LambdaConfig'] = LambdaConfig
+        result = self.cognito_client.update_user_pool(UserPoolId=user_pool, **description_kwargs)
+        if result['ResponseMetadata']['HTTPStatusCode'] != 200:
+            print("Cognito:  Failed to update user pool", result)
+
+        # Now we need to add a policy to the IAM that allows cognito access
+        result = self.create_event_permission(lambda_name,
+                                              'cognito-idp.amazonaws.com',
+                                              'arn:aws:cognito-idp:{}:{}:userpool/{}'.
+                                              format(self.aws_region,
+                                                     self.sts_client.get_caller_identity().get('Account'),
+                                                     user_pool)
+                                              )
+        if result['ResponseMetadata']['HTTPStatusCode'] != 201:
+            print("Cognito:  Failed to update lambda permission", result)
 
     def delete_stack(self, name, wait=False):
         """

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -303,6 +303,13 @@ class LambdaHandler(object):
 
         return None
 
+    def get_function_for_cognito_trigger(self, trigger):
+        """
+        Get the associated function to execute for a cognito trigger
+        """
+        print("get_function_for_cognito_trigger", self.settings.COGNITO_TRIGGER_MAPPING, trigger, self.settings.COGNITO_TRIGGER_MAPPING.get(trigger))
+        return self.settings.COGNITO_TRIGGER_MAPPING.get(trigger)
+
     def handler(self, event, context):
         """
         An AWS Lambda function which parses specific API Gateway input into a
@@ -400,6 +407,19 @@ class LambdaHandler(object):
             else:
                 logger.error("Cannot find a function to process the authorization request.")
                 raise Exception('Unauthorized')
+
+        # This is an AWS Cognito Trigger Event
+        elif event.get('triggerSource', None):
+            triggerSource = event.get('triggerSource')
+            whole_function = self.get_function_for_cognito_trigger(triggerSource)
+            result = event
+            if whole_function:
+                app_function = self.import_module_and_get_function(whole_function)
+                result = self.run_function(app_function, event, context)
+                logger.debug(result)
+            else:
+                logger.error("Cannot find a function to handle cognito trigger {}".format(triggerSource))
+            return result
 
         # Normal web app flow
         try:


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Add support for configuring AWS Cognito triggers.
You can now map any of the triggerSources documented
http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html to any function in your Zappa deployment.

This allows for extensive, simple customisation of the AWS Cognito authentication flow, so you can automatically approve users from defined domains.   If you need to check those domains against blacklists in your DB you have all the same access to DB records from the handler.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
