### PR TITLE
Fix an issue with ALB aliases and already-deployed functions.

### DIFF
--- a/tests/placebo/TestZappa.test_cli_aws/lambda.GetAlias_1.json
+++ b/tests/placebo/TestZappa.test_cli_aws/lambda.GetAlias_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "AliasArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:current-alb-version",
+        "Description": "Zappa Deployment",
+        "FunctionVersion": "1",
+        "Name": "current-alb-version"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_lambda_function_local/lambda.GetAlias_1.json
+++ b/tests/placebo/TestZappa.test_create_lambda_function_local/lambda.GetAlias_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "AliasArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:current-alb-version",
+        "Description": "Zappa Deployment",
+        "FunctionVersion": "1",
+        "Name": "current-alb-version"
+    }
+}

--- a/tests/placebo/TestZappa.test_create_lambda_function_s3/lambda.GetAlias_1.json
+++ b/tests/placebo/TestZappa.test_create_lambda_function_s3/lambda.GetAlias_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "AliasArn": "arn:aws:lambda:us-east-1:12345:function:test_lmbda_function55:current-alb-version",
+        "Description": "Zappa Deployment",
+        "FunctionVersion": "1",
+        "Name": "current-alb-version"
+    }
+}

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -757,7 +757,8 @@ class ZappaCLI(object):
                 memory_size=self.memory_size,
                 runtime=self.runtime,
                 aws_environment_variables=self.aws_environment_variables,
-                aws_kms_key_arn=self.aws_kms_key_arn
+                aws_kms_key_arn=self.aws_kms_key_arn,
+                use_alb=self.use_alb
             )
             if source_zip and source_zip.startswith('s3://'):
                 bucket, key_name = parse_s3_url(source_zip)


### PR DESCRIPTION
### Description
In #1807, we introduced support for application load balancers as an event source for Zappa-driven functions. Unfortunately, that PR also introduced a bug where previously deployed services became unable to be updated with `zappa update`, as the code branch dealing with Lambda aliases wasn't checking for the existence of those aliases first. This PR fixes this bug two ways:

a) Check for the existence of the alias first before trying to update it. This handles the narrow case of older applications failing to deploy. 
b) Only _create_ the alias given that ALB provisioning is requested. Since we're checking to see if it exists before updating anyway, we can safely _not_ create it in any circumstance where an ALB isn't part of the configuration. 

### Issues
https://github.com/Miserlou/Zappa/issues/1823