### PR TITLE
Dirty fix for request authorizers...

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1362,8 +1362,7 @@ class Zappa(object):
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        if authorizer_type != 'REQUEST':  # Identity source isn't mandatory for request authorizers
-          authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
+        authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
           
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = identity_validation_expression

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1853,7 +1853,7 @@ class Zappa(object):
         elif iam_authorization:
             auth_type = "AWS_IAM"
         elif authorizer:
-            if authorizer.get("type").upper() !== 'REQUEST':
+            if authorizer.get("type").upper() != 'REQUEST':
               auth_type = authorizer.get("type", "CUSTOM")
             else: 
               auth_type = "CUSTOM"

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1363,7 +1363,7 @@ class Zappa(object):
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
         if authorizer_type == 'REQUEST':
-          authorizer_resource.IdentitySource = authorizer.get('identity_source', 'context.identity.clientip')
+          authorizer_resource.IdentitySource = authorizer.get('identity_source', 'context.identity.sourceIp')
         else:
           authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
           

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1857,7 +1857,7 @@ class Zappa(object):
         elif iam_authorization:
             auth_type = "AWS_IAM"
         elif authorizer:
-            if authorizer.get("type").upper() != 'REQUEST':
+            if not authorizer.get("type") or authorizer.get("type").upper() != 'REQUEST':
               auth_type = authorizer.get("type", "CUSTOM")
             else: 
               auth_type = "CUSTOM"

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1362,7 +1362,7 @@ class Zappa(object):
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        if uthorizer_type != 'REQUEST':  # Identity source isn't mandatory for request authorizers
+        if authorizer_type != 'REQUEST':  # Identity source isn't mandatory for request authorizers
           authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
           
         if identity_validation_expression:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1362,7 +1362,10 @@ class Zappa(object):
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
+        if authorizer_type == 'REQUEST':
+          authorizer_resource.IdentitySource = authorizer.get('identity_source', 'context.identity.clientip')
+        else:
+          authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
           
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = identity_validation_expression

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1853,7 +1853,10 @@ class Zappa(object):
         elif iam_authorization:
             auth_type = "AWS_IAM"
         elif authorizer:
-            auth_type = authorizer.get("type", "CUSTOM")
+            if authorizer.get("type").upper() !== 'REQUEST':
+              auth_type = authorizer.get("type", "CUSTOM")
+            else: 
+              auth_type = "CUSTOM"
 
         # build a fresh template
         self.cf_template = troposphere.Template()

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1362,7 +1362,9 @@ class Zappa(object):
         authorizer_resource.Name = authorizer.get("name", "ZappaAuthorizer")
         authorizer_resource.Type = authorizer_type
         authorizer_resource.AuthorizerUri = uri
-        authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
+        if uthorizer_type != 'REQUEST':  # Identity source isn't mandatory for request authorizers
+          authorizer_resource.IdentitySource = "method.request.header.%s" % authorizer.get('token_header', 'Authorization')
+          
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = identity_validation_expression
 


### PR DESCRIPTION
Api gateway with a request authorizer must have an AuthorizationType value equal to 'CUSTOM' and not 'REQUEST'.

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?
Yes (still need to add a functional test, I'll may do this right after...)

* If this is a non-trivial commit, did you **open a ticket** for discussion?
This is a trivial commit

* Did you **put the URL for that ticket in a comment** in the code?
No, this one could be a good ticket for reference (https://github.com/Miserlou/Zappa/issues/1159)

* If you made a new function, did you **write a good docstring** for it?
Not a new function.

* Did you avoid putting "_" in front of your new function for no reason?
No.

* Did you write a test for your new code?
Not yet.

* Did the Travis build pass?
No idea.

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?
Will see.

* Did you **make sure this code actually works on Lambda**, as well as locally?
No need for this simple changement.

* Did you test this code with both **Python 2.7** and **Python 3.6**? 
No.

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?
Yes.

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Support Request authorizer type with correct apu gateway authorizationType.

This is a dirty hack.
I am not very familiar with zappa's internal code.
Maybe this can/should be moved somewhere else in the code.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1159

