### PR TITLE
Add setting to clean up s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ to change Zappa's behavior. Use these at your own risk!
         "dead_letter_arn": "arn:aws:<sns/sqs>:::my-topic/queue", // Optional Dead Letter configuration for when Lambda async invoke fails thrice
         "debug": true, // Print Zappa configuration errors tracebacks in the 500. Default true.
         "delete_local_zip": true, // Delete the local zip archive after code updates. Default true.
+        "delete_s3_bucket": false, // Delete the s3 bucket after code updates. Default false.
         "delete_s3_zip": true, // Delete the s3 zip archive. Default true.
         "django_settings": "your_project.production_settings", // The modular path to your Django project's settings. For Django projects only.
         "domain": "yourapp.yourdomain.com", // Required if you're using a domain

--- a/tests/placebo/TestZappa.test_cli_aws/s3.DeleteBucket_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "ldu8D2RVRw0NbQAkx/6NrC87k8c8NR8fI1JxN1PLjFw/+GkMir3UIRjU25z/p4it0ppVHY8epWs=",
+            "RequestId": "A112859017E5977B",
+            "RetryAttempts": 0,
+            "HTTPHeaders": {
+                "date": "Tue, 20 Sep 2016 19:58:20 GMT",
+                "server": "AmazonS3",
+                "x-amz-id-2": "ldu8D2RVRw0NbQAkx/6NrC87k8c8NR8fI1JxN1PLjFw/+GkMir3UIRjU25z/p4it0ppVHY8epWs=",
+                "x-amz-request-id": "A112859017E5977B"
+            }
+        }
+    }
+}

--- a/tests/placebo/TestZappa.test_upload_remove_s3/s3.DeleteBucket_1.json
+++ b/tests/placebo/TestZappa.test_upload_remove_s3/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "ldu8D2RVRw0NbQAkx/6NrC87k8c8NR8fI1JxN1PLjFw/+GkMir3UIRjU25z/p4it0ppVHY8epWs=",
+            "RequestId": "A112859017E5977B",
+            "RetryAttempts": 0,
+            "HTTPHeaders": {
+                "date": "Tue, 20 Sep 2016 19:58:20 GMT",
+                "server": "AmazonS3",
+                "x-amz-id-2": "ldu8D2RVRw0NbQAkx/6NrC87k8c8NR8fI1JxN1PLjFw/+GkMir3UIRjU25z/p4it0ppVHY8epWs=",
+                "x-amz-request-id": "A112859017E5977B"
+            }
+        }
+    }
+}

--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -5,6 +5,8 @@ import random
 import string
 import unittest
 
+from botocore.exceptions import ClientError
+
 from .utils import placebo_session
 
 from zappa.cli import ZappaCLI
@@ -62,6 +64,10 @@ class TestZappa(unittest.TestCase):
         z.aws_region = 'us-east-1'
         res = z.upload_to_s3(zip_path, bucket_name)
         os.remove(zip_path)
+        self.assertTrue(res)
+
+        # will clean up s3 bucket
+        res = z.remove_s3_bucket(bucket_name)
         self.assertTrue(res)
 
     @placebo_session

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -57,6 +57,7 @@ CUSTOM_SETTINGS = [
     'attach_policy',
     'aws_region',
     'delete_local_zip',
+    'delete_s3_bucket',
     'delete_s3_zip',
     'exclude',
     'extra_permissions',
@@ -849,6 +850,10 @@ class ZappaCLI(object):
         if not source_zip:
             self.remove_uploaded_zip()
 
+        # Remove the S3 bucket.
+        if not source_zip:
+            self.remove_s3_bucket()
+
         self.callback('post')
 
         click.echo(deployment_string)
@@ -1020,6 +1025,10 @@ class ZappaCLI(object):
             endpoint_url = None
 
         self.schedule()
+
+        # Clean up the S3 bucket, because it is no longer needed.
+        if not source_zip and not no_upload:
+            self.remove_s3_bucket()
 
         # Update any cognito pool with the lambda arn
         # do this after schedule as schedule clears the lambda policy and we need to add one
@@ -2454,6 +2463,13 @@ class ZappaCLI(object):
             except Exception as e: # pragma: no cover
                 sys.exit(-1)
 
+    def remove_s3_bucket(self):
+        """
+        Remove the s3 upload bucket after uploading and updating.
+        """
+        if self.stage_config.get('delete_s3_bucket', True):
+            self.zappa.remove_s3_bucket(self.s3_bucket_name)
+
     def remove_uploaded_zip(self):
         """
         Remove the local and S3 zip file after uploading and updating.
@@ -2475,6 +2491,7 @@ class ZappaCLI(object):
             # Only try to remove uploaded zip if we're running a command that has loaded credentials
             if self.load_credentials:
                 self.remove_uploaded_zip()
+                self.remove_s3_bucket()
 
             self.remove_local_zip()
 

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1023,6 +1023,27 @@ class Zappa(object):
         except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError):  # pragma: no cover
             return False
 
+    def remove_s3_bucket(self, bucket_name):
+        """
+        Given a bucket, delete it from S3.
+
+        There's no reason to keep the s3 bucket once a Lambda function has been created, so we can delete it from S3.
+
+        Returns True on success, False on failure.
+        """
+        try:
+            self.s3_client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError as e:  # pragma: no cover
+            error_code = int(e.response['Error']['Code'])
+            if error_code == 404:
+                return False
+
+        try:
+            self.s3_client.delete_bucket(Bucket=bucket_name)
+            return True
+        except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError):  # pragma: no cover
+            return False
+
     ##
     # Lambda
     ##


### PR DESCRIPTION
## Description
This PR adds:

- the custom setting `delete_s3_bucket`, which will delete the s3 bucket at
  the end of a deploy or update. The default value of the new setting is
  `False` to ensure there is no behaviour change for existing projects.

- a new assertion in the `tests_placebo.py:TestZappa.test_upload_remove_s3`
  test case.

- a line in the README to reflect the new setting. 

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1643
