### PR TITLE
Endpoint configuration with warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,7 +1399,7 @@ More information on using ALB as an event source for Lambda can be found [here](
 
 ### Endpoint Configuration
 
-API Gateway can be configured to be only accessible in a VPC. To enable this; [configure your VPC to support](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html) then set the `endpoint_configuration` to `PRIVATE` and set up Resource Policy on the API Gateway.
+API Gateway can be configured to be only accessible in a VPC. To enable this; [configure your VPC to support](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html) then set the `endpoint_configuration` to `PRIVATE` and set up Resource Policy on the API Gateway. A note about this; if you're using a private endpoint, Zappa won't be able to tell if the API is returning a successful status code upon deploy or update, so you'll have to check it manually to ensure your setup is working properly.
 
 For full list of options for endpoint configuration refer to [API Gateway EndpointConfiguration documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html)
 
@@ -1438,10 +1438,11 @@ apigateway_resource_policy.json:
             "Effect": "Allow",
             "Principal": "*",
             "Action": "execute-api:Invoke",
-            "Resource": "execute-api:/*",
+            "Resource": "execute-api:/*"
         }
     ]
 }
+```
 
 ## Zappa Guides
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@
   - [Dead Letter Queues](#dead-letter-queues)
   - [Unique Package ID](#unique-package-id)
   - [Application Load Balancer Event Source](#application-load-balancer-event-source)
+  - [Endpoint Configuration](#endpoint-configuration)
+    - [Example Private API Gateway configuration](#example-private-api-gateway-configuration)
 - [Zappa Guides](#zappa-guides)
 - [Zappa in the Press](#zappa-in-the-press)
 - [Sites Using Zappa](#sites-using-zappa)
@@ -888,6 +890,7 @@ to change Zappa's behavior. Use these at your own risk!
                 }
             }
         ],
+        "endpoint_configuration": ["EDGE", "REGIONAL", "PRIVATE"],  // Specify APIGateway endpoint None (default) or list `EDGE`, `REGION`, `PRIVATE`
         "exception_handler": "your_module.report_exception", // function that will be invoked in case Zappa sees an unhandled exception raised from your code
         "exclude": ["*.gz", "*.rar"], // A list of regex patterns to exclude from the archive. To exclude boto3 and botocore (available in an older version on Lambda), add "boto3*" and "botocore*".
         "extends": "stage_name", // Duplicate and extend another stage's settings. For example, `dev-asia` could extend from `dev-common` with a different `s3_bucket` value.
@@ -1389,11 +1392,56 @@ Like API Gateway, Zappa can automatically provision ALB resources for you.  You'
         // And here, a list of security group IDs, eg. 'sg-fbacb791'
     ]
 }
-```
 
 More information on using ALB as an event source for Lambda can be found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html).
 
 *An important note*: right now, Zappa will provision ONE lambda to ONE load balancer, which means using `base_path` along with ALB configuration is currently unsupported.
