### PR TITLE
Allow non-route53 domains to re-certify

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1804,6 +1804,7 @@ class ZappaCLI(object):
 
         # Custom SSL / ACM
         else:
+            route53 = self.stage_config.get('route53_enabled', True)
             if not self.zappa.get_domain_name(self.domain):
                 dns_name = self.zappa.create_domain_name(
                     domain_name=self.domain,
@@ -1814,8 +1815,9 @@ class ZappaCLI(object):
                     certificate_arn=cert_arn,
                     lambda_name=self.lambda_name,
                     stage=self.api_stage,
+                    route53=route53
                 )
-                if self.stage_config.get('route53_enabled', True):
+                if route53:
                     self.zappa.update_route53_records(self.domain, dns_name)
                 print("Created a new domain name with supplied certificate. Please note that it can take up to 40 minutes for this domain to be "
                       "created and propagated through AWS, but it requires no further work on your part.")
@@ -1829,7 +1831,7 @@ class ZappaCLI(object):
                     certificate_arn=cert_arn,
                     lambda_name=self.lambda_name,
                     stage=self.api_stage,
-                    route53=self.stage_config.get('route53_enabled', True)
+                    route53=route53
                 )
 
             cert_success = True

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2086,7 +2086,7 @@ class Zappa(object):
                                                               "value" : certificate_arn}
                                                          ])
 
-    def get_domain_name(self, domain_name):
+    def get_domain_name(self, domain_name, route53=True):
         """
         Scan our hosted zones for the record of a given name.
 
@@ -2098,6 +2098,9 @@ class Zappa(object):
             self.apigateway_client.get_domain_name(domainName=domain_name)
         except Exception:
             return None
+
+        if not route53:
+            return True
 
         try:
             zones = self.route53.list_hosted_zones()


### PR DESCRIPTION
When certifying an existing custom domain name don't check to see if it has a route53 record if route53 is disabled.

`get_domain_name()` was returning None because it couldn't find the domain in the route53 zone and so `create_domain_name()` was being called instead of `update_domain_name()` and I was getting an exception with message

> An error occurred (BadRequestException) when calling the CreateDomainName
> operation: The domain name you provided already exists.
