### PR TITLE
Add SNS message filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,27 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
         ]
 ```
 
+Optionally you could add [SNS message filters](http://docs.aws.amazon.com/sns/latest/dg/message-filtering.html):
+
+```javascript
+        "events": [
+            {
+                "function": "your_module.your_function",
+                "event_source": {
+                    "arn":  "arn:aws:sns:::your-event-topic-arn",
+                    "filters": {
+                        "interests": ["python", "aws", "zappa"],
+                        "version": ["1.0"]
+                    },
+                    "events": [
+                        "sns:Publish"
+                    ]
+                }
+            }
+        ]
+```
+
+
 [DynamoDB](http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html) and [Kinesis](http://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) are slightly different as it is not event based but pulling from a stream:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Similarly, for a [Simple Notification Service](https://aws.amazon.com/sns/) even
         ]
 ```
 
-Optionally you could add [SNS message filters](http://docs.aws.amazon.com/sns/latest/dg/message-filtering.html):
+Optionally you can add [SNS message filters](http://docs.aws.amazon.com/sns/latest/dg/message-filtering.html):
 
 ```javascript
         "events": [
@@ -528,14 +528,11 @@ Optionally you could add [SNS message filters](http://docs.aws.amazon.com/sns/la
                         "interests": ["python", "aws", "zappa"],
                         "version": ["1.0"]
                     },
-                    "events": [
-                        "sns:Publish"
-                    ]
+                    ...
                 }
             }
         ]
 ```
-
 
 [DynamoDB](http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html) and [Kinesis](http://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) are slightly different as it is not event based but pulling from a stream:
 

--- a/test_settings.json
+++ b/test_settings.json
@@ -33,6 +33,19 @@
                      "sns:Publish"
                    ]
                }
+           },
+           {
+               "function": "test.test_app.method_filters",
+               "event_source": {
+                   "arn": "arn:aws:sns:::with-filters",
+                   "filters": {
+                        "interests": ["python", "aws", "zappa"],
+                        "version": ["1.0"]
+                    },
+                   "events": [
+                     "sns:Publish"
+                   ]
+               }
            }
        ],
        "cognito": {

--- a/test_settings.json
+++ b/test_settings.json
@@ -84,7 +84,7 @@
     },
     "extendo2": {
        "extends": "extendo",
-       "s3_bucket": "lmbda2",
+       "s3_bucket": "lmbda2"
     },
     "slim_handler": {
        "extends": "ttt888",

--- a/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_2.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_2.json
@@ -1,24 +1,31 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "c31b8bb1-05e2-52c5-8c71-dbeaaa6a1b4e", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "c31b8bb1-05e2-52c5-8c71-dbeaaa6a1b4e",
             "HTTPHeaders": {
-                "x-amzn-requestid": "c31b8bb1-05e2-52c5-8c71-dbeaaa6a1b4e", 
-                "date": "Tue, 20 Sep 2016 21:42:32 GMT", 
-                "content-length": "720", 
+                "x-amzn-requestid": "c31b8bb1-05e2-52c5-8c71-dbeaaa6a1b4e",
+                "date": "Tue, 20 Sep 2016 21:42:32 GMT",
+                "content-length": "720",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "Subscriptions": [
             {
-                "Owner": "123456789123", 
-                "Endpoint": "arn:aws:lambda:us-east-1:123456789123:function:zappa-ttt888", 
-                "Protocol": "lambda", 
-                "TopicArn": "arn:aws:sns:::1", 
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::1",
                 "SubscriptionArn": "arn:aws:sns:::1"
+            },
+            {
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::with-filters",
+                "SubscriptionArn": "arn:aws:sns:::with-filters:subscription1"
             }
         ]
     }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_3.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_3.json
@@ -1,24 +1,31 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "4b297fb0-32e1-5466-8b32-2feb82122ee6", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "4b297fb0-32e1-5466-8b32-2feb82122ee6",
             "HTTPHeaders": {
-                "x-amzn-requestid": "4b297fb0-32e1-5466-8b32-2feb82122ee6", 
-                "date": "Tue, 20 Sep 2016 21:48:34 GMT", 
-                "content-length": "720", 
+                "x-amzn-requestid": "4b297fb0-32e1-5466-8b32-2feb82122ee6",
+                "date": "Tue, 20 Sep 2016 21:48:34 GMT",
+                "content-length": "720",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "Subscriptions": [
             {
-                "Owner": "123456789123", 
-                "Endpoint": "arn:aws:lambda:us-east-1:123456789123:function:zappa-ttt888", 
-                "Protocol": "lambda", 
-                "TopicArn": "arn:aws:sns:::1", 
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::1",
                 "SubscriptionArn": "arn:aws:sns:::1:1833de9b-d325-4610-bc69-139311499f5d"
+            },
+            {
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::with-filters",
+                "SubscriptionArn": "arn:aws:sns:::with-filters:subscription1"
             }
         ]
     }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_5.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_5.json
@@ -1,24 +1,31 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "4d8b41db-39d2-57af-b9e9-1180883901a2", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "4d8b41db-39d2-57af-b9e9-1180883901a2",
             "HTTPHeaders": {
-                "x-amzn-requestid": "4d8b41db-39d2-57af-b9e9-1180883901a2", 
-                "date": "Tue, 20 Sep 2016 21:52:42 GMT", 
-                "content-length": "720", 
+                "x-amzn-requestid": "4d8b41db-39d2-57af-b9e9-1180883901a2",
+                "date": "Tue, 20 Sep 2016 21:52:42 GMT",
+                "content-length": "720",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "Subscriptions": [
             {
-                "Owner": "123456789123", 
-                "Endpoint": "arn:aws:lambda:us-east-1:123456789123:function:zappa-ttt888", 
-                "Protocol": "lambda", 
-                "TopicArn": "arn:aws:sns:::1", 
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::1",
                 "SubscriptionArn": "arn:aws:sns:::1:57ae90d2-0fe8-4204-85a3-bcd4848545f6"
+            },
+            {
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::with-filters",
+                "SubscriptionArn": "arn:aws:sns:::with-filters:subscription2"
             }
         ]
     }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_6.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_6.json
@@ -1,24 +1,31 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "e51e3ca3-a2ca-5748-98dd-6cf813310bcc", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "e51e3ca3-a2ca-5748-98dd-6cf813310bcc",
             "HTTPHeaders": {
-                "x-amzn-requestid": "e51e3ca3-a2ca-5748-98dd-6cf813310bcc", 
-                "date": "Tue, 20 Sep 2016 21:52:58 GMT", 
-                "content-length": "720", 
+                "x-amzn-requestid": "e51e3ca3-a2ca-5748-98dd-6cf813310bcc",
+                "date": "Tue, 20 Sep 2016 21:52:58 GMT",
+                "content-length": "720",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "Subscriptions": [
             {
-                "Owner": "123456789123", 
-                "Endpoint": "arn:aws:lambda:us-east-1:123456789123:function:zappa-ttt888", 
-                "Protocol": "lambda", 
-                "TopicArn": "arn:aws:sns:::1", 
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::1",
                 "SubscriptionArn": "arn:aws:sns:::1:8e52fdf5-49ec-4fab-93d8-29502b2899d4"
+            },
+            {
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::with-filters",
+                "SubscriptionArn": "arn:aws:sns:::with-filters:subscription2"
             }
         ]
     }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_7.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.ListSubscriptionsByTopic_7.json
@@ -1,24 +1,31 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "1d25a7ba-9a6b-53cb-b029-f7e12b951045", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "1d25a7ba-9a6b-53cb-b029-f7e12b951045",
             "HTTPHeaders": {
-                "x-amzn-requestid": "1d25a7ba-9a6b-53cb-b029-f7e12b951045", 
-                "date": "Tue, 20 Sep 2016 21:53:01 GMT", 
-                "content-length": "720", 
+                "x-amzn-requestid": "1d25a7ba-9a6b-53cb-b029-f7e12b951045",
+                "date": "Tue, 20 Sep 2016 21:53:01 GMT",
+                "content-length": "720",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "Subscriptions": [
             {
-                "Owner": "123456789123", 
-                "Endpoint": "arn:aws:lambda:us-east-1:123456789123:function:zappa-ttt888", 
-                "Protocol": "lambda", 
-                "TopicArn": "arn:aws:sns:::1", 
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::1",
                 "SubscriptionArn": "arn:aws:sns:::1:e62db82e-757c-4356-ab9b-a2441b0662c8"
+            },
+            {
+                "Owner": "123456789123",
+                "Endpoint": "arn:aws:lambda:us-east-1:724336686645:function:zappa-ttt888:1",
+                "Protocol": "lambda",
+                "TopicArn": "arn:aws:sns:::with-filters",
+                "SubscriptionArn": "arn:aws:sns:::with-filters:subscription2"
             }
         ]
     }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.SetSubscriptionAttributes_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.SetSubscriptionAttributes_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "0fd08270-517b-5524-b434-d0bf5c813e24",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "0fd08270-517b-5524-b434-d0bf5c813e24",
+        "content-type": "text/xml",
+        "content-length": "229",
+        "date": "Tue, 09 Jan 2018 18:36:42 GMT"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_1.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "ba6b9df2-b2c7-5c29-86c9-cda91d89fa8b", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "ba6b9df2-b2c7-5c29-86c9-cda91d89fa8b",
             "HTTPHeaders": {
-                "x-amzn-requestid": "ba6b9df2-b2c7-5c29-86c9-cda91d89fa8b", 
-                "date": "Tue, 20 Sep 2016 21:41:33 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "ba6b9df2-b2c7-5c29-86c9-cda91d89fa8b",
+                "date": "Tue, 20 Sep 2016 21:41:33 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
-        "SubscriptionArn": "arn:aws:sns:::1"
+        },
+        "SubscriptionArn": "arn:aws:sns:::with-filters"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_2.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_2.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "5fc669e7-9952-5cd5-8a41-39bc36d8d93c", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "5fc669e7-9952-5cd5-8a41-39bc36d8d93c",
             "HTTPHeaders": {
-                "x-amzn-requestid": "5fc669e7-9952-5cd5-8a41-39bc36d8d93c", 
-                "date": "Tue, 20 Sep 2016 21:42:34 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "5fc669e7-9952-5cd5-8a41-39bc36d8d93c",
+                "date": "Tue, 20 Sep 2016 21:42:34 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "SubscriptionArn": "arn:aws:sns:::1:1833de9b-d325-4610-bc69-139311499f5d"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_3.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_3.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "a735afa5-04c9-5ddc-b6fa-fffeb43afd23", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "a735afa5-04c9-5ddc-b6fa-fffeb43afd23",
             "HTTPHeaders": {
-                "x-amzn-requestid": "a735afa5-04c9-5ddc-b6fa-fffeb43afd23", 
-                "date": "Tue, 20 Sep 2016 21:48:35 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "a735afa5-04c9-5ddc-b6fa-fffeb43afd23",
+                "date": "Tue, 20 Sep 2016 21:48:35 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
-        "SubscriptionArn": "arn:aws:sns:::1:221eb6cc-2fcb-496c-87c2-3af0f81cf34e"
+        },
+        "SubscriptionArn": "arn:aws:sns:::with-filters:221eb6cc-2fcb-496c-87c2-3af0f81cf34e"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_4.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_4.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "4f2c7f44-73ba-5f13-bd94-2f1fc21b4ca1", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "4f2c7f44-73ba-5f13-bd94-2f1fc21b4ca1",
             "HTTPHeaders": {
-                "x-amzn-requestid": "4f2c7f44-73ba-5f13-bd94-2f1fc21b4ca1", 
-                "date": "Tue, 20 Sep 2016 21:51:29 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "4f2c7f44-73ba-5f13-bd94-2f1fc21b4ca1",
+                "date": "Tue, 20 Sep 2016 21:51:29 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "SubscriptionArn": "arn:aws:sns:::1:57ae90d2-0fe8-4204-85a3-bcd4848545f6"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_5.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_5.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "e682d70b-5a4f-51e7-9791-8750eba3af24", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "e682d70b-5a4f-51e7-9791-8750eba3af24",
             "HTTPHeaders": {
-                "x-amzn-requestid": "e682d70b-5a4f-51e7-9791-8750eba3af24", 
-                "date": "Tue, 20 Sep 2016 21:52:44 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "e682d70b-5a4f-51e7-9791-8750eba3af24",
+                "date": "Tue, 20 Sep 2016 21:52:44 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
-        "SubscriptionArn": "arn:aws:sns:::1:8e52fdf5-49ec-4fab-93d8-29502b2899d4"
+        },
+        "SubscriptionArn": "arn:aws:sns:::with-filters:8e52fdf5-49ec-4fab-93d8-29502b2899d4"
     }
 }

--- a/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_6.json
+++ b/tests/placebo/TestZappa.test_cli_aws/sns.Subscribe_6.json
@@ -1,17 +1,17 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "dccdb21f-87c2-5b69-8e47-e244363ec978", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "dccdb21f-87c2-5b69-8e47-e244363ec978",
             "HTTPHeaders": {
-                "x-amzn-requestid": "dccdb21f-87c2-5b69-8e47-e244363ec978", 
-                "date": "Tue, 20 Sep 2016 21:53:00 GMT", 
-                "content-length": "354", 
+                "x-amzn-requestid": "dccdb21f-87c2-5b69-8e47-e244363ec978",
+                "date": "Tue, 20 Sep 2016 21:53:00 GMT",
+                "content-length": "354",
                 "content-type": "text/xml"
             }
-        }, 
+        },
         "SubscriptionArn": "arn:aws:sns:::1:e62db82e-757c-4356-ab9b-a2441b0662c8"
     }
 }

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -211,11 +211,36 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
         def __init__(self):
             return
 
