### PR TITLE
Fix exception handler for web requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.4.7
 docutils>=0.12
 durationpy==0.5
 future==0.16.0
-futures==3.2.0
+futures==3.2.0; python_version < '3'
 hjson==3.0.1
 jmespath==0.9.3
 kappa==0.6.0

--- a/tests/test_bot_exception_handler_settings.py
+++ b/tests/test_bot_exception_handler_settings.py
@@ -1,0 +1,14 @@
+API_STAGE = 'dev'
+APP_FUNCTION = 'app'
+APP_MODULE = 'tests.test_wsgi_script_name_app'
+BINARY_SUPPORT = False
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'wsgi_script_name_settings'
+COGNITO_TRIGGER_MAPPING = {}
+AWS_BOT_EVENT_MAPPING = {'intent-name:DialogCodeHook': 'tests.test_handler.raises_exception'}
+EXCEPTION_HANDLER = 'tests.test_handler.mocked_exception_handler'

--- a/tests/test_exception_handler_settings.py
+++ b/tests/test_exception_handler_settings.py
@@ -1,0 +1,13 @@
+API_STAGE = 'dev'
+APP_FUNCTION = 'raises_exception'
+APP_MODULE = 'tests.test_handler'
+BINARY_SUPPORT = False
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'raises_exception'
+COGNITO_TRIGGER_MAPPING = {}
+EXCEPTION_HANDLER = 'tests.test_handler.mocked_exception_handler'

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -151,7 +151,7 @@ class TestZappa(unittest.TestCase):
 
     def test_exception_handler_on_web_request(self):
         """
-        Ensure that app exceptions triggered by web requests use the exception_handler
+        Ensure that app exceptions triggered by web requests use the exception_handler.
         """
         lh = LambdaHandler('tests.test_exception_handler_settings')
 
@@ -238,7 +238,7 @@ class TestZappa(unittest.TestCase):
 
     def test_exception_in_bot_triggered_event(self):
         """
-        Ensure that bot triggered exceptions are handled as in the settings
+        Ensure that bot triggered exceptions are handled as defined in the settings.
         """
         lh = LambdaHandler('tests.test_bot_exception_handler_settings')
         # from : https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-lex

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,4 +1,5 @@
 import unittest
+from mock import Mock
 from zappa.handler import LambdaHandler
 
 
@@ -26,11 +27,26 @@ def unsupported(first, second, third):
     return first, second, third
 
 
+def raises_exception(*args, **kwargs):
+    raise Exception('app exception')
+
+
 def handle_bot_intent(event, context):
     return "Success"
 
 
+mocked_exception_handler = Mock()
+
+
 class TestZappa(unittest.TestCase):
+
+    def setUp(self):
+        mocked_exception_handler.reset_mock()
+
+    def tearDown(self):
+        LambdaHandler._LambdaHandler__instance = None
+        LambdaHandler.settings = None
+        LambdaHandler.settings_name = None
 
     def test_run_function(self):
         self.assertIsNone(LambdaHandler.run_function(no_args, 'e', 'c'))
@@ -133,6 +149,35 @@ class TestZappa(unittest.TestCase):
             'https://zappa:80/return/request/url'
         )
 
+    def test_exception_handler_on_web_request(self):
+        """
+        Ensure that app exceptions triggered by web requests use the exception_handler
+        """
+        lh = LambdaHandler('tests.test_exception_handler_settings')
+
+        event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {
+                'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
+            },
+            'pathParameters': {
+                'proxy': 'return/request/url'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/return/request/url'
+        }
+
+        mocked_exception_handler.assert_not_called()
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 500)
+        mocked_exception_handler.assert_called()
+
+
     def test_wsgi_script_on_cognito_event_request(self):
         """
         Ensure that requests sent by cognito behave sensibly
@@ -190,3 +235,37 @@ class TestZappa(unittest.TestCase):
         response = lh.handler(event, None)
 
         self.assertEqual(response, 'Success')
+
+    def test_exception_in_bot_triggered_event(self):
+        """
+        Ensure that bot triggered exceptions are handled as in the settings
+        """
+        lh = LambdaHandler('tests.test_bot_exception_handler_settings')
+        # from : https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-lex
+        event = {
+            "messageVersion": "1.0",
+            "invocationSource": "DialogCodeHook",
+            "userId": "user-id specified in the POST request to Amazon Lex.",
+            "sessionAttributes": {
+                "key1": "value1",
+                "key2": "value2",
+            },
+            "bot": {
+                "name": "bot-name",
+                "alias": "bot-alias",
+                "version": "bot-version"
+            },
+            "outputDialogMode": "Text or Voice, based on ContentType request header in runtime API request",
+            "currentIntent": {
+                "name": "intent-name",
+                "slots": {
+                    "slot-name": "value",
+                    "slot-name": "value",
+                    "slot-name": "value"
+                },
+                "confirmationStatus": "None, Confirmed, or Denied (intent confirmation, if configured)"
+            }
+        }
+
+        response = lh.lambda_handler(event, None)
+        mocked_exception_handler.assert_called

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -539,6 +539,11 @@ class LambdaHandler(object):
                 except NameError as ne:
                     message = 'Failed to import module: {}'.format(ne.message)
 
+            # Call exception handler for unhandled exceptions
+            exception_handler = self.settings.EXCEPTION_HANDLER
+            self._process_exception(exception_handler=exception_handler,
+                                    event=event, context=context, exception=e)
+
             # Return this unspecified exception as a 500, using template that API Gateway expects.
             content = collections.OrderedDict()
             content['statusCode'] = 500


### PR DESCRIPTION
## Description
Call the settings' defined exception handler for web requests. For this and the tests I had to also include the following changes:
 * Make futures from requirementst.txt only install for python 2.7.
 * Add a mock_exception_handler that is reset on tests.test_handler.TestZappa.setUp so it's state is correct for every step.
 * Added a tearDown method so you can use different settings in each test (currently it's always reusing the same config).
 * Added tests for checking the work of the exception handler on bot events and web requests.

## GitHub Issues

#1353
