### PR TITLE
Editing requirements.txt to remove upper version limit of 10.1.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ hjson==3.0.1
 jmespath==0.9.3
 kappa==0.6.0
 lambda-packages==0.20.0
-pip>=9.0.1, <=10.1.0
+pip>=9.0.1
 python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4
 PyYAML==3.12


### PR DESCRIPTION
## Description
The end result of that ticket (#1588) is either this or raising the upper version limit of pip to current pip, which is v18. (they changed their versioning scheme)

I preferred this approach for a handful of minor reasons, but they are minor IMO, so the other solution (including another upper limit) is fine with me if the reviewer prefers it, as long #1588 actually is fixed. Using pip 18 caused no changes in my tests locally on Python 2.7 and 3.6, and works for me.

## GitHub Issues
Fixes #1588 
