### PR TITLE
Fix path case sensitivity in get_installed_packages

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -834,56 +834,56 @@ class TestZappa(unittest.TestCase):
             os.chdir(orig_cwd)
             shutil.rmtree(tempdir)
 
-    # def test_cli_utility(self):
-    #     zappa_cli = ZappaCLI()
-    #     zappa_cli.api_stage = 'ttt888'
-    #     zappa_cli.load_settings('test_settings.json')
-    #     zappa_cli.create_package()
-    #     zappa_cli.remove_local_zip()
-    #     logs = [
-    #         {
-    #             'timestamp': '12345',
-    #             'message': '[START RequestId] test'
-    #         },
-    #         {
-    #             'timestamp': '12345',
-    #             'message': '[REPORT RequestId] test'
-    #         },
-    #         {
-    #             'timestamp': '12345',
-    #             'message': '[END RequestId] test'
-    #         },
-    #         {
-    #             'timestamp': '12345',
-    #             'message': 'test'
-    #         },
-    #         {
-    #             'timestamp': '1480001341214',
-    #             'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 200 2590 "" "python-requests/2.11.0" 0/4.672'
-    #         },
-    #         {
-    #             'timestamp': '1480001341214',
-    #             'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 400 2590 "" "python-requests/2.11.0" 0/4.672'
-    #         },
-    #         {
-    #             'timestamp': '1480001341215',
-    #             'message': '[1480001341258] [DEBUG] 2016-11-24T15:29:01.258Z b890d8f6-b25a-11e6-b6bc-718f7ec807df Zappa Event: {}'
-    #         }
-    #     ]
-    #     zappa_cli.print_logs(logs)
-    #     zappa_cli.print_logs(logs, colorize=False)
-    #     zappa_cli.print_logs(logs, colorize=False, http=True)
-    #     zappa_cli.print_logs(logs, colorize=True, http=True)
-    #     zappa_cli.print_logs(logs, colorize=True, http=False)
-    #     zappa_cli.print_logs(logs, colorize=True, non_http=True)
-    #     zappa_cli.print_logs(logs, colorize=True, non_http=False)
-    #     zappa_cli.print_logs(logs, colorize=True, non_http=True, http=True)
-    #     zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False)
-    #     zappa_cli.print_logs(logs, colorize=False, force_colorize=False)
-    #     zappa_cli.print_logs(logs, colorize=False, force_colorize=True)
-    #     zappa_cli.print_logs(logs, colorize=True, force_colorize=False)
-    #     zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False, force_colorize=True)
-    #     zappa_cli.check_for_update()
+    def test_cli_utility(self):
+        zappa_cli = ZappaCLI()
+        zappa_cli.api_stage = 'ttt888'
+        zappa_cli.load_settings('test_settings.json')
+        zappa_cli.create_package()
+        zappa_cli.remove_local_zip()
+        logs = [
+            {
+                'timestamp': '12345',
+                'message': '[START RequestId] test'
+            },
+            {
+                'timestamp': '12345',
+                'message': '[REPORT RequestId] test'
+            },
+            {
+                'timestamp': '12345',
+                'message': '[END RequestId] test'
+            },
+            {
+                'timestamp': '12345',
+                'message': 'test'
+            },
+            {
+                'timestamp': '1480001341214',
+                'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 200 2590 "" "python-requests/2.11.0" 0/4.672'
+            },
+            {
+                'timestamp': '1480001341214',
+                'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 400 2590 "" "python-requests/2.11.0" 0/4.672'
+            },
+            {
+                'timestamp': '1480001341215',
+                'message': '[1480001341258] [DEBUG] 2016-11-24T15:29:01.258Z b890d8f6-b25a-11e6-b6bc-718f7ec807df Zappa Event: {}'
+            }
+        ]
+        zappa_cli.print_logs(logs)
+        zappa_cli.print_logs(logs, colorize=False)
+        zappa_cli.print_logs(logs, colorize=False, http=True)
+        zappa_cli.print_logs(logs, colorize=True, http=True)
+        zappa_cli.print_logs(logs, colorize=True, http=False)
+        zappa_cli.print_logs(logs, colorize=True, non_http=True)
+        zappa_cli.print_logs(logs, colorize=True, non_http=False)
+        zappa_cli.print_logs(logs, colorize=True, non_http=True, http=True)
+        zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False)
+        zappa_cli.print_logs(logs, colorize=False, force_colorize=False)
+        zappa_cli.print_logs(logs, colorize=False, force_colorize=True)
+        zappa_cli.print_logs(logs, colorize=True, force_colorize=False)
+        zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False, force_colorize=True)
+        zappa_cli.check_for_update()
 
     def test_cli_format_invoke_command(self):
         zappa_cli = ZappaCLI()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -169,6 +169,25 @@ class TestZappa(unittest.TestCase):
                 with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
                     self.assertDictEqual(z.get_installed_packages('',''), {'super_package' : '0.1'})
 
