### PR TITLE
Fix Python 2 Unicode path behavior

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -573,7 +573,7 @@ class TestZappa(unittest.TestCase):
             "path": '/path/%E6%B8%AC%E8%A9%A6',
             "httpMethod": "GET",
             "queryStringParameters": {
-                "a": '\xe6\xb8\xac\xe8\xa9\xa6'
+                "a": u'\u6e2c\u8a66'.encode('utf-8')
             },
             "requestContext": {}
         }

--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -201,4 +201,5 @@ def get_wsgi_string(string, encoding='utf-8'):
     """
     Returns wsgi-compatible string
     """
-    return string.encode(encoding).decode('iso-8859-1')
+    return string if sys.version_info[0] < 3 else \
+        string.encode(encoding).decode('iso-8859-1')


### PR DESCRIPTION
I am investigating our Zappa code problem but found out a regression caused by previous fix.
So I am sending a pull request.

Also I made the commit message wrong. Should be only `decode` to iso-8859-1 instead of `encode`.

## Description

Fix Python 2 unicode path behavior, by only decoding to iso-8859-1 on Python 3

Minimal Flask app to introduce the problem:
```python
import sys
from flask import Flask, request, jsonify

app = Flask(__name__)


@app.route('/a/<name>')
def name(name):
    return jsonify({
        'url': request.url
    })


if __name__ == '__main__':
    app.run(debug=True)
```

Use the following URL:
```https://~~~.amazonaws.com/dev/a/%E6%B8%AC%E8%A9%A6?q=%E6%B8%AC%E8%A9%A6```

The URL in JSON should be ends with `/dev/a/測試?q=測試` in either Python 2 or 3 locally.
But for current Zappa, it ends with `/a/æ¸¬è©¦?q=測試"` in Python 2.

### Reason and fixes

The WSGI implementations (both Werkzeug and Django) expect `iso-8859-1`-decoded string **ONLY** if it is under Python 3.

So we fixed the Unicode URL path in Python 3 but braking Python 2.

This patch should bring the Python 2 behavior back.

## GitHub Issues
A #1199 follow-up.

