### PR TITLE
allow pyyaml>=3.13 in order to avoid vulnerabilities in pyyaml 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ lambda-packages==0.20.0
 pip>=9.0.1
 python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4
-PyYAML==3.13
+PyYAML>=3.13
 # previous version don't work with urllib3 1.24
 requests>=2.20.0
 six>=1.11.0


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

Change dependency on pyyaml from `==3.13` to `>=3.13`.

I have a couple of projects in GitHub that depend on Zappa and use `pipenv` to manage dependencies. GitHub has started sending me security alerts saying that there is a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) in that version of PyYAML and to upgrade to >= 4.02b1. 

This is impossible to do because of Zappa's explicit dependency on `pyyaml==3.13`. So I just changed the `==` to `>=`.


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