+
+### Endpoint Configuration
+
+API Gateway can be configured to be only accessible in a VPC. To enable this; [configure your VPC to support](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html) then set the `endpoint_configuration` to `PRIVATE` and set up Resource Policy on the API Gateway.
+
+For full list of options for endpoint configuration refer to [API Gateway EndpointConfiguration documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html)
+
+#### Example Private API Gateway configuration
+
+zappa_settings.json:
+```json
+{
+    "dev": {
+        ...
+        "endpoint_configuration": ["PRIVATE"],
+        "apigateway_policy": "apigateway_resource_policy.json",
+        ...
+    },
+    ...
+}
+```
+
+apigateway_resource_policy.json:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": "execute-api:/*",
+            "Condition": {
+                "StringNotEquals": {
+                    "aws:sourceVpc": "{{vpcID}}" // UPDATE ME
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": "execute-api:/*",
+        }
+    ]
+}
 
 ## Zappa Guides
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -663,7 +663,8 @@ class ZappaCLI(object):
                                             authorizer=self.authorizer,
                                             cors_options=self.cors,
                                             description=self.apigateway_description,
-                                            policy=self.apigateway_policy
+                                            policy=self.apigateway_policy,
+                                            endpoint_configuration=self.endpoint_configuration
                                         )
 
         if not output:
@@ -801,7 +802,8 @@ class ZappaCLI(object):
                                                         iam_authorization=self.iam_authorization,
                                                         authorizer=self.authorizer,
                                                         cors_options=self.cors,
-                                                        description=self.apigateway_description
+                                                        description=self.apigateway_description,
+                                                        endpoint_configuration=self.endpoint_configuration
                                                     )
 
             self.zappa.update_stack(
@@ -981,7 +983,8 @@ class ZappaCLI(object):
                                             iam_authorization=self.iam_authorization,
                                             authorizer=self.authorizer,
                                             cors_options=self.cors,
-                                            description=self.apigateway_description
+                                            description=self.apigateway_description,
+                                            endpoint_configuration=self.endpoint_configuration
                                         )
             self.zappa.update_stack(
                                     self.lambda_name,
@@ -2076,6 +2079,7 @@ class ZappaCLI(object):
         self.binary_support = self.stage_config.get('binary_support', True)
         self.api_key_required = self.stage_config.get('api_key_required', False)
         self.api_key = self.stage_config.get('api_key')
+        self.endpoint_configuration = self.stage_config.get('endpoint_configuration', None)
         self.iam_authorization = self.stage_config.get('iam_authorization', False)
         self.cors = self.stage_config.get("cors", False)
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2697,8 +2697,23 @@ class ZappaCLI(object):
 
     def touch_endpoint(self, endpoint_url):
         """
-        Test the deployed endpoint with a GET request
+        Test the deployed endpoint with a GET request.
         """
+
+        # Private APIGW endpoints most likely can't be reached by a deployer
+        # unless they're connected to the VPC by VPN. Instead of trying
+        # connect to the service, print a warning and let the user know
+        # to check it manually.
+        # See: https://github.com/Miserlou/Zappa/pull/1719#issuecomment-471341565
+        if 'PRIVATE' in self.stage_config.get('endpoint_configuration', []):
+            print(
+                click.style("Warning!", fg="yellow", bold=True) +
+                " Since you're deploying a private API Gateway endpoint,"
+                " Zappa cannot determine if your function is returning "
+                " a correct status code. You should check your API's response"
+                " manually before considering this deployment complete."
+            )
+            return
 
         touch_path = self.stage_config.get('touch_path', '/')
         req = requests.get(endpoint_url + touch_path)

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1511,7 +1511,8 @@ class Zappa(object):
                                     authorization_type='NONE',
                                     authorizer=None,
                                     cors_options=None,
-                                    description=None
+                                    description=None,
+                                    endpoint_configuration=None
                                 ):
         """
         Create the API Gateway for this Zappa deployment.
@@ -1524,9 +1525,12 @@ class Zappa(object):
         if not description:
             description = 'Created automatically by Zappa.'
         restapi.Description = description
+        endpoint_configuration = [] if endpoint_configuration is None else endpoint_configuration
         if self.boto_session.region_name == "us-gov-west-1":
+            endpoint_configuration.append("REGIONAL")
+        if endpoint_configuration:
             endpoint = troposphere.apigateway.EndpointConfiguration()
-            endpoint.Types = ["REGIONAL"]
+            endpoint.Types = list(set(endpoint_configuration))
             restapi.EndpointConfiguration = endpoint
         if self.apigateway_policy:
             restapi.Policy = json.loads(self.apigateway_policy)
@@ -2080,7 +2084,8 @@ class Zappa(object):
                                 iam_authorization,
                                 authorizer,
                                 cors_options=None,
-                                description=None
+                                description=None,
+                                endpoint_configuration=None
                             ):
         """
         Build the entire CF stack.
@@ -2111,7 +2116,8 @@ class Zappa(object):
                                             authorization_type=auth_type,
                                             authorizer=authorizer,
                                             cors_options=cors_options,
-                                            description=description
+                                            description=description,
+                                            endpoint_configuration=endpoint_configuration
                                         )
         return self.cf_template
 


### PR DESCRIPTION
### Description
Per @IlyaSukhanov's work in #1719, this adds an option within settings to tweak an API Gateway's [endpoint configuration](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html), which allows for creation of private APIGW endpoints.

One note; due to the nature of private endpoints, a status code can't be retrieved on `zappa deploy` or `zappa update`, so a warning message is shown to the user instead indicating to double-check the success of their deployment. 

### GitHub Issues
#1540