### PR TITLE
Set bucket to have  SSE encryption by default

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -920,12 +920,38 @@ class Zappa(object):
             if self.aws_region == 'us-east-1':
                 self.s3_client.create_bucket(
                     Bucket=bucket_name,
-                )
+                    )
+
+                self.s3_client.put_bucket_encryption(
+                    Bucket=bucket_name,
+                    ServerSideEncryptionConfiguration={
+                        'Rules': [
+                            {
+                                'ApplyServerSideEncryptionByDefault': {
+                                    'SSEAlgorithm': 'AES256',
+                                    }
+                                },
+                            ]
+                        }
+                    )
             else:
                 self.s3_client.create_bucket(
                     Bucket=bucket_name,
                     CreateBucketConfiguration={'LocationConstraint': self.aws_region},
-                )
+                    )
+
+                self.s3_client.put_bucket_encryption(
+                    Bucket=bucket_name,
+                    ServerSideEncryptionConfiguration={
+                        'Rules': [
+                            {
+                                'ApplyServerSideEncryptionByDefault': {
+                                    'SSEAlgorithm': 'AES256',
+                                    }
+                                },
+                            ]
+                        }
+                    )
 
             if self.tags:
                 tags = {


### PR DESCRIPTION
Potential fix for #1792

## Description
Sets the encryption on the bucket to AES256 by default when it's created.

## GitHub Issues

#1792
