### PR TITLE
Add base_path stripping and fix unsetting of base_path

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2000,6 +2000,7 @@ class ZappaCLI(object):
         self.profile_name = self.stage_config.get('profile_name', None)
         self.log_level = self.stage_config.get('log_level', "DEBUG")
         self.domain = self.stage_config.get('domain', None)
+        self.base_path = self.stage_config.get('base_path', None)
         self.timeout_seconds = self.stage_config.get('timeout_seconds', 30)
         dead_letter_arn = self.stage_config.get('dead_letter_arn', '')
         self.dead_letter_config = {'TargetArn': dead_letter_arn} if dead_letter_arn else {}
@@ -2265,6 +2266,11 @@ class ZappaCLI(object):
                 settings_s = settings_s + "DOMAIN='{0!s}'\n".format((self.domain))
             else:
                 settings_s = settings_s + "DOMAIN=None\n"
+
+            if self.base_path:
+                settings_s = settings_s + "BASE_PATH='{0!s}'\n".format((self.base_path))
+            else:
+                settings_s = settings_s + "BASE_PATH=None\n"
 
             # Pass through remote config bucket and path
             if self.remote_env:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1454,8 +1454,11 @@ class ZappaCLI(object):
             # There literally isn't a better way to do this.
             # AWS provides no way to tie a APIGW domain name to its Lambda function.
             domain_url = self.stage_config.get('domain', None)
+            base_path = self.stage_config.get('base_path', None)
             if domain_url:
                 status_dict["Domain URL"] = 'https://' + domain_url
+                if base_path:
+                    status_dict["Domain URL"] += '/' + base_path
             else:
                 status_dict["Domain URL"] = "None Supplied"
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1013,6 +1013,9 @@ class ZappaCLI(object):
         if endpoint_url and 'https://' not in endpoint_url:
             endpoint_url = 'https://' + endpoint_url
 
+        if self.base_path:
+            endpoint_url += '/' + self.base_path
+
         deployed_string = "Your updated Zappa deployment is " + click.style("live", fg='green', bold=True) + "!"
         if self.use_apigateway:
             deployed_string = deployed_string + ": " + click.style("{}".format(endpoint_url), bold=True)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2180,7 +2180,7 @@ class Zappa(object):
                                                                     patchOperations=[
                                                                         {"op" : "replace", 
                                                                          "path" : "/basePath", 
-                                                                         "value" : base_path}
+                                                                         "value" : '' if base_path is None else base_path}
                                                                     ])
         if not found:
             self.apigateway_client.create_base_path_mapping(

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -492,6 +492,7 @@ class LambdaHandler(object):
                     script_name=script_name,
                     trailing_slash=self.trailing_slash,
                     binary_support=settings.BINARY_SUPPORT,
+                    base_path=settings.BASE_PATH,
                     context_header_mappings=settings.CONTEXT_HEADER_MAPPINGS
                 )
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -486,13 +486,15 @@ class LambdaHandler(object):
                         # API stage
                         script_name = '/' + settings.API_STAGE
 
+                base_path = getattr(settings, 'BASE_PATH', None)
+
                 # Create the environment for WSGI and handle the request
                 environ = create_wsgi_request(
                     event,
                     script_name=script_name,
+                    base_path=base_path,
                     trailing_slash=self.trailing_slash,
                     binary_support=settings.BINARY_SUPPORT,
-                    base_path=settings.BASE_PATH,
                     context_header_mappings=settings.CONTEXT_HEADER_MAPPINGS
                 )
 

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -32,6 +32,7 @@ def create_wsgi_request(event_info,
                         script_name=None,
                         trailing_slash=True,
                         binary_support=False,
+                        base_path=None,
                         context_header_mappings={}
                         ):
         """
@@ -87,6 +88,11 @@ def create_wsgi_request(event_info,
         headers = titlecase_keys(headers)
 
         path = urls.url_unquote(event_info['path'])
+        if base_path:
+            script_name = '/' + base_path
+
+            if path.startswith(script_name):
+                path = path[len(script_name):]
 
         if query:
             query_string = urlencode(query)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

<!-- Please describe the changes included in this PR --> 
Minor fixes to existing code.

- When removing/unsetting a base_path after previously having it
deployed, it would fail because the base_path would be None, instead of
''.
- When a base_path was set, the path wasn't stripped from the request
path, making (at least) Flask, non-functional without changing the Flask
code.
(borrowed from
https://github.com/logandk/serverless-wsgi/blob/master/wsgi.py#L77)

If a base_path is updated, both a zappa update and a zappa certify action have to
be taken, I'm not sure if there's already procedure/code for forcing one
or the other.

<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->