### PR TITLE
pin urllib3 to a version compatible with requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4
 PyYAML==3.13
 requests>=2.10.0
+# requests has issues with urllib3 1.24
+urllib3<=1.23
 six>=1.11.0
 toml>=0.9.4
 tqdm==4.19.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,6 @@ mock>=2.0.0
 nose>=1.3.7
 nose-timer==0.6.0
 placebo>=0.8.1
+# requests has issues with urllib3 1.24
+# and if we install 1.24 here python setup.py install keeps both versions
+urllib3<=1.23


### PR DESCRIPTION
## Description
urllib3 1.24 and requests 2.19.1 don't play well together

Sample stacktrace:
```
======================================================================
ERROR: Failure: ImportError (No module named ordered_dict)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/Miserlou/Zappa/tests/tests_placebo.py", line 10, in <module>
    from zappa.cli import ZappaCLI
  File "/home/travis/build/Miserlou/Zappa/zappa/cli.py", line 31, in <module>
    import requests
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/__init__.py", line 112, in <module>
    from . import utils
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/utils.py", line 26, in <module>
    from ._internal_utils import to_native_string
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/_internal_utils.py", line 11, in <module>
    from .compat import is_py2, builtin_str, str
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/requests/compat.py", line 48, in <module>
    from urllib3.packages.ordered_dict import OrderedDict
ImportError: No module named ordered_dict
```


