### PR TITLE
Allow newest Werkzeug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ six>=1.11.0
 toml>=0.9.4
 tqdm==4.19.1
 troposphere>=1.9.0
-Werkzeug==0.13
+Werkzeug>=0.13
 wheel>=0.30.0
 wsgi-request-logger==0.4.6


### PR DESCRIPTION
## Description
Flask 1.0 requires Werkzeug>=0.14 which is incompatible with Zappa requirement of Werkzeug==0.12

