### PR TITLE
Require Django <2.0 for Python 2.7 compatibility

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coveralls>=1.1
 coverage>=4.3.1
-Django>=1.10.5
+Django>=1.10.5,<2.0
 Flask>=0.12
 mock>=2.0.0
 nose>=1.3.7


### PR DESCRIPTION
`test_requirements.txt` just specifies a minimum version of Django, not a maximum. However, the latest version of Django, 2.0, [does not support Python 2.7](https://docs.djangoproject.com/en/2.0/releases/2.0/#python-compatibility). Thus the Python 2.7 tests always fail.