+    class ExtendedSnsEventSource(kappa.event_source.sns.SNSEventSource):
+        @property
+        def filters(self):
+            return self._config.get('filters')
+
+        def add_filters(self, function):
+            try:
+                subscription = self.exists(function)
+                if subscription:
+                    response = self._sns.call(
+                        'set_subscription_attributes',
+                        SubscriptionArn=subscription['SubscriptionArn'],
+                        AttributeName='FilterPolicy',
+                        AttributeValue=json.dumps(self.filters)
+                    )
+                    kappa.event_source.sns.LOG.debug(response)
+            except Exception:
+                kappa.event_source.sns.LOG.exception('Unable to add filters for SNS topic %s', self.arn)
+
+        def add(self, function):
+            super(ExtendedSnsEventSource, self).add(function)
+
+            if self.filters:
+                self.add_filters(function)
+
     event_source_map = {
         'dynamodb': kappa.event_source.dynamodb_stream.DynamoDBStreamEventSource,
         'kinesis': kappa.event_source.kinesis.KinesisEventSource,
         's3': kappa.event_source.s3.S3EventSource,
-        'sns': kappa.event_source.sns.SNSEventSource,
+        'sns': ExtendedSnsEventSource,
         'events': kappa.event_source.cloudwatch.CloudWatchEventSource
     }
 
