### PR TITLE
Fix subprocess.check_output invocation

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -433,7 +433,7 @@ class Zappa(object):
             venv = os.environ['VIRTUAL_ENV']
         elif os.path.exists('.python-version'):  # pragma: no cover
             try:
-                subprocess.check_output('pyenv help', stderr=subprocess.STDOUT)
+                subprocess.check_output(['pyenv', 'help'], stderr=subprocess.STDOUT)
             except OSError:
                 print("This directory seems to have pyenv's local venv, "
                       "but pyenv executable was not found.")


### PR DESCRIPTION
Fixes #1561 by calling `subprocess.check_output` properly.

Tested on both python `2.7.15` and python `3.6.5`

https://github.com/Miserlou/Zappa/issues/1561