### PR TITLE
Add support to delete old versions of lambda functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ to change Zappa's behavior. Use these at your own risk!
         "log_level": "DEBUG", // Set the Zappa log level. Can be one of CRITICAL, ERROR, WARNING, INFO and DEBUG. Default: DEBUG
         "manage_roles": true, // Have Zappa automatically create and define IAM execution roles and policies. Default true. If false, you must define your own IAM Role and role_name setting.
         "memory_size": 512, // Lambda function memory in MB. Default 512.
+        "num_retained_versions":10, // Indicates the number of old versions to retain for the lambda. If absent, keeps all the versions of the function.
         "payload_compression": true, // Whether or not to enable API gateway payload compression (default: true)
         "payload_minimum_compression_size": 0, // The threshold size (in bytes) below which payload compression will not be applied (default: 0)
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -915,7 +915,8 @@ class ZappaCLI(object):
             self.lambda_arn = self.zappa.update_lambda_function(
                                             bucket,
                                             self.lambda_name,
-                                            key_name
+                                            key_name,
+                                            num_revisions=self.num_retained_versions
                                         )
         elif source_zip and not source_zip.startswith('s3://'):
             with open(source_zip, mode='rb') as fh:
@@ -923,14 +924,16 @@ class ZappaCLI(object):
             self.lambda_arn = self.zappa.update_lambda_function(
                                             self.s3_bucket_name,
                                             self.lambda_name,
-                                            local_zip=byte_stream
+                                            local_zip=byte_stream,
+                                            num_revisions=self.num_retained_versions
                                         )
         else:
             if not no_upload:
                 self.lambda_arn = self.zappa.update_lambda_function(
                                                 self.s3_bucket_name,
                                                 self.lambda_name,
-                                                handler_file
+                                                handler_file,
+                                                num_revisions=self.num_retained_versions
                                             )
 
         # Remove the uploaded zip from S3, because it is now registered..
@@ -1996,6 +1999,7 @@ class ZappaCLI(object):
         dead_letter_arn = self.stage_config.get('dead_letter_arn', '')
         self.dead_letter_config = {'TargetArn': dead_letter_arn} if dead_letter_arn else {}
         self.cognito = self.stage_config.get('cognito', None)
+        self.num_retained_versions = self.stage_config.get('num_retained_versions',None)
 
         # Provide legacy support for `use_apigateway`, now `apigateway_enabled`.
         # https://github.com/Miserlou/Zappa/issues/490

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1064,9 +1064,10 @@ class Zappa(object):
 
         return resource_arn
 
-    def update_lambda_function(self, bucket, function_name, s3_key=None, publish=True, local_zip=None):
+    def update_lambda_function(self, bucket, function_name, s3_key=None, publish=True, local_zip=None, num_revisions=None):
         """
         Given a bucket and key (or a local path) of a valid Lambda-zip, a function name and a handler, update that Lambda function's code.
+        Optionally, delete previous versions if they exceed the optional limit.
         """
         print("Updating Lambda function code..")
 
@@ -1081,6 +1082,22 @@ class Zappa(object):
             kwargs['S3Key'] = s3_key
 
         response = self.lambda_client.update_function_code(**kwargs)
+
+        if type(num_revisions) is int and num_revisions>=1:
+            # Find the existing revision IDs for the given function
+            # Related: https://github.com/Miserlou/Zappa/issues/1402
+            versions_in_lambda = []
+            versions = self.lambda_client.list_versions_by_function(FunctionName=function_name)
+            for version in versions['Versions']:
+                versions_in_lambda.append(version['Version'])
+            while 'NextMarker' in versions:
+                versions = self.lambda_client.list_versions_by_function(FunctionName=function_name,Marker=versions['NextMarker'])
+                for version in versions['Versions']:
+                    versions_in_lambda.append(version['Version'])
+            versions_in_lambda.remove('$LATEST')
+            # Delete older revisions if their number exceeds the specified limit
+            for version in versions_in_lambda[::-1][num_revisions:]:
+                self.lambda_client.delete_function(FunctionNmae=function_name,Qualifier=version)
 
         return response['FunctionArn']
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Added settings flag to limit the number of versions for a function in lambda to avoid crossing the limit on max storage for lambda.
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
Resolves https://github.com/Miserlou/Zappa/issues/1402
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
