### PR TITLE
Allow multiple ARNs for a single event definition

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2312,10 +2312,17 @@ class ZappaCLI(object):
             event_mapping = {}
             events = self.stage_config.get('events', [])
             for event in events:
-                arn = event.get('event_source', {}).get('arn')
                 function = event.get('function')
-                if arn and function:
-                    event_mapping[arn] = function
+                if not function:
+                    continue
+
+                arns = event.get('event_source', {}).get('arn')
+                if not isinstance(arns, list):
+                    arns = [arns]
+
+                for arn in arns:
+                    if arn:
+                        event_mapping[arn] = function
             settings_s = settings_s + "AWS_EVENT_MAPPING={0!s}\n".format(event_mapping)
 
             # Map Lext bot events

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2386,33 +2386,42 @@ class Zappa(object):
                         print("Problem scheduling {} with expression {}.".format(rule_name, expression))
 
             elif event_source:
-                service = self.service_from_arn(event_source['arn'])
-
-                if service not in pull_services:
-                    svc = ','.join(event['event_source']['events'])
-                    self.create_event_permission(
-                        lambda_name,
-                        service + '.amazonaws.com',
-                        event['event_source']['arn']
-                    )
+                if isinstance(event_source['arn'], list):
+                    arns = event_source['arn']
                 else:
-                    svc = service
+                    arns = [event_source['arn']]
 
-                rule_response = add_event_source(
-                    event_source,
-                    lambda_arn,
-                    function,
-                    self.boto_session
-                )
+                for arn in arns:
+                    service = self.service_from_arn(arn)
 
-                if rule_response == 'successful':
-                    print("Created {} event schedule for {}!".format(svc, function))
-                elif rule_response == 'failed':
-                    print("Problem creating {} event schedule for {}!".format(svc, function))
-                elif rule_response == 'exists':
-                    print("{} event schedule for {} already exists - Nothing to do here.".format(svc, function))
-                elif rule_response == 'dryrun':
-                    print("Dryrun for creating {} event schedule for {}!!".format(svc, function))
+                    if service not in pull_services:
+                        svc = ','.join(event['event_source']['events'])
+                        self.create_event_permission(
+                            lambda_name,
+                            service + '.amazonaws.com',
+                            arn
+                        )
+                    else:
+                        svc = service
+
+                    rule_response = add_event_source(
+                        {
+                            'arn': arn,
+                            'events': event_source['events']
+                        },
+                        lambda_arn,
+                        function,
+                        self.boto_session
+                    )
+
+                    if rule_response == 'successful':
+                        print("Created {} event schedule for {}:{}!".format(svc, function, arn))
+                    elif rule_response == 'failed':
+                        print("Problem creating {} event schedule for {}:{}!".format(svc, function, arn))
+                    elif rule_response == 'exists':
+                        print("{} event schedule for {}:{} already exists - Nothing to do here.".format(svc, function, arn))
+                    elif rule_response == 'dryrun':
+                        print("Dryrun for creating {} event schedule for {}:{}!!".format(svc, function, arn))
             else:
                 print("Could not create event {} - Please define either an expression or an event source".format(name))
 
@@ -2524,17 +2533,26 @@ class Zappa(object):
             function = event['function']
             name = event.get('name', function)
             event_source = event.get('event_source', function)
-            service = self.service_from_arn(event_source['arn'])
-            # DynamoDB and Kinesis streams take quite a while to setup after they are created and do not need to be
-            # re-scheduled when a new Lambda function is deployed. Therefore, they should not be removed during zappa
-            # update or zappa schedule.
-            if service not in excluded_source_services:
-                remove_event_source(
-                    event_source,
-                    lambda_arn,
-                    function,
-                    self.boto_session
-                )
+            if isinstance(event_source['arn'], list):
+                arns = event_source['arn']
+            else:
+                arns = [event_source['arn']]
+            for arn in arns:
+                service = self.service_from_arn(arn)
+                # DynamoDB and Kinesis streams take quite a while to setup after they are created and do not need to be
+                # re-scheduled when a new Lambda function is deployed. Therefore, they should not be removed during zappa
+                # update or zappa schedule.
+                if service not in excluded_source_services:
+                    remove_event_source(
+                        {
+                            'arn': arn,
+                            'events': event_source['events']
+                        },
+                        lambda_arn,
+                        function,
+                        self.boto_session
+                    )
+
                 print("Removed event " + name + " (" + str(event_source['events']) + ").")
 
     ###

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2386,9 +2386,8 @@ class Zappa(object):
                         print("Problem scheduling {} with expression {}.".format(rule_name, expression))
 
             elif event_source:
-                if isinstance(event_source['arn'], list):
-                    arns = event_source['arn']
-                else:
+                arns = event_source['arn']
+                if not isinstance(event_source['arn'], list):
                     arns = [event_source['arn']]
 
                 for arn in arns:
@@ -2533,9 +2532,8 @@ class Zappa(object):
             function = event['function']
             name = event.get('name', function)
             event_source = event.get('event_source', function)
-            if isinstance(event_source['arn'], list):
-                arns = event_source['arn']
-            else:
+            arns = event_source['arn']
+            if not isinstance(arns, list):
                 arns = [event_source['arn']]
             for arn in arns:
                 service = self.service_from_arn(arn)


### PR DESCRIPTION
## Description

There was a bug with AWS event source handling when trying to setup triggers on the same function from multiple events. Only 1 of the events would be setup. In the original setup, the following `zappa_settings.json` would result in the behaviour described:

```json
{
    "prod": {
        "s3_bucket": "my-zappa-packages",
        "role_name": "my-zappa-role",
        "cloudwatch_log_level": "ERROR",
        "events": [
            {
                "function": "my_app.handle_my_trigger",
                "event_source": {
                    "arn": "arn:aws:s3:::my-first-bucket",
                    "events": [
                        "s3:ObjectCreated:*"
                    ]
                }
            },
            {
                "function": "my_app.handle_my_trigger",
                "event_source": {
                    "arn": "arn:aws:s3:::my-second-bucket",
                    "events": [
                        "s3:ObjectCreated:*"
                    ]
                }
            },
            {
                "function": "my_app.handle_my_trigger",
                "event_source": {
                    "arn": "arn:aws:s3:::my-third-bucket",
                    "events": [
                        "s3:ObjectCreated:*"
                    ]
                }
            }
        ]
    }
}
```

Whereas, with these changes, the following settings work as expected, setting up the event source triggers on each of the buckets in question:

```json
{
    "prod": {
        "s3_bucket": "my-zappa-packages",
        "role_name": "my-zappa-role",
        "cloudwatch_log_level": "ERROR",
        "events": [
            {
                "function": "my_app.handle_my_trigger",
                "event_source": {
                    "arn": [
                        "arn:aws:s3:::my-first-bucket",
                        "arn:aws:s3:::my-second-bucket",
                        "arn:aws:s3:::my-third-bucket"
                    ],
                    "events": [
                        "s3:ObjectCreated:*"
                    ]
                }
            }
        ]
    }
}
```