### PR TITLE
Example of Remote Function Invocation to create superuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,9 @@ Any remote print statements made and the value the function returned will then b
 You can also invoke interpretable Python 2.7 or Python 3.6 strings directly by using `--raw`, like so:
 
     $ zappa invoke production "print 1 + 2 + 3" --raw
+    
+For instance, it can come in handy if you want to create your first `superuser` on a RDS database running in a VPC (like Serverless Aurora):
+    $ zappa invoke staging "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('username', 'email', 'password')" --raw
 
 ### Django Management Commands
 


### PR DESCRIPTION
## Description
Add example usage of Remote Function Invocation with a real-world usage about how to create a Django superuser. 

Handy if there is no direct access to the DB _(most likely because it's running in a RDS instance inside a VPC which makes direct access more tedious yet possible)_


