### PR TITLE
SES event support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ zappa_settings.json
 *.sublime-workspace
 
 README.test.md
+.vscode

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,6 @@
 APP_MODULE = 'tests.test_app'
 APP_FUNCTION = 'hello_world'
-DJANGO_SETTINGS = None 
+DJANGO_SETTINGS = None
 DEBUG = 'True'
 LOG_LEVEL = 'DEBUG'
 SCRIPT_NAME = 'hello_world'
@@ -9,11 +9,6 @@ API_STAGE = 'ttt888'
 PROJECT_NAME = 'ttt888'
 
 REMOTE_ENV='s3://lmbda/test_env.json'
-## test_env.json
-#{
-#	"hello": "world"
-#}
-#
 
 AWS_EVENT_MAPPING = {
     'arn:aws:s3:1': 'test_settings.aws_s3_event',
@@ -40,8 +35,13 @@ def aws_s3_event(event, content):
     return "AWS S3 EVENT"
 
 
+def aws_ses_event(event, content):
+    return event
+
+
 def aws_sns_event(event, content):
     return "AWS SNS EVENT"
+
 
 def aws_async_sns_event(arg1, arg2, arg3):
     return "AWS ASYNC SNS EVENT"
@@ -65,4 +65,3 @@ def authorizer_event(event, content):
 
 def command():
     print("command")
-

--- a/tests/test_ses_settings.py
+++ b/tests/test_ses_settings.py
@@ -1,0 +1,12 @@
+API_STAGE = 'dev'
+BINARY_SUPPORT = False
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'wsgi_script_name_settings'
+AWS_EVENT_MAPPING = {
+    'arn:aws:ses:1': 'test_settings.aws_ses_event',
+}
+EXCEPTION_HANDLER = None

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -294,7 +294,7 @@ class LambdaHandler(object):
         """
         Get the associated function to execute for a triggered AWS event
 
-        Support S3, SNS, DynamoDB, kinesis and SQS events
+        Support S3, SNS, DynamoDB, kinesis, SQS, and SES events
         """
         if 's3' in record:
             if ':' in record['s3']['configurationId']:
@@ -309,6 +309,8 @@ class LambdaHandler(object):
             except ValueError:
                 pass
             arn = record['Sns'].get('TopicArn')
+        elif record.get('eventSource') == 'aws:ses':
+            arn = record['ses']['receipt']['action'].get('functionArn')
         elif 'dynamodb' in record or 'kinesis' in record:
             arn = record.get('eventSourceARN')
         elif 'eventSource' in record and record.get('eventSource') == 'aws:sqs':
@@ -318,7 +320,6 @@ class LambdaHandler(object):
 
         if arn:
             return self.settings.AWS_EVENT_MAPPING.get(arn)
-
         return None
 
     def get_function_from_bot_intent_trigger(self, event):
@@ -415,7 +416,6 @@ class LambdaHandler(object):
 
         # This is an AWS-event triggered invocation.
         elif event.get('Records', None):
-
             records = event.get('Records')
             result = None
             whole_function = self.get_function_for_aws_event(records[0])


### PR DESCRIPTION
## Description
Lambda has supported SES events as a trigger for quite awhile now, and there's a few folks that have requested this functionality. It's a fairly easy add; the bulk of the code here is around testing the event shape that comes in.

The one caveat here is that when AWS sends an SES message along, it _doesn't_ send the content of the email, even if the event type is that an email was received. If you're looking for SES support when it comes to _actually handling the content of received emails_, you'll have to set up a [SES to S3 pipeline](https://aws.amazon.com/getting-started/projects/setup-email-receiving-pipeline/) and instead trigger off of an S3 event.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1501

