### PR TITLE
Fixed when running zappa with no parameters

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -450,6 +450,10 @@ class ZappaCLI(object):
         # been specified AND that stage_env='showmigrations')
         # By having command_rest collect everything but --all we can split it
         # apart here instead of relying on argparse.
+        if not args.command:
+            parser.print_help()
+            return
+
         if args.command == 'manage' and not self.vargs.get('all'):
             self.stage_env = self.vargs['command_rest'].pop(0)
         else:
@@ -512,7 +516,7 @@ class ZappaCLI(object):
         self.api_stage = stage
 
         if command not in ['status', 'manage']:
-            if not self.vargs['json']:
+            if not self.vargs.get('json', None):
                 click.echo("Calling " + click.style(command, fg="green", bold=True) + " for stage " +
                            click.style(self.api_stage, bold=True) + ".." )
 
@@ -1660,10 +1664,10 @@ class ZappaCLI(object):
                 'project_name': self.get_project_name()
             }
         }
-        
+
         if profile_region:
-          zappa_settings[env]['aws_region'] = profile_region
-        
+            zappa_settings[env]['aws_region'] = profile_region
+
         if has_django:
             zappa_settings[env]['django_settings'] = django_settings
         else:


### PR DESCRIPTION
Fixed issue when running Zappa with no arguments. First, there was no checking to verify if any command was passed as an argument in the command-line and later on the dispatch_command function we were trying to get the value of 'json' in self.vargs causing an unhandled KeyError
exception. Now, if no argument is specified, the help will be displayed to the users.

See reported issue here: https://github.com/Miserlou/Zappa/issues/1350


