### PR TITLE
Preserve symlinks when packaging files into the zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ to change Zappa's behavior. Use these at your own risk!
         "payload_compression": true, // Whether or not to enable API gateway payload compression (default: true)
         "payload_minimum_compression_size": 0, // The threshold size (in bytes) below which payload compression will not be applied (default: 0)
         "prebuild_script": "your_module.your_function", // Function to execute before uploading code
+        "preserve_symlinks": false, // Symlinks to files within the source directory are preserved in the deployment package
         "profile_name": "your-profile-name", // AWS profile credentials to use. Default 'default'. Removing this setting will use the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables instead.
         "project_name": "MyProject", // The name of the project as it appears on AWS. Defaults to a slugified `pwd`.
         "remote_env": "s3://my-project-config-files/filename.json", // optional file in s3 bucket containing a flat json object which will be used to set custom environment variables.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -401,7 +401,7 @@ class TestZappa(unittest.TestCase):
             os.symlink('../external_file', './external_link')
             os.symlink(os.path.join(temp_directory, 'external_file'), './external_absolute_link')
 
-            z = Zappa()
+            z = Zappa(preserve_symlinks=True)
             path = z.create_lambda_zip()
             self.assertTrue(os.path.isfile(path))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -389,6 +389,7 @@ class TestZappa(unittest.TestCase):
             temp_directory = tempfile.mkdtemp()
             working_directory = os.path.join(temp_directory, 'working')
             os.mkdir(working_directory)
+            orig_cwd = os.getcwd()
             os.chdir(working_directory)
             with open('./real_file', 'w') as out_file:
                 out_file.write('abc')
@@ -435,6 +436,7 @@ class TestZappa(unittest.TestCase):
 
             os.remove(path)
             shutil.rmtree(temp_directory)
+            os.chdir(orig_cwd)
 
     ##
     # Logging

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -386,12 +386,19 @@ class TestZappa(unittest.TestCase):
         """Packaging a symlink to a file only includes the file once.
         """
         with mock.patch('zappa.core.Zappa.get_installed_packages', return_value={}):
-            with tempfile.TemporaryDirectory() as working_directory:
+            with tempfile.TemporaryDirectory() as temp_directory:
+                working_directory = os.path.join(temp_directory, 'working')
+                os.mkdir(working_directory)
                 os.chdir(working_directory)
                 with open('./real_file', 'w') as out_file:
                     out_file.write('abc')
 
+                with open('../external_file', 'w') as out_file:
+                    out_file.write('def')
+
                 os.symlink('./real_file', './link')
+                os.symlink('../external_file', './external_link')
+                os.symlink(os.path.join(temp_directory, 'external_file'), './external_absolute_link')
 
                 z = Zappa()
                 path = z.create_lambda_zip()
@@ -400,6 +407,8 @@ class TestZappa(unittest.TestCase):
                 with zipfile.ZipFile(path) as lambda_zip:
                     self.assertIn('real_file', lambda_zip.namelist())
                     self.assertIn('link', lambda_zip.namelist())
+                    self.assertIn('external_link', lambda_zip.namelist())
+                    self.assertIn('external_absolute_link', lambda_zip.namelist())
 
                     # We can't extract the zip to test the symlink,
                     # because zipfile.extract() doesn't preserve symlinks.
@@ -407,8 +416,22 @@ class TestZappa(unittest.TestCase):
                     zip_file_flag = 0o120000 << int(16)
                     self.assertEqual(link_info.external_attr & zip_file_flag, zip_file_flag)
 
+                    # The link to an external file should not be a
+                    # symlink, since it's not inside the directory
+                    # being packaged.
+                    external_link_info = lambda_zip.getinfo('external_link')
+                    self.assertEqual(external_link_info.external_attr & zip_file_flag, 0)
+                    external_absolute_link_info = lambda_zip.getinfo('external_absolute_link')
+                    self.assertEqual(external_absolute_link_info.external_attr & zip_file_flag, 0)
+
                     with lambda_zip.open('link') as link_data:
                         self.assertEqual(link_data.read(), b'./real_file')
