### PR TITLE
Improvements to touch (logging + endpoint setting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ to change Zappa's behavior. Use these at your own risk!
             },
         "timeout_seconds": 30, // Maximum lifespan for the Lambda function (default 30, max 300.)
         "touch": true, // GET the production URL upon initial deployment (default True)
+        "touch_path": "/", // The endpoint path to GET when checking the initial deployment (default "/")
         "use_precompiled_packages": true, // If possible, use C-extension packages which have been pre-compiled for AWS Lambda. Default true.
         "vpc_config": { // Optional Virtual Private Cloud (VPC) configuration for Lambda function
             "SubnetIds": [ "subnet-12345678" ], // Note: not all availability zones support Lambda!

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -812,7 +812,7 @@ class ZappaCLI(object):
                     self.zappa.add_api_stage_to_api_key(api_key=self.api_key, api_id=api_id, stage_name=self.api_stage)
 
             if self.stage_config.get('touch', True):
-                requests.get(endpoint_url)
+                self.touch_endpoint(endpoint_url)
 
         # Finally, delete the local copy our zip package
         if not source_zip:
@@ -1012,9 +1012,9 @@ class ZappaCLI(object):
 
             if self.stage_config.get('touch', True):
                 if api_url:
-                    requests.get(api_url)
+                    self.touch_endpoint(api_url)
                 elif endpoint_url:
-                    requests.get(endpoint_url)
+                    self.touch_endpoint(endpoint_url)
 
         click.echo(deployed_string)
 
@@ -2609,6 +2609,20 @@ class ZappaCLI(object):
 
         sys.stdout = open(os.devnull, 'w')
         sys.stderr = open(os.devnull, 'w')
+
+    def touch_endpoint(self, endpoint_url):
+        """
+        Test the deployed endpoint with a GET request
+        """
+
+        touch_path = self.stage_config.get('touch_path', '/')
+        req = requests.get(endpoint_url + touch_path)
+
+        if req.status_code >= 500:
+            raise ClickException(click.style("Warning!", fg="red", bold=True) +
+                " Status check on the deployed lambda failed." +
+                " A GET request to '" + touch_path + "' yielded a " +
+                click.style(str(req.status_code), fg="red", bold=True) + " response code.")
 
 ####################################################################
 # Main


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
* Unifies the different places that endpoint "touches" are done into a `touch_endpoint` function
* Adds an error log when the touch GET request returns a status code >= 500
* Adds a `touch_path` setting to allow configuration of the endpoint to be used when "touch"-ing the newly deployed/updated lambda

Not sure if `touch_path` or `touch_endpoint` is a better name for the new setting. Totally open to changing that 🙂

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
@1414

