### PR TITLE
Retries and timeout for dependencies.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -436,6 +436,7 @@ class ZappaCLI(object):
         )
         # added timeout and retries when dowloading dependencies
         # Related : https://github.com/Miserlou/Zappa/issues/1235
+        # Related : https://github.com/Miserlou/Zappa/issues/1040
         update_parser.add_argument(
             '-t', '--timeout', type=positive_int, default=2, help='Timeout on downloading dependencies'
         )

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -434,6 +434,8 @@ class ZappaCLI(object):
         update_parser.add_argument(
             '-n', '--no-upload', help="Update configuration where appropriate, but don't upload new code"
         )
+        # added timeout and retries when dowloading dependencies
+        # Related : https://github.com/Miserlou/Zappa/issues/1235
         update_parser.add_argument(
             '-t', '--timeout', type=positive_int, default=2, help='Timeout on downloading dependencies'
         )

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -797,8 +797,11 @@ class Zappa(object):
         Downloads a given url in chunks and writes to the provided stream (can be any io stream).
         Displays the progress bar for the download.
         """
-        resp = requests.get(url, timeout=timeout, stream=True)
-        # TODO implement retry scheme here (requests.Session and HTTPAdapter with retries=retries)
+        # implemented retries scheme
+        # Related : https://github.com/Miserlou/Zappa/issues/1235
+        session = requests.Session()
+        session.mount(url, requests.adapters.HTTPAdapter(max_retries=retries))
+        resp = session.get(url, timeout=timeout, stream=True)
         resp.raw.decode_content = True
 
         progress = tqdm(unit="B", unit_scale=True, total=int(resp.headers.get('Content-Length', 0)), disable=disable_progress)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -33,6 +33,8 @@ from builtins import int, bytes
 from botocore.exceptions import ClientError
 from distutils.dir_util import copy_tree
 from io import BytesIO, open
+
+from click import ClickException
 from lambda_packages import lambda_packages as lambda_packages_orig
 from setuptools import find_packages
 from tqdm import tqdm
@@ -436,7 +438,9 @@ class Zappa(object):
                             venv=None,
                             output=None,
                             disable_progress=False,
-                            archive_format='zip'
+                            archive_format='zip',
+                            retries=None,
+                            timeout=None
                         ):
         """
         Create a Lambda-ready zip file of the current virtualenvironment and working directory.
@@ -606,7 +610,7 @@ class Zappa(object):
                         print(" - %s==%s: Using precompiled lambda package " % (installed_package_name, installed_package_version,))
                         self.extract_lambda_package(installed_package_name, temp_project_path)
                     else:
-                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version, disable_progress)
+                        cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version, disable_progress, retries, timeout)
                         if cached_wheel_path:
                             # Otherwise try to use manylinux packages from PyPi..
                             # Related: https://github.com/Miserlou/Zappa/issues/398
@@ -627,10 +631,13 @@ class Zappa(object):
                 if self.runtime == "python3.6":
                     print(" - sqlite==python36: Using precompiled lambda package")
                     self.extract_lambda_package('sqlite3', temp_project_path)
-
-            except Exception as e:
-                print(e)
-                # XXX - What should we do here?
+            except (requests.ConnectionError, requests.Timeout):
+                raise ClickException(
+                    'There was a connection failure while trying to fetch packages'
+                )
+            except Exception:
+                # failing here in order to avoid deploying a broken application
+                raise
 
         # Then archive it all up..
         if archive_format == 'zip':
@@ -785,12 +792,13 @@ class Zappa(object):
         return lambda_packages.get(package_name, {}).get(self.runtime) is not None
 
     @staticmethod
-    def download_url_with_progress(url, stream, disable_progress):
+    def download_url_with_progress(url, stream, disable_progress, retries, timeout):
         """
         Downloads a given url in chunks and writes to the provided stream (can be any io stream).
         Displays the progress bar for the download.
         """
-        resp = requests.get(url, timeout=2, stream=True)
+        resp = requests.get(url, timeout=timeout, stream=True)
+        # TODO implement retry scheme here (requests.Session and HTTPAdapter with retries=retries)
         resp.raw.decode_content = True
 
         progress = tqdm(unit="B", unit_scale=True, total=int(resp.headers.get('Content-Length', 0)), disable=disable_progress)
@@ -801,7 +809,7 @@ class Zappa(object):
 
         progress.close()
 
-    def get_cached_manylinux_wheel(self, package_name, package_version, disable_progress=False):
+    def get_cached_manylinux_wheel(self, package_name, package_version, disable_progress=False, retries=None, timeout=None):
         """
         Gets the locally stored version of a manylinux wheel. If one does not exist, the function downloads it.
         """
@@ -820,7 +828,7 @@ class Zappa(object):
 
             print(" - {}=={}: Downloading".format(package_name, package_version))
             with open(wheel_path, 'wb') as f:
-                self.download_url_with_progress(wheel_url, f, disable_progress)
+                self.download_url_with_progress(wheel_url, f, disable_progress, retries, timeout)
 
             if not zipfile.is_zipfile(wheel_path):
                 return None


### PR DESCRIPTION

## Description
Added retries and timeout optional parameters in the cli, a retry scheme when downloading dependencies and a different exception handling when downloading packages.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1235
https://github.com/Miserlou/Zappa/issues/1040

