### PR TITLE
Add ability to ignore SSL verification when uploading to S3 (resolves #1639)

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2660,7 +2660,7 @@ class ZappaCLI(object):
         """
 
         touch_path = self.stage_config.get('touch_path', '/')
-        req = requests.get(endpoint_url + touch_path)
+        req = requests.get(endpoint_url + touch_path, verify=os.getenv('ZAPPA_NO_VERIFY_SSL', "0") != "1")
 
         if req.status_code >= 500:
             raise ClickException(click.style("Warning!", fg="red", bold=True) +

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -291,8 +291,11 @@ class Zappa(object):
         if load_credentials:
             self.load_credentials(boto_session, profile_name)
 
+            # Gives us the option to skip SSL when in the context of a proxy
+            use_ssl = os.environ.get('ZAPPA_NO_VERIFY_SSL', '') != '1'
+
             # Initialize clients
-            self.s3_client = self.boto_client('s3')
+            self.s3_client = self.boto_client('s3', use_ssl=use_ssl)
             self.lambda_client = self.boto_client('lambda', config=long_config)
             self.events_client = self.boto_client('events')
             self.apigateway_client = self.boto_client('apigateway')
@@ -2164,7 +2167,7 @@ class Zappa(object):
                                                               "path" : "/certificateArn",
                                                               "value" : certificate_arn}
                                                          ])
-    
+
     def update_domain_base_path_mapping(self, domain_name, lambda_name, stage, base_path):
         """
         Update domain base path mapping on API Gateway if it was changed
@@ -2182,8 +2185,8 @@ class Zappa(object):
                     self.apigateway_client.update_base_path_mapping(domainName=domain_name,
                                                                     basePath=base_path_mapping['basePath'],
                                                                     patchOperations=[
-                                                                        {"op" : "replace", 
-                                                                         "path" : "/basePath", 
+                                                                        {"op" : "replace",
+                                                                         "path" : "/basePath",
                                                                          "value" : '' if base_path is None else base_path}
                                                                     ])
         if not found:
@@ -2193,7 +2196,7 @@ class Zappa(object):
                 restApiId=api_id,
                 stage=stage
             )
-        
+
 
     def get_domain_name(self, domain_name, route53=True):
         """


### PR DESCRIPTION
The native aws s3 commands that boto uses allow for a
`--no-verify-ssl` flag that makes it easier to upload
files in network contexts that involve a proxy.

Because boto3 doesn't allow the setting of this configuration
from a configuration file or enviornment variable,
this pull request proposes that we allow for a
zappa-specific environment variable to control this behavior.

We propose an environment variable here because the
deployment behavior is dependent upon the machine where
the deploy call is run, and not upon a configuration in AWS.
For instance, this behavior may be required when running
from within a local network on a personal machine,
but it may not be necessary when running through CI/CD
in the cloud.

