### PR TITLE
Upgrade kappa to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ future==0.16.0
 futures==3.2.0; python_version < '3'
 hjson==3.0.1
 jmespath==0.9.3
-kappa==0.6.0
+kappa==0.7.0
 lambda-packages==0.20.0
 pip>=9.0.1, <=10.1.0
 python-dateutil>=2.6.1, <2.7.0

--- a/tests/placebo/TestZappa.test_add_event_source/s3.GetBucketNotificationConfiguration_1.json
+++ b/tests/placebo/TestZappa.test_add_event_source/s3.GetBucketNotificationConfiguration_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "items": [
+            {
+                "description": "Api Key for rdrde6pecd",
+                "enabled": true,
+                "stageKeys": [
+                    "rdrde6pecd/devor"
+                ],
+                "lastUpdatedDate": 1470384739,
+                "createdDate": 1470384739,
+                "id": "W9QTptojpE3bsg816Rrjh4was83amtaAx5s6NXaAl",
+                "name": "devor_rdrde6pecd"
+            }
+       ]
+    }
+}

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -9,7 +9,7 @@ from .utils import placebo_session
 
 from zappa.cli import ZappaCLI
 from zappa.handler import LambdaHandler
-from zappa.utilities import (add_event_source, remove_event_source)
+from zappa.utilities import (add_event_source, get_event_source_status, remove_event_source)
 from zappa.core import Zappa
 
 
@@ -462,8 +462,8 @@ class TestZappa(unittest.TestCase):
                     "s3:ObjectCreated:*"
                   ]}
         add_event_source(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
+        get_event_source_status(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
         remove_event_source(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
-        # get_event_source_status(event_source, 'lambda:lambda:lambda:lambda', 'test_settings.callback', session, dry=True)
 
     @placebo_session
     def test_cognito_trigger(self, session):

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -240,10 +240,17 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
             if self.filters:
                 self.add_filters(function)
 
+    class ExtendedS3EventSource(kappa.event_source.s3.S3EventSource):
+        # https://github.com/garnaat/kappa/pull/120
+        def _make_notification_id(self, function_name):
+            import hashlib
+            id_no = self._config.get('id', hashlib.md5(bytes(self._config)).hexdigest()[:8])
+            return 'Kappa-%s-notification-%s' % (function_name, id_no)
+
     event_source_map = {
         'dynamodb': kappa.event_source.dynamodb_stream.DynamoDBStreamEventSource,
         'kinesis': kappa.event_source.kinesis.KinesisEventSource,
-        's3': kappa.event_source.s3.S3EventSource,
+        's3': ExtendedS3EventSource,
         'sns': ExtendedSnsEventSource,
         'events': kappa.event_source.cloudwatch.CloudWatchEventSource
     }
@@ -258,31 +265,15 @@ def get_event_source(event_source, lambda_arn, target_function, boto_session, dr
     def autoreturn(self, function_name):
         return function_name
 
-    event_source_func._make_notification_id = autoreturn
+    if svc != 's3':
+        event_source_func._make_notification_id = autoreturn
 
     ctx = PseudoContext()
     ctx.session = boto_session
 
     funk = PseudoFunction()
     funk.name = lambda_arn
-
-    # Kappa 0.6.0 requires this nasty hacking,
-    # hopefully we can remove at least some of this soon.
-    # Kappa 0.7.0 introduces a whole host over other changes we don't
-    # really want, so we're stuck here for a little while.
-
-    # Related:  https://github.com/Miserlou/Zappa/issues/684
-    #           https://github.com/Miserlou/Zappa/issues/688
-    #           https://github.com/Miserlou/Zappa/commit/3216f7e5149e76921ecdf9451167846b95616313
-    if svc == 's3':
-        split_arn = lambda_arn.split(':')
-        arn_front = ':'.join(split_arn[:-1])
-        arn_back = split_arn[-1]
-        ctx.environment = arn_back
-        funk.arn = arn_front
-        funk.name = ':'.join([arn_back, target_function])
-    else:
-        funk.arn = lambda_arn
+    funk.arn = lambda_arn
 
     funk._context = ctx
 


### PR DESCRIPTION
## Description

In the latest Kappa (0.7.0), there have been many improvements.
https://github.com/garnaat/kappa/releases/tag/0.7.0

These mostly include keeping up with enhancements in AWS' capabilities and in effect new Boto3 functions.

In my example, I was trying to add multiple S3 Event Notifications on the same bucket. This is limited in 0.6.0 because `get_bucket_notification` only returns _one_ configuration. Whereas `get_bucket_notification_configuration` returns all the events set up for a bucket. This was limiting in my use-case, and actually had to not use Zappa because of it.

The fix in this pull request not only allows Zappa to register multiple S3 Event Notifications on a single bucket, but also takes advantage of the rest of the features brought forth by Kappa 0.7.0 - which to my knowledge include similar enhancements in Kinesis, SNS, and SQS.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/684
https://github.com/Miserlou/Zappa/issues/688
https://github.com/Miserlou/Zappa/issues/1319
https://github.com/Miserlou/Zappa/pull/1461
https://github.com/Miserlou/Zappa/issues/1442
https://github.com/Miserlou/Zappa/issues/1545

Please tag duplicates as this is a catch-all to kappa issues - AWS Lambda resource management.
And correct if I tagged non relevant issues. This PR is scoped to mine, but upgrading may hopefully solve others.


This is the sample configuration that doesn't work without this PR, and Kappa 0.7.0.
```
{
  "dev": {
    "aws_region": "us-east-1",
    "profile_name": "default",
    "project_name": "test-app",
    "runtime": "python3.6",
    "apigateway_enabled": false,
    "events": [
       {
         "function": "app.test_handler",
         "event_source": {
           "key_filters": [ { "type": "prefix", "value": "test-dir/" } ],
           "arn":  "arn:aws:s3:::key-filter-test",
           "events": [ "s3:ObjectCreated:*" ]
         }
       },
       {
         "function": "app.another_test_handler",
         "event_source": {
           "key_filters": [ { "type": "prefix", "value": "another-test-dir/" } ],
           "arn":  "arn:aws:s3:::key-filter-test",
           "events": [ "s3:ObjectCreated:*" ]
         }
       }
     ]
  }
}
```
