### PR TITLE
PyPI now takes Markdown, and add trove classifiers for Django.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,8 @@ from setuptools import setup
 from io import open
 from zappa import __version__
 
-# Set external files
-try:
-    from pypandoc import convert
-    README = convert('README.md', 'rst')
-except ImportError:
-    README = open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r', encoding="utf-8").read()
+with open('README.md') as readme_file:
+    long_description = readme_file.read()
 
 with open(os.path.join(os.path.dirname(__file__), 'requirements.txt')) as f:
     if sys.version_info[0] == 2:
@@ -37,7 +33,8 @@ setup(
     include_package_data=True,
     license='MIT License',
     description='Server-less Python Web Services for AWS Lambda and API Gateway',
-    long_description=README,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/Miserlou/Zappa',
     author='Rich Jones',
     author_email='rich@openwatch.net',
@@ -54,6 +51,9 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
## Description
PyPI now takes Markdown. This fixes the page here:

https://pypi.org/project/zappa/

It *may* need some touch up afterward for images, as I don't have a way to test the publish to PyPI.

The PR also adds trove classifiers to be listed with packages in the Django category.
