### PR TITLE
Allow Docutils to be shipped to Lambda

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -201,7 +201,7 @@ LAMBDA_REGIONS = ['us-east-1', 'us-east-2',
 # Related: https://github.com/Miserlou/Zappa/pull/581
 ZIP_EXCLUDES = [
     '*.exe', '*.DS_Store', '*.Python', '*.git', '.git/*', '*.zip', '*.tar.gz',
-    '*.hg', 'pip', 'docutils*', 'setuputils*', '__pycache__/*'
+    '*.hg', 'pip', 'setuputils*', '__pycache__/*'
 ]
 
 # When using ALB as an event source for Lambdas, we need to create an alias


### PR DESCRIPTION
## Description
Allows the `docutils` module to be shipped to lambdas.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1829
