### PR TITLE
Bump __version__ to match the Pypi release (0.46.0 --> 0.46.1)

### DIFF
--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -11,4 +11,4 @@ if (python_major_version, python_minor_version) not in SUPPORTED_VERSIONS:
               'Zappa (and AWS Lambda) support the following versions of Python: {}'.format(formatted_supported_versions)
     raise RuntimeError(err_msg)
 
-__version__ = '0.46.0'
+__version__ = '0.46.1'


### PR DESCRIPTION
## Description

It was discovered that the Pypi release is at 0.46.1 (https://pypi.org/project/zappa/) while the `__version__` that `setup.py` uses was still at 0.46.0 (https://github.com/Miserlou/Zappa/blob/master/zappa/__init__.py#L14)

This is a symptom of someone doing a release but not checking in the bumped version.

I'm here to help if there is more to be done with this PR.