### PR TITLE
1465 regional endpoint option

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1756,7 +1756,7 @@ class ZappaCLI(object):
             if confirm != 'y':
                 return
 
-        # Make sure this isn't already deployed.
+        # Make sure this is already deployed.
         deployed_versions = self.zappa.get_lambda_function_versions(self.lambda_name)
         if len(deployed_versions) == 0:
             raise ClickException("This application " + click.style("isn't deployed yet", fg="red") +
@@ -1768,6 +1768,7 @@ class ZappaCLI(object):
         cert_key_location = self.stage_config.get('certificate_key', None)
         cert_chain_location = self.stage_config.get('certificate_chain', None)
         cert_arn = self.stage_config.get('certificate_arn', None)
+        use_regional_endpoint = self.stage_config.get('use_regional_endpoint', False)
 
         # These are sensitive
         certificate_body = None
@@ -1834,7 +1835,8 @@ class ZappaCLI(object):
                     certificate_chain=certificate_chain,
                     certificate_arn=cert_arn,
                     lambda_name=self.lambda_name,
-                    stage=self.api_stage
+                    stage=self.api_stage,
+                    use_regional_endpoint=use_regional_endpoint
                 )
                 if route53:
                     self.zappa.update_route53_records(self.domain, dns_name)
@@ -1850,7 +1852,8 @@ class ZappaCLI(object):
                     certificate_arn=cert_arn,
                     lambda_name=self.lambda_name,
                     stage=self.api_stage,
-                    route53=route53
+                    route53=route53,
+                    use_regional_endpoint=use_regional_endpoint
                 )
 
             cert_success = True

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1827,7 +1827,7 @@ class ZappaCLI(object):
         else:
             route53 = self.stage_config.get('route53_enabled', True)
             if not self.zappa.get_domain_name(self.domain, route53=route53):
