### PR TITLE
Fix for repeated values on headers

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -402,7 +402,7 @@ class TestZappa(unittest.TestCase):
         }
 
         merged = merge_headers(event)
-        self.assertEqual(merged['a'], 'c, b')
+        self.assertEqual(merged['a'], 'c')
         self.assertEqual(merged['x'], 'y')
         self.assertEqual(merged['z'], 'q')
 

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -572,5 +572,6 @@ def merge_headers(event):
     for h in set(headers.keys()):
         if h not in multi_headers:
             multi_headers[h] = [headers[h]]
+    for h in multi_headers.keys():
         multi_headers[h] = ', '.join(multi_headers[h])
     return multi_headers

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -569,10 +569,8 @@ def merge_headers(event):
     """
     headers = event.get('headers') or {}
     multi_headers = (event.get('multiValueHeaders') or {}).copy()
-    for h in (set(multi_headers.keys()) | set(headers.keys())):
+    for h in set(headers.keys()):
         if h not in multi_headers:
             multi_headers[h] = [headers[h]]
-        elif h in headers:
-            multi_headers[h].append(headers[h])
         multi_headers[h] = ', '.join(multi_headers[h])
     return multi_headers


### PR DESCRIPTION


## Description

This changes the merge_headers function to just copy the multiValueHeaders and add non-existing entries from headers instead of replicating existing values multiple times.

## GitHub Issues

#1821
#1825 
