### PR TITLE
Zappa with Flask cannot route unicode strings.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coveralls>=1.1
 coverage>=4.3.1
-Django>=1.10.5
+Django>=1.10.5, <2.0
 Flask>=0.12
 mock>=2.0.0
 nose>=1.3.7

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -529,6 +529,21 @@ class TestZappa(unittest.TestCase):
         request = create_wsgi_request(event, trailing_slash=True)
         self.assertEqual("/path:1", request['PATH_INFO'])
 
+    def test_wsgi_latin1(self):
+        event = {
+            "body": {},
+            "headers": {},
+            "pathParameters": {},
+            "path": '/path/%E4%BB%8A%E6%97%A5%E3%81%AF',
+            "httpMethod": "GET",
+            "queryStringParameters": {"a": "%E4%BB%8A%E6%97%A5%E3%81%AF"},
+            "requestContext": {}
+        }
+        request = create_wsgi_request(event, script_name="%E4%BB%8A%E6%97%A5%E3%81%AF")
+        # verify that the path, query params and script name can be encoded in iso-8859-1
+        request['PATH_INFO'].encode('iso-8859-1')
+        request['QUERY_STRING'].encode('iso-8859-1')
+        request['SCRIPT_NAME'].encode('iso-8859-1')
 
     def test_wsgi_logging(self):
         # event = {

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -180,7 +180,7 @@ def common_log(environ, response, response_time=None):
 
 
 # Related: https://github.com/Miserlou/Zappa/issues/1199
-def _get_wsgi_string(string, encoding='utf-8'):
+def get_wsgi_string(string, encoding='utf-8'):
     """
     Returns wsgi-compatible string
     """

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -179,7 +179,9 @@ def common_log(environ, response, response_time=None):
     return log_entry
 
 
-# added this function in order to have wsgi compatible strings in the environ
 # Related: https://github.com/Miserlou/Zappa/issues/1199
 def _get_wsgi_string(string, encoding='utf-8'):
+    """
+    Returns wsgi-compatible string
+    """
     return string.encode(encoding).decode('iso-8859-1')

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -102,11 +102,11 @@ def create_wsgi_request(event_info,
             remote_addr = '127.0.0.1'
 
         environ = {
-            'PATH_INFO': _get_wsgi_string(path),
-            'QUERY_STRING': _get_wsgi_string(query_string),
+            'PATH_INFO': get_wsgi_string(path),
+            'QUERY_STRING': get_wsgi_string(query_string),
             'REMOTE_ADDR': remote_addr,
             'REQUEST_METHOD': method,
-            'SCRIPT_NAME': _get_wsgi_string(str(script_name)) if script_name else '',
+            'SCRIPT_NAME': get_wsgi_string(str(script_name)) if script_name else '',
             'SERVER_NAME': str(server_name),
             'SERVER_PORT': headers.get('X-Forwarded-Port', '80'),
             'SERVER_PROTOCOL': str('HTTP/1.1'),

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -102,11 +102,11 @@ def create_wsgi_request(event_info,
             remote_addr = '127.0.0.1'
 
         environ = {
-            'PATH_INFO': path,
-            'QUERY_STRING': query_string,
+            'PATH_INFO': _get_wsgi_string(path),
+            'QUERY_STRING': _get_wsgi_string(query_string),
             'REMOTE_ADDR': remote_addr,
             'REQUEST_METHOD': method,
-            'SCRIPT_NAME': str(script_name) if script_name else '',
+            'SCRIPT_NAME': _get_wsgi_string(str(script_name)) if script_name else '',
             'SERVER_NAME': str(server_name),
             'SERVER_PORT': headers.get('X-Forwarded-Port', '80'),
             'SERVER_PROTOCOL': str('HTTP/1.1'),
@@ -177,3 +177,7 @@ def common_log(environ, response, response_time=None):
     logger.info(log_entry)
 
     return log_entry
+
+
+def _get_wsgi_string(string, encoding='utf-8'):
+    return string.encode(encoding).decode('iso-8859-1')

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -179,5 +179,7 @@ def common_log(environ, response, response_time=None):
     return log_entry
 
 
+# added this function in order to have wsgi compatible strings in the environ
+# Related: https://github.com/Miserlou/Zappa/issues/1199
 def _get_wsgi_string(string, encoding='utf-8'):
     return string.encode(encoding).decode('iso-8859-1')


### PR DESCRIPTION
## Description
Create and use utility function that transforms a bytestring or a string into an iso-8859-1 string in order to respect the wsgi reference : https://www.python.org/dev/peps/pep-3333/#unicode-issues
https://www.python.org/dev/peps/pep-3333/#environ-variables

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1199

