### PR TITLE
start of config refactor

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,21 @@
+Zappa Config Index
+=======================
+
+This document describes the Zappa configuration options.
+
+* `id`: The name by which the config will be referenced in the `zappa_settings.json`
+* `default`: The default value.
+* `summary`: A short description of the purpose of the configuration parameter.
+
+
+Zappa Configs
+===================
+
+<!-- list-of-configs -->
+
+| ID | Default | Summary |
+| --- | --- | --- |
+| [certificate_arn]( | AWS certificate arn |
+
+<!-- /list-of-configs -->
+

--- a/config/configs/certificate-arn.json
+++ b/config/configs/certificate-arn.json
@@ -1,0 +1,5 @@
+{
+  "id": "certificate_arn",
+  "default": "",
+  "summary": "AWS certificate arn"
+}

--- a/config/schema.json
+++ b/config/schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "default": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "summary"
+  ],
+  "title": "Config"
+}

--- a/config/update_readme.py
+++ b/config/update_readme.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+
+readme_file = Path('README.md')
+readme = readme_file.read_text().splitlines()
+
+start = readme.index('<!-- list-of-configs -->')
+end = readme.index('<!-- /list-of-configs -->')
+
+del readme[start+1:end]
+
+readme.insert(start+1, '')
+readme.insert(start+2, '| ID | Default | Summary |')
+readme.insert(start+3, '| --- | --- | --- |')
+
+for config_file in sorted(Path('configs').glob('*.json')):
+    end = readme.index('<!-- /list-of-configs -->')
+    config = json.loads(config_file.read_text())
+    readme.insert(
+        end, '| [{id}]({default} | {summary} |'.format(**config))
+
+readme.insert(end+1, '')
+
+readme_file.write_text(''.join('{}\n'.format(l) for l in readme))


### PR DESCRIPTION
## Description

In light of #1371 we may want to better define a single source
of truth for configs alongside increasing the maintainability
and visibility of Zappa configuration.

* create config schema and bring forward a good amount of
https://github.com/juju/layer-index/blob/master/update_readme.py
* create example config `certificate_arn`

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1371

