### PR TITLE
added govcloud support by adjusting s3 bucket url for stack template,…

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1269,10 +1269,15 @@ class Zappa(object):
         if not description:
             description = 'Created automatically by Zappa.'
         restapi.Description = description
+        if self.boto_session.region_name == "us-gov-west-1":
+            endpoint = troposphere.apigateway.EndpointConfiguration()
+            endpoint.Types = ["REGIONAL"]
+            restapi.EndpointConfiguration = endpoint
         self.cf_template.add_resource(restapi)
 
         root_id = troposphere.GetAtt(restapi, 'RootResourceId')
-        invocations_uri = 'arn:aws:apigateway:' + self.boto_session.region_name + ':lambda:path/2015-03-31/functions/' + lambda_arn + '/invocations'
+        invocation_prefix = "aws" if self.boto_session.region_name != "us-gov-west-1" else "aws-us-gov"
+        invocations_uri = 'arn:' + invocation_prefix + ':apigateway:' + self.boto_session.region_name + ':lambda:path/2015-03-31/functions/' + lambda_arn + '/invocations'
 
         ##
         # The Resources
@@ -1280,7 +1285,8 @@ class Zappa(object):
         authorizer_resource = None
         if authorizer:
             authorizer_lambda_arn = authorizer.get('arn', lambda_arn)
-            lambda_uri = 'arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations'.format(
+            lambda_uri = 'arn:{invocation_prefix}:apigateway:{region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations'.format(
+                invocation_prefix=invocation_prefix,
                 region_name=self.boto_session.region_name,
                 lambda_arn=authorizer_lambda_arn
             )
@@ -1863,8 +1869,11 @@ class Zappa(object):
             out.write(bytes(self.cf_template.to_json(indent=None, separators=(',',':')), "utf-8"))
 
         self.upload_to_s3(template, working_bucket, disable_progress=disable_progress)
+        if self.boto_session.region_name == "us-gov-west-1":
+            url = 'https://s3-us-gov-west-1.amazonaws.com/{0}/{1}'.format(working_bucket, template)
+        else:
+            url = 'https://s3.amazonaws.com/{0}/{1}'.format(working_bucket, template)
 
-        url = 'https://s3.amazonaws.com/{0}/{1}'.format(working_bucket, template)
         tags = [{'Key': key, 'Value': self.tags[key]}
                 for key in self.tags.keys()
                 if key != 'ZappaProject']


### PR DESCRIPTION
… adding REGIONAL option for api gateway setup, and adjusting api gateway arn

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Checking if the aws region is govcloud and updating the s3 bucket we upload the cloudformation stack to appropriately.
Specifying a REGIONAL deployment of api gateway if region is govcloud since govcloud cannot be deployed to EDGE.
Adjusted invocations_uri based on being in a govcloud region appropriately.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
In Reference to: https://github.com/Miserlou/Zappa/issues/1519

