### PR TITLE
Fixes AttributeError: 'module' object has no attribute 'get_installed…

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -748,7 +748,7 @@ class Zappa(object):
         """
         Returns a dict of installed packages that Zappa cares about.
         """
-        import pip  # this is to avoid 'funkiness' with global import
+        from pip._internal.utils.misc import get_installed_distributions  # this is to avoid 'funkiness' with global import
         package_to_keep = []
         if os.path.isdir(site_packages):
             package_to_keep += os.listdir(site_packages)
@@ -758,7 +758,7 @@ class Zappa(object):
         package_to_keep = [x.lower() for x in package_to_keep]
 
         installed_packages = {package.project_name.lower(): package.version for package in
-                              pip.get_installed_distributions()
+                              get_installed_distributions()
                               if package.project_name.lower() in package_to_keep
                               or package.location in [site_packages, site_packages_64]}
 


### PR DESCRIPTION
I kept coming across this error when trying to update any of my environments. This was how I fixed it. 
`
Traceback (most recent call last):
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/cli.py", line 2610, in handle
    sys.exit(cli.handle())
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/cli.py", line 505, in handle
    self.dispatch_command(self.command, stage)
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/cli.py", line 549, in dispatch_command
    self.update(self.vargs['zip'], self.vargs['no_upload'])
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/cli.py", line 877, in update
    self.create_package()
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/cli.py", line 2171, in create_package
    disable_progress=self.disable_progress
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/core.py", line 595, in create_lambda_zip
    installed_packages = self.get_installed_packages(site_packages, site_packages_64)
  File "${project}/venv/local/lib/python2.7/site-packages/zappa/core.py", line 751, in get_installed_packages
    pip.get_installed_distributions()
AttributeError: 'module' object has no attribute 'get_installed_distributions'
`