### PR TITLE
use latest version of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 cache:
   - pip
 install:
-  - "pip install setuptools --upgrade; pip install -r test_requirements.txt; pip install -e git+https://github.com/django/django-contrib-comments.git#egg=django-contrib-comments; python setup.py install" 
+  - "pip install --upgrade pip; pip install --upgrade setuptools; pip install -r test_requirements.txt; pip install -e git+https://github.com/django/django-contrib-comments.git#egg=django-contrib-comments; python setup.py install" 
 # command to run tests
 env:
   - TESTCASE=tests/tests_docs.py


### PR DESCRIPTION

## Description
Use latest version of pip instead of older version. Upgrade pip before upgrading/installing the rest.

