### PR TITLE
Pip10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ hjson==3.0.1
 jmespath==0.9.3
 kappa==0.6.0
 lambda-packages==0.19.0
-pip==9.0.1
+pip>=9.0.1, <=10.0.0
 python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4
 PyYAML==3.12

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -165,13 +165,9 @@ class TestZappa(unittest.TestCase):
 
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['super_package']):
-                import pip  # this gets called in non-test Zappa mode
-                try:
-                    with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
-                        self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
-                except ImportError:
-                    with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
-                        self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
+                import pkg_resources  # this gets called in non-test Zappa mode
+                with mock.patch('pkg_resources.WorkingSet', return_value=mock_pip_installed_packages):
+                    self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
 
     def test_getting_installed_packages_mixed_case(self, *args):
         z = Zappa(runtime='python2.7')
@@ -182,13 +178,9 @@ class TestZappa(unittest.TestCase):
 
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['superpackage']):
-                import pip  # this gets called in non-test Zappa mode
-                try:
-                    with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
-                        self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
-                except ImportError:
-                    with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
-                        self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
+                import pkg_resources  # this gets called in non-test Zappa mode
+                with mock.patch('pkg_resources.WorkingSet', return_value=mock_pip_installed_packages):
+                    self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
 
 
     def test_load_credentials(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -108,7 +108,7 @@ class TestZappa(unittest.TestCase):
     #             self.assertEqual(mock_remove.call_count, 1)
 
     def test_create_lambda_package(self):
-        # mock the pip.get_installed_distributions() to include a known package in lambda_packages so that the code
+        # mock the pip._internal.utils.misc.get_installed_distributions() to include a known package in lambda_packages so that the code
         # for zipping pre-compiled packages gets called
         mock_installed_packages = {'psycopg2': '2.6.1'}
         with mock.patch('zappa.core.Zappa.get_installed_packages', return_value=mock_installed_packages):
@@ -166,7 +166,7 @@ class TestZappa(unittest.TestCase):
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['super_package']):
                 import pip  # this gets called in non-test Zappa mode
-                with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
                     self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
 
     def test_getting_installed_packages_mixed_case(self, *args):
@@ -179,7 +179,7 @@ class TestZappa(unittest.TestCase):
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['superpackage']):
                 import pip  # this gets called in non-test Zappa mode
-                with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
                     self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
 
     def test_load_credentials(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -166,8 +166,12 @@ class TestZappa(unittest.TestCase):
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['super_package']):
                 import pip  # this gets called in non-test Zappa mode
-                with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
-                    self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
+                try:
+                    with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
+                        self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
+                except AttributeError:
+                    with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                        self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
 
     def test_getting_installed_packages_mixed_case(self, *args):
         z = Zappa(runtime='python2.7')
@@ -179,8 +183,13 @@ class TestZappa(unittest.TestCase):
         with mock.patch('os.path.isdir', return_value=True):
             with mock.patch('os.listdir', return_value=['superpackage']):
                 import pip  # this gets called in non-test Zappa mode
-                with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
-                    self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
+                try:
+                    with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
+                        self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
+                except AttributeError:
+                    with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                        self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
+
 
     def test_load_credentials(self):
         z = Zappa()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -108,7 +108,7 @@ class TestZappa(unittest.TestCase):
     #             self.assertEqual(mock_remove.call_count, 1)
 
     def test_create_lambda_package(self):
-        # mock the pip._internal.utils.misc.get_installed_distributions() to include a known package in lambda_packages so that the code
+        # mock the pkg_resources.WorkingSet() to include a known package in lambda_packages so that the code
         # for zipping pre-compiled packages gets called
         mock_installed_packages = {'psycopg2': '2.6.1'}
         with mock.patch('zappa.core.Zappa.get_installed_packages', return_value=mock_installed_packages):
