### PR TITLE
Adding explicit UTF-8 encoding for Flask app detection

### DIFF
--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -4,6 +4,7 @@ import durationpy
 import fnmatch
 import json
 import os
+import io
 import re
 import shutil
 import stat
@@ -143,7 +144,7 @@ def detect_flask_apps():
 
             full = os.path.join(root, filename)
 
-            with os.io.open(full, 'r', encoding='utf-8') as f:
+            with io.open(full, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
                 for line in lines:
                     app = None

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -92,7 +92,7 @@ def string_to_timestamp(timestring):
 
     # Uses an extended version of Go's duration string.
     try:
-        delta = durationpy.from_str(timestring);
+        delta = durationpy.from_str(timestring)
         past = datetime.datetime.utcnow() - delta
         ts = calendar.timegm(past.timetuple())
         return ts

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -2,9 +2,9 @@ import calendar
 import datetime
 import durationpy
 import fnmatch
+import io
 import json
 import os
-import io
 import re
 import shutil
 import stat
@@ -93,7 +93,7 @@ def string_to_timestamp(timestring):
 
     # Uses an extended version of Go's duration string.
     try:
-        delta = durationpy.from_str(timestring)
+        delta = durationpy.from_str(timestring);
         past = datetime.datetime.utcnow() - delta
         ts = calendar.timegm(past.timetuple())
         return ts

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -143,7 +143,7 @@ def detect_flask_apps():
 
             full = os.path.join(root, filename)
 
-            with open(full, 'r') as f:
+            with os.io.open(full, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
                 for line in lines:
                     app = None


### PR DESCRIPTION
Attempt 2, previous attempt PR #1406 

## Description
Attempting to fix this code path for Windows + Python 3 users. This should not affect Unix systems as they already have UTF-8 encoding by default.

Tested on my Windows + Python 3 machine, but did not test for Python 2.

`io.open()` is an alias for `open()` in Python versions after 3.0, so the Python 3 path should be unchanged.
This allows for explicit encoding to be set in Python 2.
[StackOverflow with additional details](https://stackoverflow.com/questions/10971033/backporting-python-3-openencoding-utf-8-to-python-2)

## GitHub Issues
Issue #825 

@mcrowson  