### PR TITLE
Travis CI: Find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ python:
 cache:
   - pip
 install:
-  - "pip install setuptools --upgrade; pip install -r test_requirements.txt; pip install -e git+https://github.com/django/django-contrib-comments.git#egg=django-contrib-comments; python setup.py install" 
+  - pip install setuptools --upgrade
+  - pip install -r test_requirements.txt
+  - pip install -e git+https://github.com/django/django-contrib-comments.git#egg=django-contrib-comments
+  - python setup.py install
 # command to run tests
 env:
   - TESTCASE=tests/tests_docs.py
@@ -15,6 +18,11 @@ env:
   - TESTCASE=tests/tests_placebo.py
   - TESTCASE=tests/tests_async.py
   - TESTCASE=tests/tests.py
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: 
   - nosetests $TESTCASE --with-coverage --cover-package=zappa --with-timer
     #  - coverage combine --append

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
 coveralls>=1.1
 coverage>=4.3.1
 Django>=1.10.5, <2.0
+flake8>=3.5.0
 Flask>=0.12
 mock>=2.0.0
 nose>=1.3.7

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,11 @@ import functools
 from contextlib import contextmanager
 from mock import patch, MagicMock
 
+try:
+    file
+except NameError:  # builtin 'file' was removed in Python 3
+    from io import IOBase as file
+
 PLACEBO_DIR = os.path.join(os.path.dirname(__file__), 'placebo')
 
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2742,7 +2742,7 @@ class Zappa(object):
         Remove the DynamoDB Table used for async return values
         """
 
-        topic_name = get_topic_name(lambda_name)
+        topic_name = get_topic_name(table_name)
         removed_arns = []
         for sub in self.sns_client.list_subscriptions()['Subscriptions']:
             if topic_name in sub['TopicArn']:


### PR DESCRIPTION
Fixes #1645, Blocked by ~#1644~ and #1671 which were all found via these tests...

Run [flake8](http://flake8.pycqa.org) tests in Travis CI to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree