### PR TITLE
Removing Null profile region

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1661,12 +1661,15 @@ class ZappaCLI(object):
         zappa_settings = {
             env: {
                 'profile_name': profile_name,
-                'aws_region': profile_region,
                 's3_bucket': bucket,
                 'runtime': 'python3.6' if sys.version_info[0] == 3 else 'python2.7',
                 'project_name': self.get_project_name()
             }
         }
+        
+        if profile_region:
+          zappa_settings[env]['aws_region'] = profile_region
+        
         if has_django:
             zappa_settings[env]['django_settings'] = django_settings
         else:


### PR DESCRIPTION
If there is not a profile region we don't set the null key.

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
I haven't tested this, just did a Github edit PR. This should address these edge cases though from PR below

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1273 

