### PR TITLE
Bump version of PyYAML from PyYAML==3.13 to >=3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ lambda-packages==0.20.0
 pip>=9.0.1
 python-dateutil>=2.6.1, <2.7.0
 python-slugify==1.2.4
-PyYAML==3.13
+PyYAML>=3.13
 # previous version don't work with urllib3 1.24
 requests>=2.20.0
 six>=1.11.0


### PR DESCRIPTION
# Fixes vulnerability https://nvd.nist.gov/vuln/detail/CVE-2017-18342

Issue https://github.com/Miserlou/Zappa/issues/1751

## Description
This is just a repeat of https://github.com/Miserlou/Zappa/pull/1757 that passes the code coverage test. From @dtenenba and https://github.com/Miserlou/Zappa/pull/1757:

> ## Context
> Zappa has an explicit version of 3.13 for PyYAML. This causes a version conflict when you have other dependencies that require a newer version. Is this actually required to be locked in to this specific version. It looks like the Zappa sub-dependencies that use PyYaml don't lock it into that version:
> 
> ```
> PyYAML==3.13
>   - cfn-flip==1.1.0.post1 [requires: PyYAML>=3.13b1]
>     - troposphere==2.4.0 [requires: cfn-flip>=1.0.2]
>       - zappa==0.47.1 [requires: troposphere>=1.9.0]
>   - googleads==15.0.2 [requires: PyYAML>=4.2b1,<5.0]
>   - kappa==0.6.0 [requires: PyYAML>=3.11]
>     - zappa==0.47.1 [requires: kappa==0.6.0]
>   - zappa==0.47.1 [requires: PyYAML==3.13]
> ```
> ## Expected Behavior
> Expect requirements.txt to include `PyYAML>=3.13`
> 
> ## Actual Behavior
> `PyYAML==3.13`
> 
> ## Possible Fix
> Update the requirements.txt to request a minimum version for PyYAML.
> 
> ## Your Environment
> * Zappa version used: `0.47.1`
> * Operating System and Python version: Mac OS 10.14.2, Python 3.6.6