### PR TITLE
Add missing argument for format string

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2336,7 +2336,7 @@ class Zappa(object):
                         StatementId=s['Sid']
                     )
                     if delete_response['ResponseMetadata']['HTTPStatusCode'] != 204:
-                        logger.error('Failed to delete an obsolete policy statement: {}'.format())
+                        logger.error('Failed to delete an obsolete policy statement: {}'.format(policy_response))
             else:
                 logger.debug('Failed to load Lambda function policy: {}'.format(policy_response))
         except ClientError as e:


### PR DESCRIPTION
Added a missing argument for format string in [core.py](https://github.com/Miserlou/Zappa/blob/master/zappa/core.py) which would raise an `IndexError`:

```
logger.error('Failed to delete an obsolete policy statement: {}'.format())
```