### PR TITLE
Replace windows path separator with posix separator in Zip files #1358

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -710,7 +710,12 @@ class Zappa(object):
                     with open(os.path.join(root, filename), 'rb') as f:
                         archivef.writestr(zipi, f.read(), compression_method)
                 elif archive_format == 'tarball':
-                    tarinfo = tarfile.TarInfo(os.path.join(root.replace(temp_project_path, '').lstrip(os.sep), filename))
+                    tarinfo = tarfile.TarInfo(
+                        # Replace Windows path separators \ with posix separators /
+                        # Related: https://github.com/Miserlou/Zappa/issues/1358
+                        # Related: https://github.com/Miserlou/Zappa/pull/1570
+                        os.path.join(root.replace(temp_project_path, '').lstrip(os.sep).replace('\\', '/'), filename)
+                    )
                     tarinfo.mode = 0o755
 
                     stat = os.stat(os.path.join(root, filename))
@@ -876,7 +881,10 @@ class Zappa(object):
         # version of the package.
         # Related: https://github.com/Miserlou/Zappa/issues/899
         json_file = '{0!s}-{1!s}.json'.format(package_name, package_version)
-        json_file_path = os.path.join(cached_pypi_info_dir, json_file)
+        # Replace Windows path separators \ with posix separators /
+        # Related: https://github.com/Miserlou/Zappa/issues/1358
+        # Related: https://github.com/Miserlou/Zappa/pull/1570
+        json_file_path = os.path.join(cached_pypi_info_dir, json_file).replace('\\', '/')
         if os.path.exists(json_file_path):
             with open(json_file_path, 'rb') as metafile:
                 data = json.load(metafile)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Replace windows path separators \\ with posix separators /

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1358
