### PR TITLE
Flask-like app factory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,7 @@ zappa_settings.json
 *.sublime-project
 *.sublime-workspace
 
+# VS Code stuff
+.vscode/
+
 README.test.md

--- a/tests/test_flask_app_factory_settings.py
+++ b/tests/test_flask_app_factory_settings.py
@@ -1,0 +1,13 @@
+API_STAGE = 'dev'
+APP_FUNCTION = 'create_app'
+APP_MODULE = 'tests.test_handler'
+BINARY_SUPPORT = False
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'create_app'
+COGNITO_TRIGGER_MAPPING = {}
+EXCEPTION_HANDLER = 'tests.test_handler.mocked_exception_handler'

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -36,6 +36,14 @@ def handle_bot_intent(event, context):
     return "Success"
 
 
+def create_app():
+    def hello_world_from_factory(environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return 'Hello World from App Factory'
+
+     return hello_world_from_factory
+
+
 mocked_exception_handler = Mock()
 
 
@@ -279,3 +287,32 @@ class TestZappa(unittest.TestCase):
 
         response = lh.lambda_handler(event, None)
         mocked_exception_handler.assert_called
+
+    def test_flask_app_factory(self):
+        """
+        Ensure that Flask application factory works.
+        """
+        lh = LambdaHandler('tests.test_flask_app_factory_settings')
+
+         event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {
+                'Host': '1234567890.execute-api.us-east-1.amazonaws.com',
+            },
+            'pathParameters': {
+                'proxy': 'return/request/url'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/return/request/url'
+        }
+
+         mocked_exception_handler.assert_not_called()
+        response = lh.handler(event, None)
+
+         self.assertEqual(response['statusCode'], 200)
+        mocked_exception_handler.assert_not_called()
+

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -41,7 +41,7 @@ def create_app():
         start_response('200 OK', [('Content-Type', 'text/html')])
         return 'Hello World from App Factory'
 
-     return hello_world_from_factory
+    return hello_world_from_factory
 
 
 mocked_exception_handler = Mock()
@@ -294,7 +294,7 @@ class TestZappa(unittest.TestCase):
         """
         lh = LambdaHandler('tests.test_flask_app_factory_settings')
 
-         event = {
+        event = {
             'body': '',
             'resource': '/{proxy+}',
             'requestContext': {},
@@ -310,9 +310,9 @@ class TestZappa(unittest.TestCase):
             'path': '/return/request/url'
         }
 
-         mocked_exception_handler.assert_not_called()
+        mocked_exception_handler.assert_not_called()
         response = lh.handler(event, None)
 
-         self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['statusCode'], 200)
         mocked_exception_handler.assert_not_called()
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -284,7 +284,7 @@ class LambdaHandler(object):
         else:  # Python 2
             args, varargs, keywords, defaults = inspect.getargspec(func)
 
-         return args, varargs, keywords, defaults
+        return args, varargs, keywords, defaults
 
     @staticmethod
     def run_function(app_function, event, context):

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -140,6 +140,15 @@ class LambdaHandler(object):
 
                 # The application
                 wsgi_app_function = getattr(self.app_module, self.settings.APP_FUNCTION)
+
+                # Flask-like app factory support
+                # https://github.com/Miserlou/Zappa/issues/1771
+                if inspect.isfunction(wsgi_app_function):
+                    args, varargs, keywords, _ = self.getargspec(wsgi_app_function)
+                    if len(args) == 0 and not varargs and not keywords:
+                        factory = wsgi_app_function
+                        wsgi_app_function = factory()
+
             # Django gets special treatment.
             else:
                 try:  # Support both for tests
@@ -267,17 +276,23 @@ class LambdaHandler(object):
         return exception_processed
 
     @staticmethod
+    def getargspec(func):
+        # getargspec does not support python 3 method with type hints
+        # Related issue: https://github.com/Miserlou/Zappa/issues/1452
+        if hasattr(inspect, "getfullargspec"):  # Python 3
+            args, varargs, keywords, defaults, _, _, _ = inspect.getfullargspec(func)
+        else:  # Python 2
+            args, varargs, keywords, defaults = inspect.getargspec(func)
+
+         return args, varargs, keywords, defaults
+
+    @staticmethod
     def run_function(app_function, event, context):
         """
         Given a function and event context,
         detect signature and execute, returning any result.
         """
-        # getargspec does not support python 3 method with type hints
-        # Related issue: https://github.com/Miserlou/Zappa/issues/1452
-        if hasattr(inspect, "getfullargspec"):  # Python 3
-            args, varargs, keywords, defaults, _, _, _ = inspect.getfullargspec(app_function)
-        else:  # Python 2
-            args, varargs, keywords, defaults = inspect.getargspec(app_function)
+        args, varargs, _, _ = LambdaHandler.getargspec(app_function)
         num_args = len(args)
         if num_args == 0:
             result = app_function(event, context) if varargs else app_function()


### PR DESCRIPTION
# Description 

How to use application factories in Zappa:

* app.py
`def create_app():`
&nbsp;&nbsp;&nbsp;&nbsp;`app = Flask()`
&nbsp;&nbsp;&nbsp;&nbsp;`#define settings, db, routes, ...`
&nbsp;&nbsp;&nbsp;&nbsp;`return app`

* zappa_settings.json
`{`
&nbsp;&nbsp;&nbsp;&nbsp;`"app_function": "app.create_app"`
`}`

# GitHub Issue

#1771 