### PR TITLE
fix certify route53 record creation with lets encrypt

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1852,6 +1852,7 @@ class ZappaCLI(object):
 
         # Get cert and update domain.
 
+        route53 = self.stage_config.get('route53_enabled', True)
         # Let's Encrypt
         if not cert_location and not cert_arn:
             from .letsencrypt import get_cert_and_update_domain
@@ -1860,12 +1861,12 @@ class ZappaCLI(object):
                     self.lambda_name,
                     self.api_stage,
                     self.domain,
-                    manual
+                    manual,
+                    route53_enabled=route53
                 )
 
         # Custom SSL / ACM
         else:
-            route53 = self.stage_config.get('route53_enabled', True)
             if not self.zappa.get_domain_name(self.domain, route53=route53):
                 dns_name = self.zappa.create_domain_name(
                     domain_name=self.domain,

--- a/zappa/letsencrypt.py
+++ b/zappa/letsencrypt.py
@@ -50,6 +50,7 @@ def get_cert_and_update_domain(
                                 api_stage,
                                 domain=None,
                                 manual=False,
+                                route53_enabled=False
                             ):
     """
     Main cert installer path.
@@ -73,7 +74,7 @@ def get_cert_and_update_domain(
         if not manual:
             if domain:
                 if not zappa_instance.get_domain_name(domain):
-                    zappa_instance.create_domain_name(
+                    dns_name = zappa_instance.create_domain_name(
                         domain_name=domain,
                         certificate_name=domain + "-Zappa-LE-Cert",
                         certificate_body=certificate_body,
@@ -84,6 +85,8 @@ def get_cert_and_update_domain(
                         stage=api_stage
                     )
                     print("Created a new domain name. Please note that it can take up to 40 minutes for this domain to be created and propagated through AWS, but it requires no further work on your part.")
+                    if route53_enabled:
+                        zappa_instance.update_route53_records(domain, dns_name)
                 else:
                     zappa_instance.update_domain_name(
                         domain_name=domain,


### PR DESCRIPTION
solves #762

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?
Yes.

* If this is a non-trivial commit, did you **open a ticket** for discussion?
It already existed.

* Did you **put the URL for that ticket in a comment** in the code?
Yes.

* If you made a new function, did you **write a good docstring** for it?
-

* Did you avoid putting "_" in front of your new function for no reason?
-

* Did you write a test for your new code?
Yes.

* Did the Travis build pass?
We'll see.

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?
Yes.

* Did you **make sure this code actually works on Lambda**, as well as locally?
No, I'll do that.

* Did you test this code with both **Python 2.7** and **Python 3.6**? 
Not yet.

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?
What linter?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Create S3 routes after creating lets encrypt certificates with `zappa certify`. https://github.com/Miserlou/Zappa/pull/784 already has a PR for this, but it's without tests and currently there's conflicts.
I reached lets encrypts rate limit when testing in python 3.6, but it's verified in python 2.7.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/762
https://github.com/Miserlou/Zappa/pull/784
