### PR TITLE
Add event to WSGI Environment

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -499,6 +499,7 @@ class LambdaHandler(object):
                 environ['HTTPS'] = 'on'
                 environ['wsgi.url_scheme'] = 'https'
                 environ['lambda.context'] = context
+                environ['lambda.event'] = event
 
                 # Execute the application
                 response = Response.from_app(self.wsgi_app, environ)


### PR DESCRIPTION
Very trivial (but useful!) commit - forgoes the usual requirements.

## Description
Some libraries supporting Lambda (e.g. fanout.io) expect the original event object, adhering to the AWS default structure.

I've tried re-assembling an object to suit these libs but the WSGI request considerably changes things (e.g. headers key case/name) and discards various other parts of the original event.

Very simply, I propose preserving this object as-is, in the same way you agreed to preserve the context object.

## Changes
One line. Add event to the WSGI environ object in exactly same way that lambda.context has been.

```
environ['lambda.context'] = context
+  environ['lambda.event'] = event
```

## GitHub Issues
Too trivial to warrant adding to the 325+ currently open issues :)