@@ -159,7 +159,7 @@ class TestZappa(unittest.TestCase):
     def test_getting_installed_packages(self, *args):
         z = Zappa(runtime='python2.7')
 
-        # mock pip packages call to be same as what our mocked site packages dir has
+        # mock pkg_resources call to be same as what our mocked site packages dir has
         mock_package = collections.namedtuple('mock_package', ['project_name', 'version', 'location'])
         mock_pip_installed_packages = [mock_package('super_package', '0.1', '/venv/site-packages')]
 
@@ -172,7 +172,7 @@ class TestZappa(unittest.TestCase):
     def test_getting_installed_packages_mixed_case(self, *args):
         z = Zappa(runtime='python2.7')
 
-        # mock pip packages call to be same as what our mocked site packages dir has
+        # mock pkg_resources call to be same as what our mocked site packages dir has
         mock_package = collections.namedtuple('mock_package', ['project_name', 'version', 'location'])
         mock_pip_installed_packages = [mock_package('SuperPackage', '0.1', '/venv/site-packages')]
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -169,7 +169,7 @@ class TestZappa(unittest.TestCase):
                 try:
                     with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
                         self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
-                except AttributeError:
+                except ImportError:
                     with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
                         self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
 
@@ -186,7 +186,7 @@ class TestZappa(unittest.TestCase):
                 try:
                     with mock.patch('pip._internal.utils.misc.get_installed_distributions', return_value=mock_pip_installed_packages):
                         self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
-                except AttributeError:
+                except ImportError:
                     with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
                         self.assertDictEqual(z.get_installed_packages('',''), {'superpackage' : '0.1'})
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -359,13 +359,10 @@ class Zappa(object):
         """
         For a given package, returns a list of required packages. Recursive.
         """
-        try: # for pip >= 10
-            from pip._internal.utils.misc import get_installed_distributions
-        except ImportError: # for pip <= 9.0.3
-            from pip import get_installed_distributions
+        import pkg_resources
         deps = []
         if not installed_distros:
-            installed_distros = get_installed_distributions()
+            installed_distros = pkg_resources.WorkingSet()
         for package in installed_distros:
             if package.project_name.lower() == pkg_name.lower():
                 deps = [(package.project_name, package.version)]

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -374,7 +374,7 @@ class Zappa(object):
         """
         Takes the installed zappa and brings it into a fresh virtualenv-like folder. All dependencies are then downloaded.
         """
-        import pip
+        import subprocess
 
         # We will need the currenv venv to pull Zappa from
         current_venv = self.get_current_venv()
@@ -403,7 +403,12 @@ class Zappa(object):
 
         # Need to manually add setuptools
         pkg_list.append('setuptools')
-        pip_return_code = pip.main(["install", "--quiet", "--target", venv_site_packages_dir] + pkg_list)
+        command = ["pip", "install", "--quiet", "--target", venv_site_packages_dir] + pkg_list
+
+        # Using subprocess as pip.main() is not supported
+        pip = subprocess.Popen(command, stdout=subprocess.PIPE)
+        pip_return_code = pip.communicate()[0]
+
         if pip_return_code:
           raise EnvironmentError("Pypi lookup failed")
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -359,6 +359,9 @@ class Zappa(object):
         """
         For a given package, returns a list of required packages. Recursive.
         """
+        # https://github.com/Miserlou/Zappa/issues/1478.  Using `pkg_resources`
+        # instead of `pip` is the recommended approach.  The usage is nearly
+        # identical.
         import pkg_resources
         deps = []
         if not installed_distros:
@@ -405,9 +408,12 @@ class Zappa(object):
         pkg_list.append('setuptools')
         command = ["pip", "install", "--quiet", "--target", venv_site_packages_dir] + pkg_list
 
-        # Using subprocess as pip.main() is not supported
-        pip = subprocess.Popen(command, stdout=subprocess.PIPE)
-        pip_return_code = pip.communicate()[0]
+        # This is the recommended method for installing packages if you don't
+        # to depend on `setuptools`
+        # https://github.com/pypa/pip/issues/5240#issuecomment-381662679
+        pip_process = subprocess.Popen(command, stdout=subprocess.PIPE)
+        # Using poll() since it gives us an meaningful return code
+        pip_return_code = pip_process.poll()
 
         if pip_return_code:
           raise EnvironmentError("Pypi lookup failed")

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -359,10 +359,10 @@ class Zappa(object):
         """
         For a given package, returns a list of required packages. Recursive.
         """
-        import pip
+        from pip._internal.utils.misc import get_installed_distributions
         deps = []
         if not installed_distros:
-            installed_distros = pip.get_installed_distributions()
+            installed_distros = get_installed_distributions()
         for package in installed_distros:
             if package.project_name.lower() == pkg_name.lower():
                 deps = [(package.project_name, package.version)]
@@ -750,7 +750,7 @@ class Zappa(object):
         """
         Returns a dict of installed packages that Zappa cares about.
         """
-        import pip  # this is to avoid 'funkiness' with global import
+        from pip._internal.utils.misc import get_installed_distributions
         package_to_keep = []
         if os.path.isdir(site_packages):
             package_to_keep += os.listdir(site_packages)
@@ -760,7 +760,7 @@ class Zappa(object):
         package_to_keep = [x.lower() for x in package_to_keep]
 
         installed_packages = {package.project_name.lower(): package.version for package in
-                              pip.get_installed_distributions()
+                              get_installed_distributions()
                               if package.project_name.lower() in package_to_keep
                               or package.location in [site_packages, site_packages_64]}
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -359,7 +359,10 @@ class Zappa(object):
         """
         For a given package, returns a list of required packages. Recursive.
         """
-        from pip._internal.utils.misc import get_installed_distributions
+        try: # for pip >= 10
+            from pip._internal.utils.misc import get_installed_distributions
+        except ImportError: # for pip <= 9.0.3
+            from pip import get_installed_distributions
         deps = []
         if not installed_distros:
             installed_distros = get_installed_distributions()
@@ -750,7 +753,10 @@ class Zappa(object):
         """
         Returns a dict of installed packages that Zappa cares about.
         """
-        from pip._internal.utils.misc import get_installed_distributions
+        try: # for pip >= 10
+            from pip._internal.utils.misc import get_installed_distributions
+        except ImportError: # for pip <= 9.0.3
+            from pip import get_installed_distributions
         package_to_keep = []
         if os.path.isdir(site_packages):
             package_to_keep += os.listdir(site_packages)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -753,10 +753,8 @@ class Zappa(object):
         """
         Returns a dict of installed packages that Zappa cares about.
         """
-        try: # for pip >= 10
-            from pip._internal.utils.misc import get_installed_distributions
-        except ImportError: # for pip <= 9.0.3
-            from pip import get_installed_distributions
+        import pkg_resources
+
         package_to_keep = []
         if os.path.isdir(site_packages):
             package_to_keep += os.listdir(site_packages)
@@ -766,7 +764,7 @@ class Zappa(object):
         package_to_keep = [x.lower() for x in package_to_keep]
 
         installed_packages = {package.project_name.lower(): package.version for package in
-                              get_installed_distributions()
+                              pkg_resources.WorkingSet()
                               if package.project_name.lower() in package_to_keep
                               or package.location in [site_packages, site_packages_64]}
 


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description


Zappa fails due to changes in pip==10.0.0.  `pip` changed how they deal with `get_installed_distributions`.  Unfortunately, the changes require usage of `pip._internal`, which goes against standard but it definitely works.

We can leverage the new method while also ensuring previous versions work.
```python
try: # for pip >= 10
    from pip._internal.utils.misc import get_installed_distributions
except ImportError: # for pip <= 9.0.3
    from pip import get_installed_distributions
```

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
https://github.com/Miserlou/Zappa/issues/1478