+    def test_getting_installed_packages_mixed_case_location(self, *args):
+        z = Zappa(runtime='python2.7')
+
+        # mock pip packages call to be same as what our mocked site packages dir has
+        mock_package = collections.namedtuple('mock_package', ['project_name', 'version', 'location'])
+        mock_pip_installed_packages = [
+            mock_package('SuperPackage', '0.1', '/Venv/site-packages'),
+            mock_package('SuperPackage64', '0.1', '/Venv/site-packages64'),
+        ]
+
+        with mock.patch('os.path.isdir', return_value=True):
+            with mock.patch('os.listdir', return_value=[]):
+                import pip  # this gets called in non-test Zappa mode
+                with mock.patch('pip.get_installed_distributions', return_value=mock_pip_installed_packages):
+                    self.assertDictEqual(z.get_installed_packages('/venv/Site-packages','/venv/site-packages64'), {
+                        'superpackage': '0.1',
+                        'superpackage64': '0.1',
+                })
+
     def test_getting_installed_packages_mixed_case(self, *args):
         z = Zappa(runtime='python2.7')
 
@@ -815,56 +834,56 @@ class TestZappa(unittest.TestCase):
             os.chdir(orig_cwd)
             shutil.rmtree(tempdir)
 
-    def test_cli_utility(self):
-        zappa_cli = ZappaCLI()
-        zappa_cli.api_stage = 'ttt888'
-        zappa_cli.load_settings('test_settings.json')
-        zappa_cli.create_package()
-        zappa_cli.remove_local_zip()
-        logs = [
-            {
-                'timestamp': '12345',
-                'message': '[START RequestId] test'
-            },
-            {
-                'timestamp': '12345',
-                'message': '[REPORT RequestId] test'
-            },
-            {
-                'timestamp': '12345',
-                'message': '[END RequestId] test'
-            },
-            {
-                'timestamp': '12345',
-                'message': 'test'
-            },
-            {
-                'timestamp': '1480001341214',
-                'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 200 2590 "" "python-requests/2.11.0" 0/4.672'
-            },
-            {
-                'timestamp': '1480001341214',
-                'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 400 2590 "" "python-requests/2.11.0" 0/4.672'
-            },
-            {
-                'timestamp': '1480001341215',
-                'message': '[1480001341258] [DEBUG] 2016-11-24T15:29:01.258Z b890d8f6-b25a-11e6-b6bc-718f7ec807df Zappa Event: {}'
-            }
-        ]
-        zappa_cli.print_logs(logs)
-        zappa_cli.print_logs(logs, colorize=False)
-        zappa_cli.print_logs(logs, colorize=False, http=True)
-        zappa_cli.print_logs(logs, colorize=True, http=True)
-        zappa_cli.print_logs(logs, colorize=True, http=False)
-        zappa_cli.print_logs(logs, colorize=True, non_http=True)
-        zappa_cli.print_logs(logs, colorize=True, non_http=False)
-        zappa_cli.print_logs(logs, colorize=True, non_http=True, http=True)
-        zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False)
-        zappa_cli.print_logs(logs, colorize=False, force_colorize=False)
-        zappa_cli.print_logs(logs, colorize=False, force_colorize=True)
-        zappa_cli.print_logs(logs, colorize=True, force_colorize=False)
-        zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False, force_colorize=True)
-        zappa_cli.check_for_update()
+    # def test_cli_utility(self):
+    #     zappa_cli = ZappaCLI()
+    #     zappa_cli.api_stage = 'ttt888'
+    #     zappa_cli.load_settings('test_settings.json')
+    #     zappa_cli.create_package()
+    #     zappa_cli.remove_local_zip()
+    #     logs = [
+    #         {
+    #             'timestamp': '12345',
+    #             'message': '[START RequestId] test'
+    #         },
+    #         {
+    #             'timestamp': '12345',
+    #             'message': '[REPORT RequestId] test'
+    #         },
+    #         {
+    #             'timestamp': '12345',
+    #             'message': '[END RequestId] test'
+    #         },
+    #         {
+    #             'timestamp': '12345',
+    #             'message': 'test'
+    #         },
+    #         {
+    #             'timestamp': '1480001341214',
+    #             'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 200 2590 "" "python-requests/2.11.0" 0/4.672'
+    #         },
+    #         {
+    #             'timestamp': '1480001341214',
+    #             'message': '[INFO] 2016-11-24T15:29:13.326Z c0cb52d1-b25a-11e6-9b73-f940ce24319a 59.111.125.48 - -  [24/Nov/2016:15:29:13 +0000] "GET / HTTP/1.1" 400 2590 "" "python-requests/2.11.0" 0/4.672'
+    #         },
+    #         {
+    #             'timestamp': '1480001341215',
+    #             'message': '[1480001341258] [DEBUG] 2016-11-24T15:29:01.258Z b890d8f6-b25a-11e6-b6bc-718f7ec807df Zappa Event: {}'
+    #         }
+    #     ]
+    #     zappa_cli.print_logs(logs)
+    #     zappa_cli.print_logs(logs, colorize=False)
+    #     zappa_cli.print_logs(logs, colorize=False, http=True)
+    #     zappa_cli.print_logs(logs, colorize=True, http=True)
+    #     zappa_cli.print_logs(logs, colorize=True, http=False)
+    #     zappa_cli.print_logs(logs, colorize=True, non_http=True)
+    #     zappa_cli.print_logs(logs, colorize=True, non_http=False)
+    #     zappa_cli.print_logs(logs, colorize=True, non_http=True, http=True)
+    #     zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False)
+    #     zappa_cli.print_logs(logs, colorize=False, force_colorize=False)
+    #     zappa_cli.print_logs(logs, colorize=False, force_colorize=True)
+    #     zappa_cli.print_logs(logs, colorize=True, force_colorize=False)
+    #     zappa_cli.print_logs(logs, colorize=True, non_http=False, http=False, force_colorize=True)
+    #     zappa_cli.check_for_update()
 
     def test_cli_format_invoke_command(self):
         zappa_cli = ZappaCLI()

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -762,7 +762,7 @@ class Zappa(object):
         installed_packages = {package.project_name.lower(): package.version for package in
                               pip.get_installed_distributions()
                               if package.project_name.lower() in package_to_keep
-                              or package.location in [site_packages, site_packages_64]}
+                              or package.location.lower() in [site_packages.lower(), site_packages_64.lower()]}
 
         return installed_packages
 


### PR DESCRIPTION
## Description
If the path for the virtual env have uppercase pip will return location as lowercased, and comparing it with uppercased filesystem location will lead to no match. This PR fixes the issue by lowercasing both site-package path and location


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1499