### PR TITLE
Support for multivalue querystring parameters

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -82,7 +82,7 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
             },
@@ -112,7 +112,7 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': 'example.com',
             },
@@ -142,7 +142,7 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'headers': {},
             'pathParameters': {
                 'proxy': 'return/request/url'
@@ -169,7 +169,7 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
-            'queryStringParameters': {},
+            'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
             },

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -82,9 +82,13 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
+            'queryStringParameters': {},
             'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
+            },
+            'multiValueHeaders': {
+                'Host': ['1234567890.execute-api.us-east-1.amazonaws.com'],
             },
             'pathParameters': {
                 'proxy': 'return/request/url'
@@ -112,9 +116,13 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
+            'queryStringParameters': {},
             'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': 'example.com',
+            },
+            'multiValueHeaders': {
+                'Host': ['example.com'],
             },
             'pathParameters': {
                 'proxy': 'return/request/url'
@@ -142,8 +150,10 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
+            'queryStringParameters': {},
             'multiValueQueryStringParameters': {},
             'headers': {},
+            'multiValueHeaders': {},
             'pathParameters': {
                 'proxy': 'return/request/url'
             },
@@ -169,9 +179,13 @@ class TestZappa(unittest.TestCase):
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
+            'queryStringParameters': {},
             'multiValueQueryStringParameters': {},
             'headers': {
                 'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
+            },
+            'multiValueHeaders': {
+                'Host': ['1234567890.execute-api.us-east-1.amazonaws.com'],
             },
             'pathParameters': {
                 'proxy': 'return/request/url'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -491,6 +491,7 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'httpMethod': u'GET',
             u'pathParameters': None,
@@ -512,54 +513,44 @@ class TestZappa(unittest.TestCase):
                 u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:48.0) Gecko/20100101 Firefox/48.0',
                 u'CloudFront-Is-Mobile-Viewer': u'false',
                 u'CloudFront-Is-Desktop-Viewer': u'true',
-                },
+            },
+            u'multiValueHeaders': {
+                u'Via': [u'1.1 6801928d54163af944bf854db8d5520e.cloudfront.net (CloudFront)'],
+                u'Accept-Language': [u'en-US,en;q=0.5'],
+                u'Accept-Encoding': [u'gzip, deflate, br'],
+                u'CloudFront-Is-SmartTV-Viewer': [u'false'],
+                u'CloudFront-Forwarded-Proto': [u'https'],
+                u'X-Forwarded-For': [u'50.191.225.98, 204.246.168.101'],
+                u'CloudFront-Viewer-Country': [u'US'],
+                u'Accept': [u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'],
+                u'Upgrade-Insecure-Requests': [u'1'],
+                u'Host': [u'9itr2lba55.execute-api.us-east-1.amazonaws.com'],
+                u'X-Forwarded-Proto': [u'https'],
+                u'X-Amz-Cf-Id': [u'qgNdqKT0_3RMttu5KjUdnvHI3OKm1BWF8mGD2lX8_rVrJQhhp-MLDw=='],
+                u'CloudFront-Is-Tablet-Viewer': [u'false'],
+                u'X-Forwarded-Port': [u'443'],
+                u'User-Agent': [u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:48.0) Gecko/20100101 Firefox/48.0'],
+                u'CloudFront-Is-Mobile-Viewer': [u'false'],
+                u'CloudFront-Is-Desktop-Viewer': [u'true'],
+            },
             u'stageVariables': None,
             u'path': u'/',
-            }
+        }
 
         request = create_wsgi_request(event)
 
