### PR TITLE
Bump lambda packages version to fix #1455

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ futures==3.2.0; python_version < '3'
 hjson==3.0.1
 jmespath==0.9.3
 kappa==0.6.0
-lambda-packages==0.19.0
+lambda-packages==0.20.0
 pip==9.0.1
 python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4


### PR DESCRIPTION
## Description
Bump lambda package version to get access to Cyptography 2.1

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1455
