### PR TITLE
Wait for pip's execution and actually check the return code

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -414,8 +414,9 @@ class Zappa(object):
         # to depend on `setuptools`
         # https://github.com/pypa/pip/issues/5240#issuecomment-381662679
         pip_process = subprocess.Popen(command, stdout=subprocess.PIPE)
-        # Using poll() since it gives us an meaningful return code
-        pip_return_code = pip_process.poll()
+        # Using communicate() to avoid deadlocks
+        pip_process.communicate()
+        pip_return_code = pip_process.returncode
 
         if pip_return_code:
           raise EnvironmentError("Pypi lookup failed")


### PR DESCRIPTION
## Description

When building the pip environment for the zip when using slim_handler, we're using `.poll()` which doesn't wait for the process to finish. `.wait()` would be the easier replacement, but it carries the risk of deadlocks, hence using `.communicate()`.

## GitHub Issues
I suspect this contributes to at least: https://github.com/Miserlou/Zappa/issues/1547