-
-    # def test_wsgi_path_info(self):
-    #     # Test no parameters (site.com/)
-    #     event = {
-    #         "body": {},
-    #         "headers": {},
-    #         "pathParameters": {},
-    #         "path": u'/',
-    #         "httpMethod": "GET",
-    #         "multiValueQueryStringParameters": {}
-    #     }
-
-    #     request = create_wsgi_request(event, trailing_slash=True)
-    #     self.assertEqual("/", request['PATH_INFO'])
-
-    #     request = create_wsgi_request(event, trailing_slash=False)
-    #     self.assertEqual("/", request['PATH_INFO'])
-
-    #     # Test parameters (site.com/asdf1/asdf2 or site.com/asdf1/asdf2/)
-    #     event_asdf2 = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
-    #     event_asdf2_slash = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'd6fda925-8991-11e6-8bd8-b5ec6db19d57', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 c70173a50d0076c99b5e680eb32d40bb.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.53', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'X-Amz-Cf-Id': u'aU_i-iuT3llVUfXv2zv6uU-m77Oga7ANhd5ZYrCoqXBy4K7I2x3FZQ==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2/'}
-
-    #     request = create_wsgi_request(event, trailing_slash=True)
-    #     self.assertEqual("/asdf1/asdf2/", request['PATH_INFO'])
-
-    #     request = create_wsgi_request(event, trailing_slash=False)
-    #     self.assertEqual("/asdf1/asdf2", request['PATH_INFO'])
-
-    #     request = create_wsgi_request(event, trailing_slash=False, script_name='asdf1')
-    #     self.assertEqual("/asdf1/asdf2", request['PATH_INFO'])
-
     def test_wsgi_path_info_unquoted(self):
         event = {
-                "body": {},
-                "headers": {},
-                "pathParameters": {},
-                "path": '/path%3A1', # encoded /path:1
-                "httpMethod": "GET",
-                "multiValueQueryStringParameters": {},
-                "requestContext": {}
-            }
+            "body": {},
+            "headers": {},
+            "multiValueHeaders": {},
+            "pathParameters": {},
+            "path": '/path%3A1', # encoded /path:1
+            "httpMethod": "GET",
+            "queryStringParameters": {},
+            "multiValueQueryStringParameters": {},
+            "requestContext": {}
+        }
         request = create_wsgi_request(event, trailing_slash=True)
         self.assertEqual("/path:1", request['PATH_INFO'])
 
@@ -567,9 +558,11 @@ class TestZappa(unittest.TestCase):
         event = {
             "body": {},
             "headers": {},
+            "multiValueHeaders": {},
             "pathParameters": {},
             "path": '/path/%E4%BB%8A%E6%97%A5%E3%81%AF',
             "httpMethod": "GET",
+            "queryStringParameters": {"a": "%E4%BB%8A%E6%97%A5%E3%81%AF"},
             "multiValueQueryStringParameters": {"a": ["%E4%BB%8A%E6%97%A5%E3%81%AF"]},
             "requestContext": {}
         }
@@ -591,7 +584,66 @@ class TestZappa(unittest.TestCase):
         #     "query": {}
         # }
 