@@ -363,7 +388,7 @@ def validate_name(name, maxlen=80):
 
 def contains_python_files_or_subdirs(folder):
     """
-    Checks (recursively) if the directory contains .py or .pyc files 
+    Checks (recursively) if the directory contains .py or .pyc files
     """
     for root, dirs, files in os.walk(folder):
         if [filename for filename in files if filename.endswith('.py') or filename.endswith('.pyc')]:

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -232,7 +232,6 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
 
         def add(self, function):
             super(ExtendedSnsEventSource, self).add(function)
-
             if self.filters:
                 self.add_filters(function)
 


### PR DESCRIPTION
## Description
AWS recently introduced SNS message filtering using message attributes. This is very useful if you use single topic for multiple consumers (SQS, Lambda, etc) and you don't want every message to trigger function or just don't want to filter messages inside Zappa. 

By simply setting the following in your config:
```javascript
        "events": [
            {
                "function": "your_module.your_function",
                "event_source": {
                    "arn":  "arn:aws:sns:::your-event-topic-arn",
                    "filters": {
                        "interests": ["python", "aws", "zappa"],
                        "version": ["1.0"]
                    },
                    "events": [
                        "sns:Publish"
                    ]
                }
            }
        ]
```
a Zappa function will be executed for SNS messages with attributes where at least one value matches `interests` list.

Note that each filter must be list of strings.

For detailed documentation how it works: http://docs.aws.amazon.com/sns/latest/dg/message-filtering.html