+
+                    with lambda_zip.open('external_link') as external_link_data:
+                        self.assertEqual(external_link_data.read(), b'def')
+
+                    with lambda_zip.open('external_absolute_link') as external_absolute_link_data:
+                        self.assertEqual(external_absolute_link_data.read(), b'def')
 
                 os.remove(path)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -386,54 +386,55 @@ class TestZappa(unittest.TestCase):
         """Packaging a symlink to a file only includes the file once.
         """
         with mock.patch('zappa.core.Zappa.get_installed_packages', return_value={}):
-            with tempfile.TemporaryDirectory() as temp_directory:
-                working_directory = os.path.join(temp_directory, 'working')
-                os.mkdir(working_directory)
-                os.chdir(working_directory)
-                with open('./real_file', 'w') as out_file:
-                    out_file.write('abc')
+            temp_directory = tempfile.mkdtemp()
+            working_directory = os.path.join(temp_directory, 'working')
+            os.mkdir(working_directory)
+            os.chdir(working_directory)
+            with open('./real_file', 'w') as out_file:
+                out_file.write('abc')
 
-                with open('../external_file', 'w') as out_file:
-                    out_file.write('def')
+            with open('../external_file', 'w') as out_file:
+                out_file.write('def')
 
-                os.symlink('./real_file', './link')
-                os.symlink('../external_file', './external_link')
-                os.symlink(os.path.join(temp_directory, 'external_file'), './external_absolute_link')
+            os.symlink('./real_file', './link')
+            os.symlink('../external_file', './external_link')
+            os.symlink(os.path.join(temp_directory, 'external_file'), './external_absolute_link')
 
-                z = Zappa()
-                path = z.create_lambda_zip()
-                self.assertTrue(os.path.isfile(path))
+            z = Zappa()
+            path = z.create_lambda_zip()
+            self.assertTrue(os.path.isfile(path))
 
-                with zipfile.ZipFile(path) as lambda_zip:
-                    self.assertIn('real_file', lambda_zip.namelist())
-                    self.assertIn('link', lambda_zip.namelist())
-                    self.assertIn('external_link', lambda_zip.namelist())
-                    self.assertIn('external_absolute_link', lambda_zip.namelist())
+            with zipfile.ZipFile(path) as lambda_zip:
+                self.assertIn('real_file', lambda_zip.namelist())
+                self.assertIn('link', lambda_zip.namelist())
+                self.assertIn('external_link', lambda_zip.namelist())
+                self.assertIn('external_absolute_link', lambda_zip.namelist())
 
-                    # We can't extract the zip to test the symlink,
-                    # because zipfile.extract() doesn't preserve symlinks.
-                    link_info = lambda_zip.getinfo('link')
-                    zip_file_flag = 0o120000 << int(16)
-                    self.assertEqual(link_info.external_attr & zip_file_flag, zip_file_flag)
+                # We can't extract the zip to test the symlink,
+                # because zipfile.extract() doesn't preserve symlinks.
+                link_info = lambda_zip.getinfo('link')
+                zip_file_flag = 0o120000 << int(16)
+                self.assertEqual(link_info.external_attr & zip_file_flag, zip_file_flag)
 
-                    # The link to an external file should not be a
-                    # symlink, since it's not inside the directory
-                    # being packaged.
-                    external_link_info = lambda_zip.getinfo('external_link')
-                    self.assertEqual(external_link_info.external_attr & zip_file_flag, 0)
-                    external_absolute_link_info = lambda_zip.getinfo('external_absolute_link')
-                    self.assertEqual(external_absolute_link_info.external_attr & zip_file_flag, 0)
+                # The link to an external file should not be a
+                # symlink, since it's not inside the directory
+                # being packaged.
+                external_link_info = lambda_zip.getinfo('external_link')
+                self.assertEqual(external_link_info.external_attr & zip_file_flag, 0)
+                external_absolute_link_info = lambda_zip.getinfo('external_absolute_link')
+                self.assertEqual(external_absolute_link_info.external_attr & zip_file_flag, 0)
 
-                    with lambda_zip.open('link') as link_data:
-                        self.assertEqual(link_data.read(), b'./real_file')
+                with lambda_zip.open('link') as link_data:
+                    self.assertEqual(link_data.read(), b'./real_file')
 
-                    with lambda_zip.open('external_link') as external_link_data:
-                        self.assertEqual(external_link_data.read(), b'def')
+                with lambda_zip.open('external_link') as external_link_data:
+                    self.assertEqual(external_link_data.read(), b'def')
 
