### PR TITLE
Securely create temporary directory for Let's Encrypt processing

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1209,16 +1209,23 @@ class TestZappa(unittest.TestCase):
 
         # We need a fake account key and crt
         import subprocess
-        proc = subprocess.Popen(["openssl genrsa 2048 > /tmp/account.key"],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        out, err = proc.communicate()
-        if proc.returncode != 0:
-            raise IOError("OpenSSL Error: {0}".format(err))
-        proc = subprocess.Popen(["openssl req -x509 -newkey rsa:2048 -subj '/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com' -passout pass:foo -keyout /tmp/key.key -out test_signed.crt -days 1 > /tmp/signed.crt"],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        out, err = proc.communicate()
-        if proc.returncode != 0:
-            raise IOError("OpenSSL Error: {0}".format(err))
+        out = subprocess.check_output(['openssl', 'genrsa', '2048'])
+        with open('/tmp/account.key', 'wb') as f:
+            f.write(out)
+
+        cmd = [
+            'openssl', 'req',
+            '-x509',
+            '-newkey', 'rsa:2048',
+            '-subj', '/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com',
+            '-passout', 'pass:foo',
+            '-keyout', '/tmp/key.key',
+            '-out', 'test_signed.crt',
+            '-days', '1'
+        ]
+        out = subprocess.check_output(cmd)
+        with open('/tmp/signed.crt', 'wb') as f:
+            f.write(out)
 
         DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
         CA = "https://acme-staging.api.letsencrypt.org"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1260,9 +1260,7 @@ class TestZappa(unittest.TestCase):
         zappa_cli = ZappaCLI()
         zappa_cli.api_stage = 'ttt888'
         zappa_cli.load_settings('test_settings.json')
-        get_cert_and_update_domain(zappa_cli, 'kerplah', 'zzzz', domain=None, clean_up=True)
-
-        cleanup()
+        get_cert_and_update_domain(zappa_cli, 'kerplah', 'zzzz', domain=None)
 
 
     def test_certify_sanity_checks(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1266,7 +1266,6 @@ class TestZappa(unittest.TestCase):
     def test_certify_sanity_checks(self):
         """
         Make sure 'zappa certify':
-        * Writes a warning with the --no-cleanup flag.
         * Errors out when a deployment hasn't taken place.
         * Writes errors when certificate settings haven't been specified.
         * Calls Zappa correctly for creates vs. updates.
@@ -1279,15 +1278,11 @@ class TestZappa(unittest.TestCase):
             zappa_cli = ZappaCLI()
             zappa_cli.domain = "test.example.com"
             try:
-                zappa_cli.certify(no_cleanup=True)
+                zappa_cli.certify()
             except AttributeError:
                 # Since zappa_cli.zappa isn't initalized, the certify() call
                 # fails when it tries to inspect what Zappa has deployed.
                 pass
-
-            log_output = sys.stdout.getvalue()
-            self.assertIn("You are calling certify with", log_output)
-            self.assertIn("--no-cleanup", log_output)
 
             class ZappaMock(object):
                 def __init__(self):
@@ -1383,7 +1378,7 @@ class TestZappa(unittest.TestCase):
                 "certificate_chain": cert_file.name
             })
             sys.stdout.truncate(0)
-            zappa_cli.certify(no_cleanup=True)
+            zappa_cli.certify()
             self.assertEquals(len(zappa_cli.zappa.calls), 2)
             self.assertTrue(zappa_cli.zappa.calls[0][0] == "create_domain_name")
             self.assertTrue(zappa_cli.zappa.calls[1][0] == "update_route53_records")
@@ -1393,7 +1388,7 @@ class TestZappa(unittest.TestCase):
             zappa_cli.zappa.calls = []
             zappa_cli.zappa.domain_names["test.example.com"] = "*.example.com"
             sys.stdout.truncate(0)
-            zappa_cli.certify(no_cleanup=True)
+            zappa_cli.certify()
             self.assertEquals(len(zappa_cli.zappa.calls), 1)
             self.assertTrue(zappa_cli.zappa.calls[0][0] == "update_domain_name")
             log_output = sys.stdout.getvalue()
@@ -1406,7 +1401,7 @@ class TestZappa(unittest.TestCase):
             zappa_cli.zappa.calls = []
             zappa_cli.zappa.domain_names["test.example.com"] = ""
             sys.stdout.truncate(0)
-            zappa_cli.certify(no_cleanup=True)
+            zappa_cli.certify()
             self.assertEquals(len(zappa_cli.zappa.calls), 1)
             self.assertTrue(zappa_cli.zappa.calls[0][0] == "create_domain_name")
             log_output = sys.stdout.getvalue()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1219,10 +1219,11 @@ class TestZappa(unittest.TestCase):
             '-subj', '/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com',
             '-passout', 'pass:foo',
             '-keyout', os.path.join(gettempdir(), 'key.key'),
-            '-out', os.path.join(gettempdir(), 'test_signed.crt'),
+            '-out', os.path.join(gettempdir(), 'signed.crt'),
             '-days', '1'
         ]
-        subprocess.check_call(cmd)
+        devnull = open(os.devnull, 'wb')
+        subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
 
         DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
         CA = "https://acme-staging.api.letsencrypt.org"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1208,7 +1208,8 @@ class TestZappa(unittest.TestCase):
     def test_lets_encrypt_sanity(self):
         # We need a fake account key and crt
         import subprocess
-        out = subprocess.check_output(['openssl', 'genrsa', '2048'])
+        devnull = open(os.devnull, 'wb')
+        out = subprocess.check_output(['openssl', 'genrsa', '2048'], stderr=devnull)
         with open(os.path.join(gettempdir(), 'account.key'), 'wb') as f:
             f.write(out)
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -233,11 +233,6 @@ class ZappaCLI(object):
             help='Create and install SSL certificate'
         )
         cert_parser.add_argument(
-            '--no-cleanup', action='store_true',
-            help=("Don't remove certificate files from /tmp during certify."
-                  " Dangerous.")
-        )
-        cert_parser.add_argument(
             '--manual', action='store_true',
             help=("Gets new Let's Encrypt certificates, but prints them to console."
                 "Does not update API Gateway domains.")
@@ -605,7 +600,6 @@ class ZappaCLI(object):
             self.status(return_json=self.vargs['json'])
         elif command == 'certify': # pragma: no cover
             self.certify(
-                no_cleanup=self.vargs['no_cleanup'],
                 no_confirm=self.vargs['yes'],
                 manual=self.vargs['manual']
             )
@@ -1729,7 +1723,7 @@ class ZappaCLI(object):
 
         return
 
-    def certify(self, no_cleanup=False, no_confirm=True, manual=False):
+    def certify(self, no_confirm=True, manual=False):
         """
         Register or update a domain certificate for this env.
         """
@@ -1741,15 +1735,6 @@ class ZappaCLI(object):
             confirm = input("Are you sure you want to certify? [y/n] ")
             if confirm != 'y':
                 return
-
-        # Give warning on --no-cleanup
-        if no_cleanup:
-            clean_up = False
-            click.echo(click.style("Warning!", fg="red", bold=True) + " You are calling certify with " +
-                       click.style("--no-cleanup", bold=True) +
-                       ". Your certificate files will remain in the system temporary directory after this command executes!")
-        else:
-            clean_up = True
 
         # Make sure this isn't already deployed.
         deployed_versions = self.zappa.get_lambda_function_versions(self.lambda_name)
@@ -1808,23 +1793,14 @@ class ZappaCLI(object):
 
         # Let's Encrypt
         if not cert_location and not cert_arn:
-            from .letsencrypt import get_cert_and_update_domain, cleanup
+            from .letsencrypt import get_cert_and_update_domain
             cert_success = get_cert_and_update_domain(
                     self.zappa,
                     self.lambda_name,
                     self.api_stage,
                     self.domain,
-                    clean_up,
                     manual
                 )
-
-            # Deliberately undocumented feature (for now, at least.)
-            # We are giving the user the ability to shoot themselves in the foot.
-            # _This is probably not a good idea._
-            # However, I am sick and tired of hitting the Let's Encrypt cert
-            # limit while testing.
-            if clean_up:
-                cleanup()
 
         # Custom SSL / ACM
         else:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2325,11 +2325,12 @@ class ZappaCLI(object):
             settings_s += "ASYNC_RESPONSE_TABLE='{0!s}'\n".format(async_response_table)
 
             # Lambda requires a specific chmod
-            temp_settings = tempfile.NamedTemporaryFile()
+            temp_settings = tempfile.NamedTemporaryFile(delete=False)
             os.chmod(temp_settings.name, 0o644)
             temp_settings.write(bytes(settings_s, "utf-8"))
             temp_settings.close()
             lambda_zip.write(temp_settings.name, 'zappa_settings.py')
+            os.unlink(temp_settings.name)
 
     def remove_local_zip(self):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2325,12 +2325,11 @@ class ZappaCLI(object):
             settings_s += "ASYNC_RESPONSE_TABLE='{0!s}'\n".format(async_response_table)
 
             # Lambda requires a specific chmod
-            temp_settings = tempfile.NamedTemporaryFile(delete=False)
+            temp_settings = tempfile.NamedTemporaryFile()
             os.chmod(temp_settings.name, 0o644)
             temp_settings.write(bytes(settings_s, "utf-8"))
             temp_settings.close()
             lambda_zip.write(temp_settings.name, 'zappa_settings.py')
-            os.remove(temp_settings.name)
 
     def remove_local_zip(self):
         """

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1777,12 +1777,13 @@ class ZappaCLI(object):
                                      " or " + click.style("certificate_arn", fg="red", bold=True) + " configured!")
 
             # Get install account_key to /tmp/account_key.pem
+            from .letsencrypt import gettempdir
             if account_key_location.startswith('s3://'):
                 bucket, key_name = parse_s3_url(account_key_location)
-                self.zappa.s3_client.download_file(bucket, key_name, '{}/account.key'.format(tempfile.gettempdir()))
+                self.zappa.s3_client.download_file(bucket, key_name, os.path.join(gettempdir(), 'account.key'))
             else:
                 from shutil import copyfile
-                copyfile(account_key_location, '{}/account.key'.format(tempfile.gettempdir()))
+                copyfile(account_key_location, os.path.join(gettempdir(), 'account.key'))
 
         # Prepare for Custom SSL
         elif not account_key_location and not cert_arn:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -499,7 +499,7 @@ class Zappa(object):
             )
 
         # First, do the project..
-        temp_project_path = os.path.join(tempfile.gettempdir(), str(int(time.time())))
+        temp_project_path = tempfile.mkdtemp(prefix='zappa-project')
 
         os.makedirs(temp_project_path)
         if not slim_handler:
@@ -566,7 +566,7 @@ class Zappa(object):
 
         # Then, do site site-packages..
         egg_links = []
-        temp_package_path = os.path.join(tempfile.gettempdir(), str(int(time.time() + 1)))
+        temp_package_path = tempfile.mkdtemp(prefix='zappa-packages')
         if os.sys.platform == 'win32':
             site_packages = os.path.join(venv, 'Lib', 'site-packages')
         else:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -501,7 +501,6 @@ class Zappa(object):
         # First, do the project..
         temp_project_path = tempfile.mkdtemp(prefix='zappa-project')
 
-        os.makedirs(temp_project_path)
         if not slim_handler:
             # Slim handler does not take the project files.
             if minify:

--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -49,7 +49,6 @@ def get_cert_and_update_domain(
                                 lambda_name,
                                 api_stage,
                                 domain=None,
-                                clean_up=True,
                                 manual=False,
                             ):
     """
@@ -110,8 +109,6 @@ def get_cert_and_update_domain(
         print(e)
         return False
 
-    if clean_up:
-        cleanup()
     return True
 
 

--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -19,6 +19,7 @@ import logging
 import re
 import subprocess
 import os
+import shutil
 import sys
 import time
 import tempfile
@@ -115,7 +116,8 @@ def get_cert_and_update_domain(
 
 
 def create_domain_key():
-    out = subprocess.check_output(['openssl', 'genrsa', '2048'])
+    devnull = open(os.devnull, 'wb')
+    out = subprocess.check_output(['openssl', 'genrsa', '2048'], stderr=devnull)
     with open(os.path.join(gettempdir(), 'domain.key'), 'wb') as f:
         f.write(out)
 
@@ -126,11 +128,12 @@ def create_domain_csr(domain):
         'openssl', 'req',
         '-new',
         '-sha256',
-        '-key', os.pathjoin(gettempdir(), 'domain.key'),
+        '-key', os.path.join(gettempdir(), 'domain.key'),
         '-subj', subj
     ]
 
-    out = subprocess.check_output(cmd)
+    devnull = open(os.devnull, 'wb')
+    out = subprocess.check_output(cmd, stderr=devnull)
     with open(os.path.join(gettempdir(), 'domain.csr'), 'wb') as f:
         f.write(out)
 
@@ -157,7 +160,8 @@ def parse_account_key():
         '-noout',
         '-text'
     ]
-    return subprocess.check_output(cmd)
+    devnull = open(os.devnull, 'wb')
+    return subprocess.check_output(cmd, stderr=devnull)
 
 
 def parse_csr():
@@ -171,7 +175,8 @@ def parse_csr():
         '-noout',
         '-text'
     ]
-    out = subprocess.check_output(cmd)
+    devnull = open(os.devnull, 'wb')
+    out = subprocess.check_output(cmd, stderr=devnull)
     domains = set([])
     common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
@@ -324,7 +329,8 @@ def sign_certificate():
         '-in', os.path.join(gettempdir(), 'domain.csr'),
         '-outform', 'DER'
     ]
-    csr_der = subprocess.check_output(cmd)
+    devnull = open(os.devnull, 'wb')
+    csr_der = subprocess.check_output(cmd, stderr=devnull)
     code, result = _send_signed_request(DEFAULT_CA + "/acme/new-cert", {
         "resource": "new-cert",
         "csr": _b64(csr_der),


### PR DESCRIPTION
Note: I have not tested this change beyond running tests on Travis CI, as I do not yet know how to exercise the code. However, due to the severity of handling cryptographic keys in insecure temporary directories, I am sharing my progress towards a resolution of #1296.

- Lazily creates a temporary directory with `tempfile.mkdtemp()` that is used for all processing in `zappa/letsencrypt.py`.

- Deletes the Let's Encrypt temporary directory when `cleanup()` is called, or when Python exits. The `no_cleanup` option is removed for now.

- Creates the temporary directories for `temp_project_path` and `temp_package_path` using `temple.mkdtemp()`.

- Replaces the custom `Popen` call with `subprocess.check_output` and family, and uses built-in file I/O functions when possible. (A little out-of-scope, sorry.)