### PR TITLE
Very large deployments - prevent unnecessary 504 error (resolves issue #1599)

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2651,9 +2651,9 @@ class ZappaCLI(object):
         req = requests.get(endpoint_url + touch_path)
 
         # Sometimes on really large packages, it can take 60-90 secs to be
-        # ready and requests will retrun 504 status_code until ready. 
+        # ready and requests will return 504 status_code until ready. 
         # So, if we get a 504 status code, rerun the request up to 4 times or 
-        # until we dont get a 504 error
+        # until we don't get a 504 error
         if req.status_code == 504:
             i = 0
             status_code = 504

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2655,12 +2655,12 @@ class ZappaCLI(object):
         # So, if we get a 504 status code, rerun the request up to 4 times or 
         # until we dont get a 504 error
         if req.status_code == 504:
-            max_tries = 0
+            i = 0
             status_code = 504
-            while status_code == 504 and max_tries <= 4:
+            while status_code == 504 and i <= 4:
                 req = requests.get(endpoint_url + touch_path)
                 status_code = req.status_code
-                max_tries += 1
+                i += 1
 
         if req.status_code >= 500:
             raise ClickException(click.style("Warning!", fg="red", bold=True) +

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2650,6 +2650,18 @@ class ZappaCLI(object):
         touch_path = self.stage_config.get('touch_path', '/')
         req = requests.get(endpoint_url + touch_path)
 
+        # Sometimes on really large packages, it can take 60-90 secs to be
+        # ready and requests will retrun 504 status_code until ready. 
+        # So, if we get a 504 status code, rerun the request up to 4 times or 
+        # until we dont get a 504 error
+        if req.status_code == 504:
+            max_tries = 0
+            status_code = 504
+            while status_code == 504 and max_tries <= 4:
+                req = requests.get(endpoint_url + touch_path)
+                status_code = req.status_code
+                max_tries += 1
+
         if req.status_code >= 500:
             raise ClickException(click.style("Warning!", fg="red", bold=True) +
                 " Status check on the deployed lambda failed." +


### PR DESCRIPTION
## Description
Allow very large deployments a little more time before erroring out

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1599
