### PR TITLE
Fix certifying a domain for the first time.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1825,7 +1825,7 @@ class ZappaCLI(object):
         # Custom SSL / ACM
         else:
             route53 = self.stage_config.get('route53_enabled', True)
-            if not self.zappa.get_domain_name(self.domain):
+            if not self.zappa.get_domain_name(self.domain, route53=route53):
                 dns_name = self.zappa.create_domain_name(
                     domain_name=self.domain,
                     certificate_name=self.domain + "-Zappa-Cert",
@@ -1834,8 +1834,7 @@ class ZappaCLI(object):
                     certificate_chain=certificate_chain,
                     certificate_arn=cert_arn,
                     lambda_name=self.lambda_name,
-                    stage=self.api_stage,
-                    route53=route53
+                    stage=self.api_stage
                 )
                 if route53:
                     self.zappa.update_route53_records(self.domain, dns_name)


### PR DESCRIPTION
## Description
In #1411 I added the route53 kwarg to `core.Zappa.get_domain_name` but when I
actually went to use the arg in `cli.ZappaCLI.certify` I added it to the next
line down... This was because I had originally made the change in my project's
venv, just to see if it was as simple as it looked, and when it worked I
cloned the Zappa repo and reimplemented it. Obviously I messed that up.

As reported by @tamiel on #1411 the call to `core.Zappa.create_domain_name` was
throwing a TypeError because of the unrecognized keyword argument. This was
not getting caught in the integration tests around `certify` because the
mocked functions were taking variable arguments.

This commit fixes the original mistake and changes the mock in
`tests.TestZappa.test_certify_sanity_checks` to use `mock.create_autospec`
instead of a custom class so that it actually has the same function signatures
as a real instance would.

## GitHub Issues
No issue raised yet but the problem was reported here: https://github.com/Miserlou/Zappa/pull/1411#issuecomment-370967045

