### PR TITLE
Fix canonical headers

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -24,7 +24,7 @@ from zappa.letsencrypt import get_cert_and_update_domain, create_domain_key, cre
     register_account, verify_challenge
 from zappa.utilities import (detect_django_settings, detect_flask_apps,  parse_s3_url, human_size, string_to_timestamp,
                              validate_name, InvalidAwsLambdaName, contains_python_files_or_subdirs,
-                             conflicts_with_a_neighbouring_module)
+                             conflicts_with_a_neighbouring_module, titlecase_keys)
 from zappa.wsgi import create_wsgi_request, common_log
 from zappa.core import Zappa, ASSUME_POLICY, ATTACH_POLICY
 
@@ -1741,6 +1741,30 @@ USE_TZ = True
             zappa_cli.create_package()
         self.assertEqual('Environment variable keys must be ascii.', str(context.exception))
 
+
+    def test_titlecase_keys(self):
+        raw = {
+            'hOSt': 'github.com',
+            'ConnECtiOn': 'keep-alive',
+            'UpGRAde-InSecuRE-ReQueSts': '1',
+            'uSer-AGEnT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
+            'cONtENt-TYPe': 'text/html; charset=utf-8',
+            'aCCEpT': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+            'ACcePT-encoDInG': 'gzip, deflate, br',
+            'AcCEpT-lAnGUagE': 'en-US,en;q=0.9'
+        }
+        transformed= titlecase_keys(raw)
+        expected = {
+            'Host': 'github.com',
+            'Connection': 'keep-alive',
+            'Upgrade-Insecure-Requests': '1',
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
+            'Content-Type': 'text/html; charset=utf-8',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Language': 'en-US,en;q=0.9'
+        }
+        self.assertEqual(expected, transformed)
 
 
 if __name__ == '__main__':

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -385,3 +385,11 @@ def conflicts_with_a_neighbouring_module(directory_path):
     neighbours = os.listdir(parent_dir_path)
     conflicting_neighbour_filename = current_dir_name+'.py'
     return conflicting_neighbour_filename in neighbours
+
+
+# https://github.com/Miserlou/Zappa/issues/1188
+def titlecase_keys(d):
+    """
+    Takes a dict with keys of type str and returns a new dict with all keys titlecased.
+    """
+    return {k.title(): v for k, v in d.items()}

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -15,6 +15,8 @@ if sys.version_info[0] < 3:
 else:
     from urllib.parse import urlencode
 
+from .utilities import titlecase_keys
+
 BINARY_METHODS = [
                     "POST",
                     "PUT",
@@ -82,14 +84,7 @@ def create_wsgi_request(event_info,
 
         # Make header names canonical, e.g. content-type => Content-Type
         # https://github.com/Miserlou/Zappa/issues/1188
-        canonicalized = {}
-        for header in headers.keys():
-            canonical = header.title()
-            if canonical != header:
-                canonicalized[header] = canonical
-
-        for header, canonical in canonicalized.items():
-            headers[canonical] = headers.pop(header)
+        headers = titlecase_keys(headers)
 
         path = urls.url_unquote(event_info['path'])
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -81,10 +81,15 @@ def create_wsgi_request(event_info,
                 body = body.encode("utf-8")
 
         # Make header names canonical, e.g. content-type => Content-Type
+        # https://github.com/Miserlou/Zappa/issues/1188
+        canonicalized = {}
         for header in headers.keys():
             canonical = header.title()
             if canonical != header:
-                headers[canonical] = headers.pop(header)
+                canonicalized[header] = canonical
+
+        for header, canonical in canonicalized.items():
+            headers[canonical] = headers.pop(header)
 
         path = urls.url_unquote(event_info['path'])
 


### PR DESCRIPTION
## Description
This PR fixes a bug in `zappa.wsgi.create_wsgi_request` function that non-deterministically results in some HTTP headers not being titlecased and consequently not being associated with the correct key in the `environ` dict that is returned. For example, the `content-type` header may end up in  `environ['HTTP_CONTENT_TYPE']` instead of `environ['CONTENT_TYPE']` where a wsgi app expects it to be. The reason this happens is because the `headers` dict is modified while it is being iterated. This PR refactors the title casing logic into a utility function which creates and returns a new dict instead of modifying the existing dict in place. The utility function has the added benefit of being reusable and more easily tested.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1188

