### PR TITLE
import botocore for line 314

### DIFF
--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -1,3 +1,4 @@
+import botocore
 import calendar
 import datetime
 import durationpy


### PR DESCRIPTION
Line 314 uses __botocore.exceptions.ClientError__ but botocore is never imported which has the potential of raising NameError instead of botocore.exceptions.ClientError.