### PR TITLE
fix Cognito lambda config for PreTokenGeneration trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ to change Zappa's behavior. Use these at your own risk!
         "cognito": { // for Cognito event triggers
             "user_pool": "user-pool-id", // User pool ID from AWS Cognito
             "triggers": [{
-                "source": "PreSignUp_SignUp", // triggerSource from http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-pre-signup
+                "source": "PreSignUp_SignUp", // triggerSource from https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-lambda-trigger-syntax-shared.html
                 "function": "my_app.pre_signup_function"
             }]
         },

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1119,7 +1119,7 @@ class ZappaCLI(object):
             triggers = self.cognito.get('triggers', [])
             lambda_configs = set()
             for trigger in triggers:
-                lambda_configs.add(trigger['source'].split('_')[0])
+                lambda_configs.add(trigger['source'].split('_')[0].replace('TokenGeneration', 'PreTokenGeneration'))
             self.zappa.update_cognito(self.lambda_name, user_pool, lambda_configs, self.lambda_arn)
 
     def schedule(self):


### PR DESCRIPTION
## Description
<!-- Please describe the changes included in this PR --> 
Map triggerSource prefixed with TokenGeneration to the PreTokenGeneration LambdaConfig.

The [PreTokenGeneration trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html) does not follow the same naming pattern as the other Cognito Lambda [trigger sources](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-lambda-trigger-syntax-shared.html)

Example error:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in LambdaConfig: "TokenGeneration", must be one of: PreSignUp, CustomMessage, PostConfirmation, PreAuthentication, PostAuthentication, DefineAuthChallenge, CreateAuthChallenge, VerifyAuthChallengeResponse, PreTokenGeneration, UserMigration
```