-                dns_name = self.zappa.create_domain_name(
+                agw_response = self.zappa.create_domain_name(
                     domain_name=self.domain,
                     certificate_name=self.domain + "-Zappa-Cert",
                     certificate_body=certificate_body,
@@ -1838,8 +1838,18 @@ class ZappaCLI(object):
                     stage=self.api_stage,
                     use_regional_endpoint=use_regional_endpoint
                 )
+
                 if route53:
-                    self.zappa.update_route53_records(self.domain, dns_name)
+                    # https://github.com/Miserlou/Zappa/issues/1465
+                    if use_regional_endpoint:
+                        dns_name = agw_response['regionalDomainName']
+                        target_hosted_zone_id = agw_response['regionalHostedZoneId']
+                        self.zappa.update_route53_records_for_regional_alias(
+                            self.domain, dns_name, target_hosted_zone_id)
+                    else:
+                        dns_name = agw_response['distributionDomainName']
+                        self.zappa.update_route53_records(self.domain, dns_name)
+
                 print("Created a new domain name with supplied certificate. Please note that it can take up to 40 minutes for this domain to be "
                       "created and propagated through AWS, but it requires no further work on your part.")
             else:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1826,7 +1826,8 @@ class ZappaCLI(object):
 
         # Custom SSL / ACM
         else:
-            if not self.zappa.get_domain_name(self.domain, route53=route53):
+            if not self.zappa.get_api_domain_name(self.domain):
+                # Follow the create flow, if there is NO entry in API Gateway for the domain
                 agw_response = self.zappa.create_domain_name(
                     domain_name=self.domain,
                     certificate_name=self.domain + "-Zappa-Cert",
@@ -1842,6 +1843,7 @@ class ZappaCLI(object):
                 print("Created a new domain name with supplied certificate. Please note that it can take up to 40 minutes for this domain to be "
                       "created and propagated through AWS, but it requires no further work on your part.")
             else:
+                # Follow the update flow, if there is an entry in API Gateway for the domain
                 agw_response = self.zappa.update_domain_name(
                     domain_name=self.domain,
                     certificate_name=self.domain + "-Zappa-Cert",
@@ -1856,6 +1858,7 @@ class ZappaCLI(object):
                 )
 
             if route53:
+                # Uses UPSERT, so always try to update route53, if route53 in use
                 # https://github.com/Miserlou/Zappa/issues/1465
                 if use_regional_endpoint:
                     dns_name = agw_response['regionalDomainName']

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2303,6 +2303,19 @@ class Zappa(object):
 
         return None
 
+    def get_api_domain_name(self, domain_name):
+        """
+        Get the API gateway domain name entry
+
+        Returns the record entry, else None.
+
+        """
+        # Make sure api gateway domain is present
+        try:
+            return self.apigateway_client.get_domain_name(domainName=domain_name)
+        except Exception:
+            return None
+
     ##
     # IAM
     ##

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2026,10 +2026,7 @@ class Zappa(object):
             stage=stage
         )
 
-        if use_regional_endpoint:
-            return agw_response['regionalDomainName']
-        else:
-            return agw_response['distributionDomainName']
+        return agw_response
 
     def update_route53_records(self, domain_name, dns_name):
         """
@@ -2082,6 +2079,35 @@ class Zappa(object):
 
         return response
 
+    def update_route53_records_for_regional_alias(self, domain_name, dns_name, target_hosted_zone_id):
+        """
+        Updates Route53 Records following GW regional endpoint creation
+        """
+        zone_id = self.get_hosted_zone_id_for_domain(domain_name)
+        record_set = {
+            'Name': domain_name,
+            'Type': 'A',
+            'AliasTarget': {
+                'HostedZoneId': target_hosted_zone_id,
+                'DNSName': dns_name,
+                'EvaluateTargetHealth': False
+            }
+        }
+
+        response = self.route53.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                'Changes': [
+                    {
+                        'Action': 'UPSERT',
+                        'ResourceRecordSet': record_set
+                    }
+                ]
+            }
+        )
+
+        return response
+
     def update_domain_name(self,
                            domain_name,
                            certificate_name=None,
@@ -2113,7 +2139,6 @@ class Zappa(object):
         print("Updating domain name!")
 
         certificate_name = certificate_name + str(time.time())
-
         api_gateway_domain = self.apigateway_client.get_domain_name(domainName=domain_name)
         if not certificate_arn\
            and certificate_body and certificate_private_key and certificate_chain:
@@ -2121,6 +2146,66 @@ class Zappa(object):
                                                                  PrivateKey=certificate_private_key,
                                                                  CertificateChain=certificate_chain)
             certificate_arn = acm_certificate['CertificateArn']
+
+        current_endpoint_type = api_gateway_domain['endpointConfiguration']['types'][0]
+        target_endpoint_type = 'REGIONAL' if use_regional_endpoint else 'EDGE'
+
+        if current_endpoint_type != target_endpoint_type:
+            # If changing type EDGE <=> REGIONAL
+            if use_regional_endpoint:
+                # Change EDGE to REGIONAL
+                # https://stackoverflow.com/a/47537714/401636 (use add then remove)
+                self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "add", "path": "/regionalCertificateName", "value": certificate_name},
+                        {"op": "add", "path": "/regionalCertificateArn", "value": certificate_arn},
+                        {"op": "add", "path": "/endpointConfiguration/types", "value": "REGIONAL"}
+                    ])
+                return self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "remove", "path": "/certificateName"},
+                        {"op": "remove", "path": "/certificateArn"},
+                        {"op": "remove", "path": "/endpointConfiguration/types", "value": "EDGE"}
+                    ])
+            else:
+                # Change REGIONAL to EDGE
+                # https://stackoverflow.com/a/47537714/401636 (use add then remove)
+                self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "add", "path": "/certificateName", "value": certificate_name},
+                        {"op": "add", "path": "/certificateArn", "value": certificate_arn},
+                        {"op": "add", "path": "/endpointConfiguration/types", "value": "EDGE"}
+                    ])
+                return self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "remove", "path": "/regionalCertificateName"},
+                        {"op": "remove", "path": "/regionalCertificateArn"},
+                        {"op": "remove", "path": "/endpointConfiguration/types", "value": "REGIONAL"}
+                    ])
+
+        else:
+            # NOT changing type EDGE <=> REGIONAL
+            if use_regional_endpoint:
+                return self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "replace", "path": "/regionalCertificateName", "value": certificate_name},
+                        {"op": "replace", "path": "/regionalCertificateArn", "value": certificate_arn}
+                    ])
+            else:
+                return self.apigateway_client.update_domain_name(
+                    domainName=domain_name,
+                    patchOperations=[
+                        {"op": "replace", "path": "/certificateName", "value": certificate_name},
+                        {"op": "replace", "path": "/certificateArn", "value": certificate_arn}
+                    ])
+
+
+
 
         if use_regional_endpoint:
             # https://github.com/Miserlou/Zappa/issues/1465

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2210,56 +2210,6 @@ class Zappa(object):
                     ])
 
 
-
-
-        if use_regional_endpoint:
-            # https://github.com/Miserlou/Zappa/issues/1465
-            return self.apigateway_client.update_domain_name(
-                domainName=domain_name,
-                patchOperations=[
-                    {"op": "remove",
-                     "path": "/certificateName"},
-                    {"op": "remove",
-                     "path": "/certificateArn"},
-                    {"op": "replace",
-                     "path": "/regionalCertificateName",
-                     "value": certificate_name},
-                    {"op": "replace",
-                     "path": "/regionalCertificateArn",
-                     "value": certificate_arn},
-                    # https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-api-migration.html
-                    {"op": "replace",
-                     "path": "/endpointConfiguration/types/EDGE",
-                     "value": "REGIONAL"}
-                ])
-        else:
-            # https://stackoverflow.com/a/47537714/401636 (use add/remove)
-            self.apigateway_client.update_domain_name(
-                domainName=domain_name,
-                patchOperations=[
-                    {"op": "replace",
-                     "path": "/certificateName",
-                     "value": certificate_name},
-                    {"op": "replace",
-                     "path": "/certificateArn",
-                     "value": certificate_arn},
-                    {"op": "add",
-                     "path": "/endpointConfiguration/types",
-                     "value": "EDGE"}
-                ])
-
-            return self.apigateway_client.update_domain_name(
-                domainName=domain_name,
-                patchOperations=[
-                    {"op": "remove",
-                     "path": "/regionalCertificateName"},
-                    {"op": "remove",
-                     "path": "/regionalCertificateArn"},
-                    {"op": "remove",
-                     "path": "/endpointConfiguration/types",
-                     "value": "REGIONAL"}
-                ])
-
     def get_domain_name(self, domain_name, route53=True):
         """
         Scan our hosted zones for the record of a given name.


### PR DESCRIPTION
## Checklist
* If this is a non-trivial commit, did you **open a ticket** for discussion? *yes*
* Did you **put the URL for that ticket in a comment** in the code? *yes*
* If you made a new function, did you **write a good docstring** for it? *yes*
* Did you avoid putting "_" in front of your new function for no reason? *yes*
* Did you write a test for your new code? *Adjusted existing tests, added coverage in cli testing. there was no existing coverage of `zappa.create_domain_name / update_domain_name`, did not add new tests*
* Did the Travis build pass? *TBD - local nose passes on 3.7*
* Did you improve (or at least not significantly reduce)  the amount of code test coverage? *yes*
* Did you **make sure this code actually works on Lambda**, as well as locally? *Yes, converted REGIONAL to EDGE and back*
* Did you test this code with both **Python 2.7** and **Python 3.6**? *No, shouldn't be anything version dependent*

## Description
This turned out a little bigger than I liked for a couple reasons.

We wanted to use A - Alias records in Route53 for regional endpoints. I included that without changing the existing behavior in the default case, but probably it would be better to replace the CNAME with A - Alias.

Finding the update from EDGE to REGIONAL required changing a bit of the logic around if something is a create or update. Truthfully the old method of using Route53 existence to drive create or update was flawed. Now it will check with APIG to see if the domain_name entry exists and use that to drive create or update of the APIG domain_name. If Route53 is in use, it will always try to UPSERT the record, at worst this is a noop.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1465

