### PR TITLE
Handle more than 100 zones in route 53

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1483,6 +1483,70 @@ class TestZappa(unittest.TestCase):
         zappa_core.route53.list_resource_record_sets.assert_called_once_with(
             HostedZoneId='somezone')
 
+    @mock.patch('botocore.client')
+    def test_get_all_zones_normal_case(self, client):
+        zappa_core = Zappa(
+            boto_session=mock.Mock(),
+            profile_name="test",
+            aws_region="test",
+            load_credentials=False
+        )
+        zappa_core.route53 = mock.Mock()
+
+        # Check that it handle the normal case
+        zappa_core.route53.list_hosted_zones.return_value = {
+            'IsTruncated': False,
+            'HostedZones': [
+                {
+                    'Id': 'somezone'
+                }
+            ]
+        }
+
+        zones = zappa_core.get_all_zones()
+        zappa_core.route53.list_hosted_zones.assert_called_with(MaxItems='100')
+        self.assertListEqual(zones['HostedZones'], [{'Id': 'somezone'}])
+
+    @mock.patch('botocore.client')
+    def test_get_all_zones_two_pages(self, client):
+        zappa_core = Zappa(
+            boto_session=mock.Mock(),
+            profile_name="test",
+            aws_region="test",
+            load_credentials=False
+        )
+        zappa_core.route53 = mock.Mock()
+
+        # Check that it handle the normal case
+        zappa_core.route53.list_hosted_zones.side_effect = [
+            {
+                'IsTruncated': True,
+                'HostedZones': [
+                    {
+                        'Id': 'zone1'
+                    }
+                ],
+                'NextMarker': "101"
+            },
+            {
+                'IsTruncated': False,
+                'HostedZones': [
+                    {
+                        'Id': 'zone2'
+                    }
+                ]
+            }
+        ]
+
+        zones = zappa_core.get_all_zones()
+        zappa_core.route53.list_hosted_zones.assert_has_calls(
+            [
+                mock.call(MaxItems='100'),
+                mock.call(MaxItems='100', Marker='101'),
+            ]
+        )
+        self.assertListEqual(zones['HostedZones'], [{'Id': 'zone1'}, {'Id': 'zone2'}])
+
     ##
     # Django
     ##

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1463,6 +1463,7 @@ class TestZappa(unittest.TestCase):
 
         # And that the route53 path still works
         zappa_core.route53.list_hosted_zones.return_value = {
+            'IsTruncated': False,
             'HostedZones': [
                 {
                     'Id': 'somezone'

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2194,6 +2194,18 @@ class Zappa(object):
                 stage=stage
             )
         
+    def get_all_zones(self):
+        """Same behaviour of list_host_zones, but transparently handling pagination."""
+        zones = {'HostedZones': []}
+
+        new_zones = self.route53.list_hosted_zones(MaxItems='100')
+        while new_zones['isTruncated']:
+            zones['HostedZones'] += new_zones['HostedZones']
+            new_zones = self.route53.list_hosted_zones(Marker=new_zones['NextMarker'], MaxItems='100')
+
+        zones['HostedZones'] += new_zones['HostedZones']
+        return zones
+
 
     def get_domain_name(self, domain_name, route53=True):
         """
@@ -2212,7 +2224,7 @@ class Zappa(object):
             return True
 
         try:
-            zones = self.route53.list_hosted_zones()
+            zones = self.get_all_zones()
             for zone in zones['HostedZones']:
                 records = self.route53.list_resource_record_sets(HostedZoneId=zone['Id'])
                 for record in records['ResourceRecordSets']:
@@ -2814,7 +2826,7 @@ class Zappa(object):
         Get the Hosted Zone ID for a given domain.
 
         """
-        all_zones = self.route53.list_hosted_zones()
+        all_zones = self.route53.get_all_zones()
         return self.get_best_match_zone(all_zones, domain)
 
     @staticmethod

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2199,7 +2199,7 @@ class Zappa(object):
         zones = {'HostedZones': []}
 
         new_zones = self.route53.list_hosted_zones(MaxItems='100')
-        while new_zones['isTruncated']:
+        while new_zones['IsTruncated']:
             zones['HostedZones'] += new_zones['HostedZones']
             new_zones = self.route53.list_hosted_zones(Marker=new_zones['NextMarker'], MaxItems='100')
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2826,7 +2826,7 @@ class Zappa(object):
         Get the Hosted Zone ID for a given domain.
 
         """
-        all_zones = self.route53.get_all_zones()
+        all_zones = self.get_all_zones()
         return self.get_best_match_zone(all_zones, domain)
 
     @staticmethod


### PR DESCRIPTION
## Description
Changed the calls to list_hosted_zones to handle route 53 setups with more than 100 zones.

## GitHub Issues
Fixes #1661