### PR TITLE
API Payload Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,7 +830,7 @@ to change Zappa's behavior. Use these at your own risk!
         "log_level": "DEBUG", // Set the Zappa log level. Can be one of CRITICAL, ERROR, WARNING, INFO and DEBUG. Default: DEBUG
         "manage_roles": true, // Have Zappa automatically create and define IAM execution roles and policies. Default true. If false, you must define your own IAM Role and role_name setting.
         "memory_size": 512, // Lambda function memory in MB. Default 512.
-        "payload_compression": False, // Whether or not to enable API gateway payload compression (default: False)
+        "payload_compression": true, // Whether or not to enable API gateway payload compression (default: true)
         "payload_minimum_compression_size": 0, // The threshold size (in bytes) below which payload compression will not be applied (default: 0)
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'. Removing this setting will use the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables instead.

--- a/README.md
+++ b/README.md
@@ -830,6 +830,8 @@ to change Zappa's behavior. Use these at your own risk!
         "log_level": "DEBUG", // Set the Zappa log level. Can be one of CRITICAL, ERROR, WARNING, INFO and DEBUG. Default: DEBUG
         "manage_roles": true, // Have Zappa automatically create and define IAM execution roles and policies. Default true. If false, you must define your own IAM Role and role_name setting.
         "memory_size": 512, // Lambda function memory in MB. Default 512.
+        "payload_compression": False, // Whether or not to enable API gateway payload compression (default: False)
+        "payload_minimum_compression_size": 0, // The threshold size (in bytes) below which payload compression will not be applied (default: 0)
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'. Removing this setting will use the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables instead.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -801,7 +801,7 @@ class ZappaCLI(object):
                 self.zappa.add_binary_support(api_id=api_id, cors=self.cors)
 
             # Add payload compression
-            if self.stage_config.get('payload_compression', False):
+            if self.stage_config.get('payload_compression', True):
                 self.zappa.add_api_compression(
                     api_id=api_id,
                     min_compression_size=self.stage_config.get('payload_minimum_compression_size', 0))
@@ -982,7 +982,7 @@ class ZappaCLI(object):
             else:
                 self.zappa.remove_binary_support(api_id=api_id, cors=self.cors)
 
-            if self.stage_config.get('payload_compression', False):
+            if self.stage_config.get('payload_compression', True):
                 self.zappa.add_api_compression(
                     api_id=api_id,
                     min_compression_size=self.stage_config.get('payload_minimum_compression_size', 0))

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -800,6 +800,12 @@ class ZappaCLI(object):
             if self.binary_support:
                 self.zappa.add_binary_support(api_id=api_id, cors=self.cors)
 
+            # Add payload compression
+            if self.stage_config.get('payload_compression', False):
+                self.zappa.add_api_compression(
+                    api_id=api_id,
+                    min_compression_size=self.stage_config.get('payload_minimum_compression_size', 0))
+
             # Deploy the API!
             endpoint_url = self.deploy_api_gateway(api_id)
             deployment_string = deployment_string + ": {}".format(endpoint_url)
@@ -975,6 +981,13 @@ class ZappaCLI(object):
                 self.zappa.add_binary_support(api_id=api_id, cors=self.cors)
             else:
                 self.zappa.remove_binary_support(api_id=api_id, cors=self.cors)
+
+            if self.stage_config.get('payload_compression', False):
+                self.zappa.add_api_compression(
+                    api_id=api_id,
+                    min_compression_size=self.stage_config.get('payload_minimum_compression_size', 0))
+            else:
+                self.zappa.remove_api_compression(api_id=api_id)
 
             # It looks a bit like we might actually be using this just to get the URL,
             # but we're also updating a few of the APIGW settings.

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1572,6 +1572,35 @@ class Zappa(object):
                     ]
                 )
 
+    def add_api_compression(self, api_id, min_compression_size):
+        """
+        Add Rest API compression
+        """
+        self.apigateway_client.update_rest_api(
+            restApiId=api_id,
+            patchOperations=[
+                {
+                    'op': 'replace',
+                    'path': '/minimumCompressionSize',
+                    'value': str(min_compression_size)
+                }
+            ]
+        )
+
+    def remove_api_compression(self, api_id):
+        """
+        Remove Rest API compression
+        """
+        self.apigateway_client.update_rest_api(
+            restApiId=api_id,
+            patchOperations=[
+                {
+                    'op': 'replace',
+                    'path': '/minimumCompressionSize',
+                }
+            ]
+        )
+
     def get_api_keys(self, api_id, stage_name):
         """
         Generator that allows to iterate per API keys associated to an api_id and a stage_name.


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
* Addresses #1360 -- adds ability to enable payload compression on Lambda Rest APIs
* New setting `payload_compression` for enabling/disabling payload compression
* New setting `payload_minimum_compression_size` to set the threshold for compressing the payload

Payload compression is a property of the REST api -- like binary support -- so it has to be enabled/disabled independently from API stages

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1360