### PR TITLE
Fix for #1508 Multiple query fields with same name only returning last value

### DIFF
--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -1,6 +1,8 @@
 import botocore
 import calendar
 import datetime
+import itertools
+
 import durationpy
 import fnmatch
 import io
@@ -525,3 +527,11 @@ def titlecase_keys(d):
     Takes a dict with keys of type str and returns a new dict with all keys titlecased.
     """
     return {k.title(): v for k, v in d.items()}
+
+
+def transform_multi_value_dict(multi_value_dict):
+    """
+    Takes a dict with values of type list and returns a tuple of key, value pairs
+    """
+    keys, values = zip(*multi_value_dict.items())
+    return tuple(next(zip(keys, v)) for v in itertools.product(*values))


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
This commit checks the event for a `multiValueQueryStringParameters` dict and if it finds it expands out the query params. APGW now support it but keep the values in a separate dictionary.
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#apigateway-multivalue-headers-and-parameters

The helper in the first commit is created so that multivalueheaders can also be implemented in another PR.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1508 
