### PR TITLE
print() is a function in Python 3

### DIFF
--- a/example/mymodule.py
+++ b/example/mymodule.py
@@ -1,7 +1,11 @@
+from __future__ import print_function
+
+
 def myfunc():
-    print 'Running my function in a schedule!'
+    print('Running my function in a schedule!')
+
 
 def myfunc_with_events(event, context):
-    print 'Event time was', event['time']
-    print 'This log is', context.log_group_name, context.log_stream_name
-    print 'Time left for execution:', context.get_remaining_time_in_millis()
+    print('Event time was', event['time'])
+    print('This log is', context.log_group_name, context.log_stream_name)
+    print('Time left for execution:', context.get_remaining_time_in_millis())

--- a/tests/tests_middleware.py
+++ b/tests/tests_middleware.py
@@ -1,9 +1,14 @@
 # -*- coding: utf8 -*-
-import unittest
 import sys
+import unittest
 
 from zappa.wsgi import create_wsgi_request
 from zappa.middleware import ZappaWSGIMiddleware, all_casings
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 
 class TestWSGIMockMiddleWare(unittest.TestCase):
@@ -245,5 +250,3 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         self.assertEqual(environ['HTTP_APISTAGE'], u'prod')
         self.assertNotIn('HTTP_INVALIDVALUE', environ)
         self.assertNotIn('HTTP_OTHERINVALID', environ)
-
-

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -8,8 +8,6 @@ Zappa core library. You may also want to look at `cli.py` and `util.py`.
 
 from __future__ import print_function
 
-import boto3
-import botocore
 import getpass
 import glob
 import hashlib
@@ -17,34 +15,38 @@ import json
 import logging
 import os
 import random
-import requests
 import shutil
 import string
 import subprocess
 import tarfile
 import tempfile
 import time
+import uuid
+import zipfile
+from builtins import bytes, int
+from distutils.dir_util import copy_tree
+from io import open
+
+import requests
+from setuptools import find_packages
+
+import boto3
+import botocore
 import troposphere
 import troposphere.apigateway
-import zipfile
-import uuid
-
-from builtins import int, bytes
 from botocore.exceptions import ClientError
-from distutils.dir_util import copy_tree
-from io import BytesIO, open
 from lambda_packages import lambda_packages as lambda_packages_orig
-from setuptools import find_packages
 from tqdm import tqdm
 
-from .utilities import (copytree,
-                    add_event_source,
-                    remove_event_source,
-                    human_size,
-                    get_topic_name,
-                    contains_python_files_or_subdirs,
-                    conflicts_with_a_neighbouring_module,
-                    get_venv_from_python_version)
+from .utilities import (add_event_source, conflicts_with_a_neighbouring_module,
+                        contains_python_files_or_subdirs, copytree,
+                        get_topic_name, get_venv_from_python_version,
+                        human_size, remove_event_source)
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 # We lower-case lambda package keys to match lower-cased keys in get_installed_packages()
 lambda_packages = {package_name.lower(): val for package_name, val in lambda_packages_orig.items()}


### PR DESCRIPTION
Fixes Python 3 syntax errors and the unresolved name __unicode__.

flake8 testing of https://github.com/Miserlou/Zappa on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./example/mymodule.py:2:46: E999 SyntaxError: invalid syntax
    print 'Running my function in a schedule!'
                                             ^
./tests/tests_middleware.py:43:27: F821 undefined name 'unicode'
            ugly_string = unicode("˝ÓÔÒÚÆ☃ЗИЙКЛМФХЦЧШ차를 타고 온 펲시맨(╯°□°）╯︵ ┻━┻)"
                          ^
./tests/utils.py:62:32: F821 undefined name 'file'
    mock_file = MagicMock(spec=file)
                               ^
./zappa/core.py:569:35: F821 undefined name 'unicode'
            package_id_file.write(unicode(dumped))
                                  ^
./zappa/core.py:2648:37: F821 undefined name 'lambda_name'
        topic_name = get_topic_name(lambda_name)
                                    ^
1     E999 SyntaxError: invalid syntax
4     F821 undefined name 'unicode'
5
```