-        event = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
+        event = {
+            u'body': None,
+            u'resource': u'/{proxy+}',
+            u'requestContext': {
+                u'resourceId': u'dg451y',
+                u'apiId': u'79gqbxq31c',
+                u'resourcePath': u'/{proxy+}',
+                u'httpMethod': u'GET',
+                u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5',
+                u'accountId': u'724336686645',
+                u'identity': {u'apiKey': None,
+                u'userArn': None,
+                u'cognitoAuthenticationType': None,
+                u'caller': None,
+                u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0',
+                u'user': None,
+                u'cognitoIdentityPoolId': None,
+                u'cognitoIdentityId': None,
+                u'cognitoAuthenticationProvider': None,
+                u'sourceIp': u'96.90.37.59',
+                u'accountId': None},
+                u'stage': u'devorr'
+            },
+            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
+            u'httpMethod': u'GET',
+            u'pathParameters': {u'proxy': u'asdf1/asdf2'},
+            u'headers': {
+                u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)',
+                u'Accept-Language': u'en-US,en;q=0.5',
+                u'Accept-Encoding': u'gzip, deflate, br',
+                u'X-Forwarded-Port': u'443',
+                u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50',
+                u'CloudFront-Viewer-Country': u'US',
+                u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                u'Upgrade-Insecure-Requests': u'1',
+                u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com',
+                u'X-Forwarded-Proto': u'https',
+                u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==',
+                u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0',
+                u'CloudFront-Forwarded-Proto': u'https'
+            },
+            u'multiValueHeaders': {
+                u'Via': [u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)'],
+                u'Accept-Language': [u'en-US,en;q=0.5'],
+                u'Accept-Encoding': [u'gzip, deflate, br'],
+                u'X-Forwarded-Port': [u'443'],
+                u'X-Forwarded-For': [u'96.90.37.59, 54.240.144.50'],
+                u'CloudFront-Viewer-Country': [u'US'],
+                u'Accept': [u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'],
+                u'Upgrade-Insecure-Requests': [u'1'],
+                u'Host': [u'79gqbxq31c.execute-api.us-east-1.amazonaws.com'],
+                u'X-Forwarded-Proto': [u'https'],
+                u'X-Amz-Cf-Id': [u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q=='],
+                u'User-Agent': [u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0'],
+                u'CloudFront-Forwarded-Proto': [u'https']
+            },
+            u'stageVariables': None,
+            u'path': u'/asdf1/asdf2'
+        }
 
         environ = create_wsgi_request(event, trailing_slash=False)
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
@@ -600,8 +652,6 @@ class TestZappa(unittest.TestCase):
         le = common_log(environ, response, response_time=False)
 
     def test_wsgi_multipart(self):
-        #event = {u'body': u'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS03Njk1MjI4NDg0Njc4MTc2NTgwNjMwOTYxDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9Im15c3RyaW5nIg0KDQpkZGQNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tNzY5NTIyODQ4NDY3ODE3NjU4MDYzMDk2MS0tDQo=', u'headers': {u'Content-Type': u'multipart/form-data; boundary=---------------------------7695228484678176580630961', u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'}, u'params': {u'parameter_1': u'post'}, u'method': u'POST', u'query': {}}
-
         event = {
             u'body': u'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS03Njk1MjI4NDg0Njc4MTc2NTgwNjMwOTYxDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9Im15c3RyaW5nIg0KDQpkZGQNCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tNzY5NTIyODQ4NDY3ODE3NjU4MDYzMDk2MS0tDQo=',
             u'resource': u'/',
@@ -627,13 +677,55 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'httpMethod': u'POST',
             u'pathParameters': None,
-            u'headers': {u'Content-Type': u'multipart/form-data; boundary=---------------------------7695228484678176580630961', u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'},
+            u'headers': {
+                u'Content-Type': u'multipart/form-data; boundary=---------------------------7695228484678176580630961',
+                u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)',
+                u'Accept-Language': u'en-US,en;q=0.5',
+                u'Accept-Encoding': u'gzip, deflate, br',
+                u'CloudFront-Is-SmartTV-Viewer': u'false',
+                u'CloudFront-Forwarded-Proto': u'https',
+                u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51',
+                u'CloudFront-Viewer-Country': u'US',
+                u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0',
+                u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com',
+                u'X-Forwarded-Proto': u'https',
+                u'Cookie': u'zappa=AQ4',
+                u'CloudFront-Is-Tablet-Viewer': u'false',
+                u'X-Forwarded-Port': u'443',
+                u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post',
+                u'CloudFront-Is-Mobile-Viewer': u'false',
+                u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==',
+                u'CloudFront-Is-Desktop-Viewer': u'true'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'multipart/form-data; boundary=---------------------------7695228484678176580630961'],
+                u'Via': [u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)'],
+                u'Accept-Language': [u'en-US,en;q=0.5'],
+                u'Accept-Encoding': [u'gzip, deflate, br'],
+                u'CloudFront-Is-SmartTV-Viewer': [u'false'],
+                u'CloudFront-Forwarded-Proto': [u'https'],
+                u'X-Forwarded-For': [u'71.231.27.57, 104.246.180.51'],
+                u'CloudFront-Viewer-Country': [u'US'],
+                u'Accept': [u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'],
+                u'User-Agent': [u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0'],
+                u'Host': [u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com'],
+                u'X-Forwarded-Proto': [u'https'],
+                u'Cookie': [u'zappa=AQ4'],
+                u'CloudFront-Is-Tablet-Viewer': [u'false'],
+                u'X-Forwarded-Port': [u'443'],
+                u'Referer': [u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post'],
+                u'CloudFront-Is-Mobile-Viewer': [u'false'],
+                u'X-Amz-Cf-Id': [u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ=='],
+                u'CloudFront-Is-Desktop-Viewer': [u'true']
+            },
             u'stageVariables': None,
             u'path': u'/',
-            }
+        }
 
         environ = create_wsgi_request(event, trailing_slash=False)
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
@@ -666,14 +758,54 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'httpMethod': u'POST',
             u'pathParameters': None,
-            u'headers': {u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'},
+            u'headers': {
+                u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)',
+                u'Accept-Language': u'en-US,en;q=0.5',
+                u'Accept-Encoding': u'gzip, deflate, br',
+                u'CloudFront-Is-SmartTV-Viewer': u'false',
+                u'CloudFront-Forwarded-Proto': u'https',
+                u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51',
+                u'CloudFront-Viewer-Country': u'US',
+                u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0',
+                u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com',
+                u'X-Forwarded-Proto': u'https',
+                u'Cookie': u'zappa=AQ4',
+                u'CloudFront-Is-Tablet-Viewer': u'false',
+                u'X-Forwarded-Port': u'443',
+                u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post',
+                u'CloudFront-Is-Mobile-Viewer': u'false',
+                u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==',
+                u'CloudFront-Is-Desktop-Viewer': u'true'
+            },
+            u'multiValueHeaders': {
+                u'Via': [u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)'],
+                u'Accept-Language': [u'en-US,en;q=0.5'],
+                u'Accept-Encoding': [u'gzip, deflate, br'],
+                u'CloudFront-Is-SmartTV-Viewer': [u'false'],
+                u'CloudFront-Forwarded-Proto': [u'https'],
+                u'X-Forwarded-For': [u'71.231.27.57, 104.246.180.51'],
+                u'CloudFront-Viewer-Country': [u'US'],
+                u'Accept': [u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'],
+                u'User-Agent': [u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0'],
+                u'Host': [u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com'],
+                u'X-Forwarded-Proto': [u'https'],
+                u'Cookie': [u'zappa=AQ4'],
+                u'CloudFront-Is-Tablet-Viewer': [u'false'],
+                u'X-Forwarded-Port': [u'443'],
+                u'Referer': [u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post'],
+                u'CloudFront-Is-Mobile-Viewer': [u'false'],
+                u'X-Amz-Cf-Id': [u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ=='],
+                u'CloudFront-Is-Desktop-Viewer': [u'true']
+            },
             u'stageVariables': None,
             u'path': u'/',
             u'isBase64Encoded': True
-            }
+        }
 
         environ = create_wsgi_request(event, trailing_slash=False)
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
@@ -690,6 +822,8 @@ class TestZappa(unittest.TestCase):
             "path": "/",
             "httpMethod": "GET",
             "headers": None,
+            "multiValueHeaders": None,
+            "queryStringParameters": None,
             "multiValueQueryStringParameters": None,
             "pathParameters": None,
             "stageVariables": None,
@@ -1740,14 +1874,16 @@ USE_TZ = True
         https://github.com/Miserlou/Zappa/issues/283
         """
         event = {
-                "body": {},
-                "headers": {},
-                "pathParameters": {},
-                "path": '/',
-                "httpMethod": "GET",
-                "multiValueQueryStringParameters": {},
-                "requestContext": {}
-            }
+            "body": {},
+            "headers": {},
+            "multiValueHeaders": {},
+            "pathParameters": {},
+            "path": '/',
+            "httpMethod": "GET",
+            "queryStringParameters": {},
+            "multiValueQueryStringParameters": {},
+            "requestContext": {}
+        }
 
         old_stderr = sys.stderr
         sys.stderr = BytesIO()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -491,7 +491,7 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'httpMethod': u'GET',
             u'pathParameters': None,
             u'headers': {
@@ -528,7 +528,7 @@ class TestZappa(unittest.TestCase):
     #         "pathParameters": {},
     #         "path": u'/',
     #         "httpMethod": "GET",
-    #         "queryStringParameters": {}
+    #         "multiValueQueryStringParameters": {}
     #     }
 
     #     request = create_wsgi_request(event, trailing_slash=True)
@@ -538,8 +538,8 @@ class TestZappa(unittest.TestCase):
     #     self.assertEqual("/", request['PATH_INFO'])
 
     #     # Test parameters (site.com/asdf1/asdf2 or site.com/asdf1/asdf2/)
-    #     event_asdf2 = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'queryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
-    #     event_asdf2_slash = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'd6fda925-8991-11e6-8bd8-b5ec6db19d57', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'queryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 c70173a50d0076c99b5e680eb32d40bb.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.53', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'X-Amz-Cf-Id': u'aU_i-iuT3llVUfXv2zv6uU-m77Oga7ANhd5ZYrCoqXBy4K7I2x3FZQ==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2/'}
+    #     event_asdf2 = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
+    #     event_asdf2_slash = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'd6fda925-8991-11e6-8bd8-b5ec6db19d57', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 c70173a50d0076c99b5e680eb32d40bb.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.53', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'X-Amz-Cf-Id': u'aU_i-iuT3llVUfXv2zv6uU-m77Oga7ANhd5ZYrCoqXBy4K7I2x3FZQ==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2/'}
 
     #     request = create_wsgi_request(event, trailing_slash=True)
     #     self.assertEqual("/asdf1/asdf2/", request['PATH_INFO'])
@@ -557,7 +557,7 @@ class TestZappa(unittest.TestCase):
                 "pathParameters": {},
                 "path": '/path%3A1', # encoded /path:1
                 "httpMethod": "GET",
-                "queryStringParameters": {},
+                "multiValueQueryStringParameters": {},
                 "requestContext": {}
             }
         request = create_wsgi_request(event, trailing_slash=True)
@@ -570,7 +570,7 @@ class TestZappa(unittest.TestCase):
             "pathParameters": {},
             "path": '/path/%E4%BB%8A%E6%97%A5%E3%81%AF',
             "httpMethod": "GET",
-            "queryStringParameters": {"a": "%E4%BB%8A%E6%97%A5%E3%81%AF"},
+            "multiValueQueryStringParameters": {"a": ["%E4%BB%8A%E6%97%A5%E3%81%AF"]},
             "requestContext": {}
         }
         request = create_wsgi_request(event, script_name="%E4%BB%8A%E6%97%A5%E3%81%AF")
@@ -591,7 +591,7 @@ class TestZappa(unittest.TestCase):
         #     "query": {}
         # }
 
-        event = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'queryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
+        event = {u'body': None, u'resource': u'/{proxy+}', u'requestContext': {u'resourceId': u'dg451y', u'apiId': u'79gqbxq31c', u'resourcePath': u'/{proxy+}', u'httpMethod': u'GET', u'requestId': u'766df67f-8991-11e6-b2c4-d120fedb94e5', u'accountId': u'724336686645', u'identity': {u'apiKey': None, u'userArn': None, u'cognitoAuthenticationType': None, u'caller': None, u'userAgent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'user': None, u'cognitoIdentityPoolId': None, u'cognitoIdentityId': None, u'cognitoAuthenticationProvider': None, u'sourceIp': u'96.90.37.59', u'accountId': None}, u'stage': u'devorr'}, u'multiValueQueryStringParameters': None, u'httpMethod': u'GET', u'pathParameters': {u'proxy': u'asdf1/asdf2'}, u'headers': {u'Via': u'1.1 b2aeb492548a8a2d4036401355f928dd.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'X-Forwarded-Port': u'443', u'X-Forwarded-For': u'96.90.37.59, 54.240.144.50', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'Upgrade-Insecure-Requests': u'1', u'Host': u'79gqbxq31c.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'X-Amz-Cf-Id': u'BBFP-RhGDrQGOzoCqjnfB2I_YzWt_dac9S5vBcSAEaoM4NfYhAQy7Q==', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:49.0) Gecko/20100101 Firefox/49.0', u'CloudFront-Forwarded-Proto': u'https'}, u'stageVariables': None, u'path': u'/asdf1/asdf2'}
 
         environ = create_wsgi_request(event, trailing_slash=False)
         response_tuple = collections.namedtuple('Response', ['status_code', 'content'])
@@ -627,7 +627,7 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'httpMethod': u'POST',
             u'pathParameters': None,
             u'headers': {u'Content-Type': u'multipart/form-data; boundary=---------------------------7695228484678176580630961', u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'},
@@ -666,7 +666,7 @@ class TestZappa(unittest.TestCase):
                     },
                 u'stage': u'devorr',
                 },
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'httpMethod': u'POST',
             u'pathParameters': None,
             u'headers': {u'Via': u'1.1 38205a04d96d60185e88658d3185ccee.cloudfront.net (CloudFront)', u'Accept-Language': u'en-US,en;q=0.5', u'Accept-Encoding': u'gzip, deflate, br', u'CloudFront-Is-SmartTV-Viewer': u'false', u'CloudFront-Forwarded-Proto': u'https', u'X-Forwarded-For': u'71.231.27.57, 104.246.180.51', u'CloudFront-Viewer-Country': u'US', u'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', u'User-Agent': u'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:45.0) Gecko/20100101 Firefox/45.0', u'Host': u'xo2z7zafjh.execute-api.us-east-1.amazonaws.com', u'X-Forwarded-Proto': u'https', u'Cookie': u'zappa=AQ4', u'CloudFront-Is-Tablet-Viewer': u'false', u'X-Forwarded-Port': u'443', u'Referer': u'https://xo8z7zafjh.execute-api.us-east-1.amazonaws.com/former/post', u'CloudFront-Is-Mobile-Viewer': u'false', u'X-Amz-Cf-Id': u'31zxcUcVyUxBOMk320yh5NOhihn5knqrlYQYpGGyOngKKwJb0J0BAQ==', u'CloudFront-Is-Desktop-Viewer': u'true'},
@@ -690,7 +690,7 @@ class TestZappa(unittest.TestCase):
             "path": "/",
             "httpMethod": "GET",
             "headers": None,
-            "queryStringParameters": None,
+            "multiValueQueryStringParameters": None,
             "pathParameters": None,
             "stageVariables": None,
             "requestContext":{
@@ -1745,7 +1745,7 @@ USE_TZ = True
                 "pathParameters": {},
                 "path": '/',
                 "httpMethod": "GET",
-                "queryStringParameters": {},
+                "multiValueQueryStringParameters": {},
                 "requestContext": {}
             }
 

--- a/tests/tests_middleware.py
+++ b/tests/tests_middleware.py
@@ -85,7 +85,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With user
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
@@ -110,7 +110,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With empty authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
@@ -136,7 +136,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With missing authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
@@ -158,7 +158,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With empty authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
@@ -184,7 +184,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # Validate a single context value mapping is translated into a HTTP header
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
@@ -212,7 +212,7 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # Invalid mapping should be ignored
         event = {
             u'httpMethod': u'GET',
-            u'queryStringParameters': None,
+            u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},

--- a/tests/tests_middleware.py
+++ b/tests/tests_middleware.py
@@ -85,12 +85,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With user
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'
@@ -110,12 +114,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With empty authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'
@@ -136,12 +144,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With missing authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'
@@ -158,12 +170,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # With empty authorizer, should not include REMOTE_USER
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'
@@ -184,12 +200,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # Validate a single context value mapping is translated into a HTTP header
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'
@@ -212,12 +232,16 @@ class TestWSGIMockMiddleWare(unittest.TestCase):
         # Invalid mapping should be ignored
         event = {
             u'httpMethod': u'GET',
+            u'queryStringParameters': None,
             u'multiValueQueryStringParameters': None,
             u'path': u'/v1/runs',
             u'params': {},
             u'body': {},
             u'headers': {
                 u'Content-Type': u'application/json'
+            },
+            u'multiValueHeaders': {
+                u'Content-Type': [u'application/json']
             },
             u'pathParameters': {
                 u'proxy': 'v1/runs'

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -18,14 +18,13 @@ else:
 from .utilities import titlecase_keys
 
 BINARY_METHODS = [
-                    "POST",
-                    "PUT",
-                    "PATCH",
-                    "DELETE",
-                    "CONNECT",
-                    "OPTIONS"
-                ]
-
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "CONNECT",
+    "OPTIONS"
+]
 
 def create_wsgi_request(event_info,
                         server_name='zappa',
@@ -35,126 +34,126 @@ def create_wsgi_request(event_info,
                         base_path=None,
                         context_header_mappings={}
                         ):
-        """
-        Given some event_info via API Gateway,
-        create and return a valid WSGI request environ.
-        """
-        method = event_info['httpMethod']
-        params = event_info['pathParameters']
-        query = event_info['multiValueQueryStringParameters']
-        headers = event_info['headers'] or {} # Allow for the AGW console 'Test' button to work (Pull #735)
+    """
+    Given some event_info via API Gateway,
+    create and return a valid WSGI request environ.
+    """
+    method = event_info['httpMethod']
+    params = event_info['pathParameters']
+    query = event_info['multiValueQueryStringParameters']
+    headers = event_info['headers'] or {}  # Allow for the AGW console 'Test' button to work (Pull #735)
 
-        if context_header_mappings:
-            for key, value in context_header_mappings.items():
-                parts = value.split('.')
-                header_val = event_info['requestContext']
-                for part in parts:
-                    if part not in header_val:
-                        header_val = None
-                        break
-                    else:
-                        header_val = header_val[part]
-                if header_val is not None:
-                    headers[key] = header_val
+    if context_header_mappings:
+        for key, value in context_header_mappings.items():
+            parts = value.split('.')
+            header_val = event_info['requestContext']
+            for part in parts:
+                if part not in header_val:
+                    header_val = None
+                    break
+                else:
+                    header_val = header_val[part]
+            if header_val is not None:
+                headers[key] = header_val
 
-        # Extract remote user from context if Authorizer is enabled
-        remote_user = None
-        if event_info['requestContext'].get('authorizer'):
-            remote_user = event_info['requestContext']['authorizer'].get('principalId')
-        elif event_info['requestContext'].get('identity'):
-            remote_user = event_info['requestContext']['identity'].get('userArn')
+    # Extract remote user from context if Authorizer is enabled
+    remote_user = None
+    if event_info['requestContext'].get('authorizer'):
+        remote_user = event_info['requestContext']['authorizer'].get('principalId')
+    elif event_info['requestContext'].get('identity'):
+        remote_user = event_info['requestContext']['identity'].get('userArn')
 
-        # Related:  https://github.com/Miserlou/Zappa/issues/677
-        #           https://github.com/Miserlou/Zappa/issues/683
-        #           https://github.com/Miserlou/Zappa/issues/696
-        #           https://github.com/Miserlou/Zappa/issues/836
-        #           https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Summary_table
-        if binary_support and (method in BINARY_METHODS):
-            if event_info.get('isBase64Encoded', False):
-                encoded_body = event_info['body']
-                body = base64.b64decode(encoded_body)
-            else:
-                body = event_info['body']
-                if isinstance(body, six.string_types):
-                    body = body.encode("utf-8")
-
+    # Related:  https://github.com/Miserlou/Zappa/issues/677
+    #           https://github.com/Miserlou/Zappa/issues/683
+    #           https://github.com/Miserlou/Zappa/issues/696
+    #           https://github.com/Miserlou/Zappa/issues/836
+    #           https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Summary_table
+    if binary_support and (method in BINARY_METHODS):
+        if event_info.get('isBase64Encoded', False):
+            encoded_body = event_info['body']
+            body = base64.b64decode(encoded_body)
         else:
             body = event_info['body']
             if isinstance(body, six.string_types):
                 body = body.encode("utf-8")
 
-        # Make header names canonical, e.g. content-type => Content-Type
-        # https://github.com/Miserlou/Zappa/issues/1188
-        headers = titlecase_keys(headers)
+    else:
+        body = event_info['body']
+        if isinstance(body, six.string_types):
+            body = body.encode("utf-8")
 
-        path = urls.url_unquote(event_info['path'])
-        if base_path:
-            script_name = '/' + base_path
+    # Make header names canonical, e.g. content-type => Content-Type
+    # https://github.com/Miserlou/Zappa/issues/1188
+    headers = titlecase_keys(headers)
 
-            if path.startswith(script_name):
-                path = path[len(script_name):]
+    path = urls.url_unquote(event_info['path'])
+    if base_path:
+        script_name = '/' + base_path
 
-        if query:
-            query_string = urlencode(query, True)
+        if path.startswith(script_name):
+            path = path[len(script_name):]
+
+    if query:
+        query_string = urlencode(query, True)
+    else:
+        query_string = ""
+
+    x_forwarded_for = headers.get('X-Forwarded-For', '')
+    if ',' in x_forwarded_for:
+        # The last one is the cloudfront proxy ip. The second to last is the real client ip.
+        # Everything else is user supplied and untrustworthy.
+        remote_addr = x_forwarded_for.split(', ')[-2]
+    else:
+        remote_addr = '127.0.0.1'
+
+    environ = {
+        'PATH_INFO': get_wsgi_string(path),
+        'QUERY_STRING': get_wsgi_string(query_string),
+        'REMOTE_ADDR': remote_addr,
+        'REQUEST_METHOD': method,
+        'SCRIPT_NAME': get_wsgi_string(str(script_name)) if script_name else '',
+        'SERVER_NAME': str(server_name),
+        'SERVER_PORT': headers.get('X-Forwarded-Port', '80'),
+        'SERVER_PROTOCOL': str('HTTP/1.1'),
+        'wsgi.version': (1, 0),
+        'wsgi.url_scheme': headers.get('X-Forwarded-Proto', 'http'),
+        'wsgi.input': body,
+        'wsgi.errors': stderr,
+        'wsgi.multiprocess': False,
+        'wsgi.multithread': False,
+        'wsgi.run_once': False,
+    }
+
+    # Input processing
+    if method in ["POST", "PUT", "PATCH", "DELETE"]:
+        if 'Content-Type' in headers:
+            environ['CONTENT_TYPE'] = headers['Content-Type']
+
+        # This must be Bytes or None
+        environ['wsgi.input'] = six.BytesIO(body)
+        if body:
+            environ['CONTENT_LENGTH'] = str(len(body))
         else:
-            query_string = ""
+            environ['CONTENT_LENGTH'] = '0'
 
-        x_forwarded_for = headers.get('X-Forwarded-For', '')
-        if ',' in x_forwarded_for:
-            # The last one is the cloudfront proxy ip. The second to last is the real client ip.
-            # Everything else is user supplied and untrustworthy.
-            remote_addr = x_forwarded_for.split(', ')[-2]
-        else:
-            remote_addr = '127.0.0.1'
+    for header in headers:
+        wsgi_name = "HTTP_" + header.upper().replace('-', '_')
+        environ[wsgi_name] = str(headers[header])
 
-        environ = {
-            'PATH_INFO': get_wsgi_string(path),
-            'QUERY_STRING': get_wsgi_string(query_string),
-            'REMOTE_ADDR': remote_addr,
-            'REQUEST_METHOD': method,
-            'SCRIPT_NAME': get_wsgi_string(str(script_name)) if script_name else '',
-            'SERVER_NAME': str(server_name),
-            'SERVER_PORT': headers.get('X-Forwarded-Port', '80'),
-            'SERVER_PROTOCOL': str('HTTP/1.1'),
-            'wsgi.version': (1, 0),
-            'wsgi.url_scheme': headers.get('X-Forwarded-Proto', 'http'),
-            'wsgi.input': body,
-            'wsgi.errors': stderr,
-            'wsgi.multiprocess': False,
-            'wsgi.multithread': False,
-            'wsgi.run_once': False,
-        }
+    if script_name:
+        environ['SCRIPT_NAME'] = script_name
+        path_info = environ['PATH_INFO']
 
-        # Input processing
-        if method in ["POST", "PUT", "PATCH", "DELETE"]:
-            if 'Content-Type' in headers:
-                environ['CONTENT_TYPE'] = headers['Content-Type']
+        if script_name in path_info:
+            environ['PATH_INFO'].replace(script_name, '')
 
-            # This must be Bytes or None
-            environ['wsgi.input'] = six.BytesIO(body)
-            if body:
-                environ['CONTENT_LENGTH'] = str(len(body))
-            else:
-                environ['CONTENT_LENGTH'] = '0'
+    if remote_user:
+        environ['REMOTE_USER'] = remote_user
 
-        for header in headers:
-            wsgi_name = "HTTP_" + header.upper().replace('-', '_')
-            environ[wsgi_name] = str(headers[header])
+    if event_info['requestContext'].get('authorizer'):
+        environ['API_GATEWAY_AUTHORIZER'] = event_info['requestContext']['authorizer']
 
-        if script_name:
-            environ['SCRIPT_NAME'] = script_name
-            path_info = environ['PATH_INFO']
-
-            if script_name in path_info:
-                environ['PATH_INFO'].replace(script_name, '')
-
-        if remote_user:
-            environ['REMOTE_USER'] = remote_user
-
-        if event_info['requestContext'].get('authorizer'):
-            environ['API_GATEWAY_AUTHORIZER'] = event_info['requestContext']['authorizer']
-
-        return environ
+    return environ
 
 
 def common_log(environ, response, response_time=None):

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -41,7 +41,7 @@ def create_wsgi_request(event_info,
         """
         method = event_info['httpMethod']
         params = event_info['pathParameters']
-        query = event_info['queryStringParameters'] # APIGW won't allow multiple entries, ex ?id=a&id=b
+        query = event_info['multiValueQueryStringParameters']
         headers = event_info['headers'] or {} # Allow for the AGW console 'Test' button to work (Pull #735)
 
         if context_header_mappings:
@@ -95,7 +95,7 @@ def create_wsgi_request(event_info,
                 path = path[len(script_name):]
 
         if query:
-            query_string = urlencode(query)
+            query_string = urlencode(query, True)
         else:
             query_string = ""
 


### PR DESCRIPTION
## Description
AWS released support for multi-value (aka array) querystring parameters in API Gateway earlier this year. This means one can pass querystring containing arguments with same name (treated as an array). e.g: `param=value&param=othervalue`

This PR adds support for multi-value querystring parameters into Zappa so they are transferred correctly to the WSGI handler.

Also adds tests for multivalue headers (see #1755)