### PR TITLE
isBase64Encoded is a boolean flag

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -512,7 +512,7 @@ class LambdaHandler(object):
                         if not response.mimetype.startswith("text/") \
                             or response.mimetype != "application/json":
                                 zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
-                                zappa_returndict["isBase64Encoded"] = "true"
+                                zappa_returndict["isBase64Encoded"] = True
                         else:
                             zappa_returndict['body'] = response.data
                     else:


### PR DESCRIPTION
## Description
_isBase64Encoded_ returned from invoking the Lambda (as ApiGateway request) is defined as boolean flag, so we should return a boolean instead of a string "true".
See [the docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format) for definition of the response.

This one was implemented in #657