-                    with lambda_zip.open('external_absolute_link') as external_absolute_link_data:
-                        self.assertEqual(external_absolute_link_data.read(), b'def')
+                with lambda_zip.open('external_absolute_link') as external_absolute_link_data:
+                    self.assertEqual(external_absolute_link_data.read(), b'def')
 
-                os.remove(path)
+            os.remove(path)
+            shutil.rmtree(temp_directory)
 
     ##
     # Logging

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -117,6 +117,7 @@ class ZappaCLI(object):
     aws_kms_key_arn = ''
     context_header_mappings = None
     tags = []
+    preserve_symlinks = None
 
     stage_name_env_pattern = re.compile('^[a-zA-Z0-9_]+$')
 
@@ -2041,6 +2042,7 @@ class ZappaCLI(object):
         self.dead_letter_config = {'TargetArn': dead_letter_arn} if dead_letter_arn else {}
         self.cognito = self.stage_config.get('cognito', None)
         self.num_retained_versions = self.stage_config.get('num_retained_versions',None)
+        self.preserve_symlinks = self.stage_config.get('preserve_symlinks', False)
 
         # Check for valid values of num_retained_versions
         if self.num_retained_versions is not None and type(self.num_retained_versions) is not int:
@@ -2093,7 +2095,8 @@ class ZappaCLI(object):
                             runtime=self.runtime,
                             tags=self.tags,
                             endpoint_urls=self.stage_config.get('aws_endpoint_urls',{}),
-                            xray_tracing=self.xray_tracing
+                            xray_tracing=self.xray_tracing,
+                            preserve_symlinks=self.preserve_symlinks
                         )
 
         for setting in CUSTOM_SETTINGS:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -536,6 +536,16 @@ class Zappa(object):
             else:
                 copytree(cwd, temp_project_path, metadata=False, symlinks=True)
 
+            # Fix any broken symlinks to files that are outside the
+            # project directory.
+            for root, dirs, files in os.walk(temp_project_path):
+                for filename in files:
+                    file_path = os.path.join(root, filename)
+                    if os.path.islink(file_path) and not os.path.realpath(file_path).startswith(temp_project_path):
+                        original_file_path = os.path.join(cwd, os.path.relpath(file_path, temp_project_path))
+                        os.remove(file_path)
+                        shutil.copy2(original_file_path, file_path)
+
         # If a handler_file is supplied, copy that to the root of the package,
         # because that's where AWS Lambda looks for it. It can't be inside a package.
         if handler_file:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -246,7 +246,8 @@ class Zappa(object):
             runtime='python2.7', # Detected at runtime in CLI
             tags=(),
             endpoint_urls={},
-            xray_tracing=False
+            xray_tracing=False,
+            preserve_symlinks=False
         ):
         """
         Instantiate this new Zappa instance, loading any custom credentials if necessary.
@@ -275,6 +276,7 @@ class Zappa(object):
 
         self.endpoint_urls = endpoint_urls
         self.xray_tracing = xray_tracing
+        self.preserve_symlinks = preserve_symlinks
 
         # Some common invocations, such as DB migrations,
         # can take longer than the default.
@@ -532,9 +534,9 @@ class Zappa(object):
             if minify:
                 # Related: https://github.com/Miserlou/Zappa/issues/744
                 excludes = ZIP_EXCLUDES + exclude + [split_venv[-1]]
-                copytree(cwd, temp_project_path, metadata=False, symlinks=True, ignore=shutil.ignore_patterns(*excludes))
+                copytree(cwd, temp_project_path, metadata=False, symlinks=self.preserve_symlinks, ignore=shutil.ignore_patterns(*excludes))
             else:
-                copytree(cwd, temp_project_path, metadata=False, symlinks=True)
+                copytree(cwd, temp_project_path, metadata=False, symlinks=self.preserve_symlinks)
 
             # Fix any broken symlinks to files that are outside the
             # project directory.


### PR DESCRIPTION
## Description
Symlinks in the source directories are created as symlinks in the zip file, rather than deploying multiple copies of the same file.

## GitHub Issues

- #754 Zipfile doesn't preserve symlinks

