### PR TITLE
Allow s3 event configurations to be named anything and still work

### DIFF
--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -262,7 +262,7 @@ class TestZappa(unittest.TestCase):
                     u'account': u'72333333333',
                     u'region': u'us-east-1',
                     u'detail': {},
-                    u'Records': [{'s3': {'configurationId': 'test_settings.aws_s3_event'}}],
+                    u'Records': [{'s3': {'configurationId': 'test_project:test_settings.aws_s3_event'}}],
                     u'source': u'aws.events',
                     u'version': u'0',
                     u'time': u'2016-05-10T21:05:39Z',

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -284,7 +284,8 @@ class LambdaHandler(object):
         Support S3, SNS, DynamoDB and kinesis events
         """
         if 's3' in record:
-            return record['s3']['configurationId'].split(':')[-1]
+            if ':' in record['s3']['configurationId']:
+                return record['s3']['configurationId'].split(':')[-1]
 
         arn = None
         if 'Sns' in record:
@@ -297,6 +298,8 @@ class LambdaHandler(object):
             arn = record['Sns'].get('TopicArn')
         elif 'dynamodb' in record or 'kinesis' in record:
             arn = record.get('eventSourceARN')
+        elif 's3' in record:
+            arn = record['s3']['bucket']['arn']
 
         if arn:
             return self.settings.AWS_EVENT_MAPPING.get(arn)


### PR DESCRIPTION
This change allows a lambda created with `zappa package` to be connected to an s3 event notification that was created with cloud formation. Cloud formation does not allow you to name the s3 event notification, so instead of using the s3 configuration id to get the handler to call, this gets the bucket arn and does a lookup of the handler based on the arn

## GitHub Issues
Adds feature requested in #1421 

