### PR TITLE
Support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 cache:
   - pip

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-SUPPORTED_VERSIONS = [(2, 7), (3, 6)]
+SUPPORTED_VERSIONS = [(2, 7), (3, 6), (3, 7)]
 
 python_major_version = sys.version_info[0]
 python_minor_version = sys.version_info[1]


### PR DESCRIPTION
## Description
Added an option to install Zappa in python 3.7 because is the official python3 installed via homebrew in MacOS

