### PR TITLE
Issue #1715 Beginning support for Application Load Balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
   - [Using Zappa With Docker](#using-zappa-with-docker)
   - [Dead Letter Queues](#dead-letter-queues)
   - [Unique Package ID](#unique-package-id)
-  - [Using Application Load Balancer for Event Source](#alb-event-source)
+  - [ALB Event Source](#alb-event-source)
 - [Zappa Guides](#zappa-guides)
 - [Zappa in the Press](#zappa-in-the-press)
 - [Sites Using Zappa](#sites-using-zappa)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
   - [Using Zappa With Docker](#using-zappa-with-docker)
   - [Dead Letter Queues](#dead-letter-queues)
   - [Unique Package ID](#unique-package-id)
+  - [Using Application Load Balancer for Event Source](#alb-event-source)
 - [Zappa Guides](#zappa-guides)
 - [Zappa in the Press](#zappa-in-the-press)
 - [Sites Using Zappa](#sites-using-zappa)
@@ -1357,6 +1358,17 @@ For monitoring of different deployments, a unique UUID for each package is avail
   "uuid": "9c2df9e6-30f4-4c0a-ac4d-4ecb51831a74"
 }
 ```
+
+### ALB Event Source
+
+Zappa can be used to handle events triggered by Application Load Balancer (ALB). This can be useful when you have functions which may require execution wait times exceeding the hard-limit timeout of 30 seconds imposed by API Gateway/CloudFront, or, you want a straightforward means of housing all components in your VPC.
+[More information](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html)
+To accomplish this:
+1. You probably want to set `use_apigateway` to False in your settings to disable API gateway stack setup/deployment (but both can be supported)
+2. Use `zappa deploy` to deploy the lambda function if it is not already deployed
+3. Manually provision/configure ALB. Manually configure targeting to route to the lambda function. Take care to ensure the security group access is correct. Also ensure the AZs for the load balancer aligns with the lambda function.
+
+The zappa request handler logic supports both API Gateway and ELB forwarded event formats.
 
 ## Zappa Guides
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -279,3 +279,43 @@ class TestZappa(unittest.TestCase):
 
         response = lh.lambda_handler(event, None)
         mocked_exception_handler.assert_called
+
+    def test_wsgi_script_name_on_alb_event(self):
+        """
+        Ensure ALB-triggered events are properly handled by LambdaHandler
+        ALB-forwarded events have a slightly different request structure than API-Gateway
+        https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+
+        event = {
+            'requestContext': {
+                'elb': {
+                    'targetGroupArn': 'arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09'
+                }
+            },
+            'httpMethod': 'GET',
+            'path': '/return/request/url',
+            'queryStringParameters': {},
+            'headers': {
+                'accept': 'text/html,application/xhtml+xml',
+                'accept-language': 'en-US,en;q=0.8',
+                'content-type': 'text/plain',
+                'cookie': 'cookies',
+                'host': '1234567890.execute-api.us-east-1.amazonaws.com',
+                'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)',
+                'x-amzn-trace-id': 'Root=1-5bdb40ca-556d8b0c50dc66f0511bf520',
+                'x-forwarded-for': '72.21.198.66',
+                'x-forwarded-port': '443',
+                'x-forwarded-proto': 'https'
+            },
+            'isBase64Encoded': False,
+            'body': ''
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(
+            response['body'],
+            'https://1234567890.execute-api.us-east-1.amazonaws.com/return/request/url'
+        )

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -315,6 +315,8 @@ class TestZappa(unittest.TestCase):
         response = lh.handler(event, None)
 
         self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['statusDescription'], '200 OK')
+        self.assertEqual(response['isBase64Encoded'], False)
         self.assertEqual(
             response['body'],
             'https://1234567890.execute-api.us-east-1.amazonaws.com/return/request/url'

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -471,12 +471,13 @@ class LambdaHandler(object):
             # This is a normal HTTP request
             if event.get('httpMethod', None):
                 script_name = ''
+                is_elb_context = False
                 headers = event.get('headers')
                 if event.get('requestContext', None) and event['requestContext'].get('elb', None):
                     # Related: https://github.com/Miserlou/Zappa/issues/1715
                     # inputs/outputs for lambda loadbalancer
                     # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html
-                    logger.debug('elasticloadbalancingv2 request detected')
+                    is_elb_context = True
                     # host is lower-case when forwarded from ELB
                     host = headers.get('host')
                     # TODO: pathParameters is a first-class citizen in apigateway but not available without
@@ -532,6 +533,12 @@ class LambdaHandler(object):
                 # This is the object we're going to return.
                 # Pack the WSGI response into our special dictionary.
                 zappa_returndict = dict()
+
+                # Issue #1715: ALB support. ALB responses must always include
+                # base64 encoding and status description
+                if is_elb_context:
+                    zappa_returndict.setdefault('isBase64Encoded', False)
+                    zappa_returndict.setdefault('statusDescription', response.status)
 
                 if response.data:
                     if settings.BINARY_SUPPORT:


### PR DESCRIPTION
By adding support for the slightly different request forwarded by an ELB
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html
We can alter the handler to begin supporting optional ELB traffic as an alternative
to API Gateway


## Description
(WIP) Support for Application load balancer -> lambda
By adjusting the handler to honor the spec for lambda functions as ALB targets defined here:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html


## Known Issues:
Since ALB is a different animal, not all options with API Gateway are a perfect fit.
* API gateway features wont work:
    * Stages
    * Authorization
    * Domains (conceivably since youre using an ELB you have other means to accomplish this)
* Cognito is untested
* Django management is untested

* No support for provisioning (via troposphere) the load balancer, nor the targeting. Currently this must be done manually (not for lack of trying, it appears cloudformation hasnt caught up with ALB/lambda targeting yet)


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1715

