### PR TITLE
Add Support for using an existing ALB and Listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,9 +821,17 @@ to change Zappa's behavior. Use these at your own risk!
     "dev": {
         "alb_enabled": false, // enable provisioning of application load balancing resources. If set to true, you _must_ fill out the alb_vpc_config option as well.
         "alb_vpc_config": {
-            "CertificateArn": "your_acm_certificate_arn", // ACM certificate ARN for ALB
+            // To create an ALB set CertificateArn, SubnetIds, and SecurityGroupIds
+            "CertificateArn": "your_acm_certificate_arn", // ACM certificate ARN for ALB  - not required if LoadBalancerArn is specified
             "SubnetIds": [], // list of subnets for ALB
             "SecurityGroupIds": [] // list of security groups for ALB
+            // To use an existing ALB set LoadBalancerArn, alb_listener_rule_conditions, alb_listener_rule_priority
+            "LoadBalancerArn": "your_alb_arn"
+            "alb_listener_rule_conditions": {
+                "Field": "path-pattern",  //  one of host-header or path-pattern
+                "Values": ["*"]  // host: "api.example.com" OR path route: "api/*",  "v1"
+            },
+            "alb_listener_rule_priority": 1 // Priority for Listener rule. A listener can't have multiple rules with the same priority.
         },
         "api_key_required": false, // enable securing API Gateway endpoints with x-api-key header (default False)
         "api_key": "your_api_key_id", // optional, use an existing API key. The option "api_key_required" must be true to apply
@@ -1392,6 +1400,20 @@ Like API Gateway, Zappa can automatically provision ALB resources for you.  You'
         // And here, a list of security group IDs, eg. 'sg-fbacb791'
     ]
 }
+
+Or if you have an ALB already provisioned you can specify it like this:
+```
+"alb_enabled": true,
+"alb_vpc_config": {
+    "LoadBalancerArn": "arn:aws:acm:us-east-1:[your-account-id]:loadbalancer/app/[alb-name]/[f851177b4d4eb840]",
+    "alb_listener_rule_conditions": {
+        "Field": "path-pattern|host-header",
+        "Values": ["api/*"|"api.example.com"]
+    },
+    "alb_listener_rule_priority": 1
+}
+
+More information about using Listener Rules can be found [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_rule)
 
 More information on using ALB as an event source for Lambda can be found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html).
 

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1110,7 +1110,7 @@ class ZappaCLI(object):
                 return
 
         if self.use_alb:
-            self.zappa.undeploy_lambda_alb(self.lambda_name)
+            self.zappa.undeploy_lambda_alb(self.lambda_name, self.alb_vpc_config)
 
         if self.use_apigateway:
             if remove_logs:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1328,33 +1328,49 @@ class Zappa(object):
         """
         if not alb_vpc_config:
             raise EnvironmentError('When creating an ALB, alb_vpc_config must be filled out in zappa_settings.')
-        if 'SubnetIds' not in alb_vpc_config:
-            raise EnvironmentError('When creating an ALB, you must supply two subnets in different availability zones.')
-        if 'SecurityGroupIds' not in alb_vpc_config:
-            alb_vpc_config["SecurityGroupIds"] = []
-        if not alb_vpc_config.get('CertificateArn'):
-            raise EnvironmentError('When creating an ALB, you must supply a CertificateArn for the HTTPS listener.')
-        print("Deploying ALB infrastructure...")
+        # Use Existing ALB if specificed
+        if 'LoadBalancerArn' in alb_vpc_config:
+            if not 'alb_listener_rule_conditions' in alb_vpc_config:
+                raise EnvironmentError('When Specifing an ALB, you must supply a Listener Rule conditions for the listener.')
+            if not 'alb_listener_rule_priority' in alb_vpc_config:
+                raise EnvironmentError('When Specifing an ALB, you must supply a Listener Rule priority for the listener.')
 
-        # Create load balancer
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_load_balancer
-        kwargs = dict(
-            Name=lambda_name,
-            Subnets=alb_vpc_config["SubnetIds"],
-            SecurityGroups=alb_vpc_config["SecurityGroupIds"],
-            # TODO: Scheme can also be "internal" we need to add a new option for this.
-            Scheme="internet-facing",
-            # TODO: Tags might be a useful means of stock-keeping zappa-generated assets.
-            #Tags=[],
-            Type="application",
-            # TODO: can be ipv4 or dualstack (for ipv4 and ipv6) ipv4 is required for internal Scheme.
-            IpAddressType="ipv4"
-        )
-        response = self.elbv2_client.create_load_balancer(**kwargs)
-        if not(response["LoadBalancers"]) or len(response["LoadBalancers"]) != 1:
-            raise EnvironmentError("Failure to create application load balancer. Response was in unexpected format. Response was: {}".format(repr(response)))
-        if response["LoadBalancers"][0]['State']['Code'] == 'failed':
-            raise EnvironmentError("Failure to create application load balancer. Response reported a failed state: {}".format(response["LoadBalancers"][0]['State']['Reason']))
+            kwargs = dict(
+                LoadBalancerArns = [alb_vpc_config["LoadBalancerArn"]]
+            )
+            response = self.elbv2_client.describe_load_balancers(**kwargs)
+            if not(response["LoadBalancers"]) or len(response["LoadBalancers"]) != 1:
+                raise EnvironmentError("Failure to find provided application load balancer. Response was in unexpected format. Response was: {}".format(repr(response)))
+        else:
+            if 'SubnetIds' not in alb_vpc_config:
+                raise EnvironmentError('When creating an ALB, you must supply two subnets in different availability zones.')
+            if 'SecurityGroupIds' not in alb_vpc_config:
+                alb_vpc_config["SecurityGroupIds"] = []
+            if not alb_vpc_config.get('CertificateArn'):
+                raise EnvironmentError('When creating an ALB, you must supply a CertificateArn for the HTTPS listener.')
+
+            print("Deploying ALB infrastructure...")
+
+            # Create load balancer
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_load_balancer
+            kwargs = dict(
+                Name=lambda_name,
+                Subnets=alb_vpc_config["SubnetIds"],
+                SecurityGroups=alb_vpc_config["SecurityGroupIds"],
+                # TODO: Scheme can also be "internal" we need to add a new option for this.
+                Scheme="internet-facing",
+                # TODO: Tags might be a useful means of stock-keeping zappa-generated assets.
+                #Tags=[],
+                Type="application",
+                # TODO: can be ipv4 or dualstack (for ipv4 and ipv6) ipv4 is required for internal Scheme.
+                IpAddressType="ipv4"
+            )
+            response = self.elbv2_client.create_load_balancer(**kwargs)
+            if not(response["LoadBalancers"]) or len(response["LoadBalancers"]) != 1:
+                raise EnvironmentError("Failure to create application load balancer. Response was in unexpected format. Response was: {}".format(repr(response)))
+            if response["LoadBalancers"][0]['State']['Code'] == 'failed':
+                raise EnvironmentError("Failure to create application load balancer. Response reported a failed state: {}".format(response["LoadBalancers"][0]['State']['Reason']))
+
         load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
         load_balancer_dns = response["LoadBalancers"][0]["DNSName"]
         load_balancer_vpc = response["LoadBalancers"][0]["VpcId"]
@@ -1412,26 +1428,53 @@ class Zappa(object):
         )
         response = self.elbv2_client.register_targets(**kwargs)
 
-        # Bind listener to load balancer with default rule to target group.
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_listener
-        kwargs = dict(
-            # TODO: Listeners support custom ssl certificates (Certificates). For now we leave this default.
-            Certificates=[{"CertificateArn": alb_vpc_config['CertificateArn']}],
-            DefaultActions=[{
-                "Type": "forward",
-                "TargetGroupArn": target_group_arn,
-            }],
-            LoadBalancerArn=load_balancer_arn,
-            Protocol="HTTPS",
-            # TODO: Add option for custom ports
-            Port=443,
-            # TODO: Listeners support custom ssl security policy (SslPolicy). For now we leave this default.
-        )
-        response = self.elbv2_client.create_listener(**kwargs)
-        print("ALB created with DNS: {}".format(load_balancer_dns))
-        print("Note it may take several minutes for load balancer to become available.")
+        # Configure existing Listener rules if ALB has been provided to us
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_rule
+        if 'LoadBalancerArn' in alb_vpc_config:
+            kwargs = dict(
+                LoadBalancerArn=load_balancer_arn,
+            )
+            response = self.elbv2_client.describe_listeners(**kwargs)
+            if not(response["Listeners"]) or len(response["Listeners"]) != 1:
+                raise EnvironmentError("Failure to load listeners for ALB. or more than 1 found, Response was in unexpected format. Response was: {}".format(repr(response)))
 
-    def undeploy_lambda_alb(self, lambda_name):
+            kwargs = dict(
+                Actions=[{
+                    "Type": "forward",
+                    "TargetGroupArn": target_group_arn,
+                }],
+                ListenerArn=response["Listeners"][0]["ListenerArn"],
+                Conditions=[
+                   alb_vpc_config['alb_listener_rule_conditions']
+                ],
+                Priority=alb_vpc_config['alb_listener_rule_priority']
+            )
+            response = self.elbv2_client.create_rule(**kwargs)
+
+            print("ALB Listener Rule have been added to ALB with DNS: {}".format(load_balancer_dns))
+
+        else:
+            # Bind listener to load balancer with default rule to target group.
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_listener
+            kwargs = dict(
+                # TODO: Listeners support custom ssl certificates (Certificates). For now we leave this default.
+                Certificates=[{"CertificateArn": alb_vpc_config['CertificateArn']}],
+                DefaultActions=[{
+                    "Type": "forward",
+                    "TargetGroupArn": target_group_arn,
+                }],
+                LoadBalancerArn=load_balancer_arn,
+                Protocol="HTTPS",
+                # TODO: Add option for custom ports
+                Port=443,
+                # TODO: Listeners support custom ssl security policy (SslPolicy). For now we leave this default.
+            )
+            response = self.elbv2_client.create_listener(**kwargs)
+
+            print("ALB created with DNS: {}".format(load_balancer_dns))
+            print("Note it may take several minutes for load balancer to become available.")
+
+    def undeploy_lambda_alb(self, lambda_name, alb_vpc_config):
         """
         The `zappa undeploy` functionality for ALB infrastructure.
         """
@@ -1452,13 +1495,17 @@ class Zappa(object):
 
         # Locate and delete load balancer
         try:
-            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.describe_load_balancers
-            response = self.elbv2_client.describe_load_balancers(
-                Names=[lambda_name]
-            )
-            if not(response["LoadBalancers"]) or len(response["LoadBalancers"]) > 1:
-                raise EnvironmentError("Failure to locate/delete ALB named [{}]. Response was: {}".format(lambda_name, repr(response)))
-            load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
+            if 'LoadBalancerArn' in alb_vpc_config:
+                load_balancer_arn = alb_vpc_config['LoadBalancerArn']
+            else:
+                # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.describe_load_balancers
+                response = self.elbv2_client.describe_load_balancers(
+                    Names=[lambda_name]
+                )
+                if not(response["LoadBalancers"]) or len(response["LoadBalancers"]) > 1:
+                    raise EnvironmentError("Failure to locate/delete ALB named [{}]. Response was: {}".format(lambda_name, repr(response)))
+                load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
+
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.describe_listeners
             response = self.elbv2_client.describe_listeners(LoadBalancerArn=load_balancer_arn)
             if not(response["Listeners"]):
@@ -1467,15 +1514,14 @@ class Zappa(object):
                 raise EnvironmentError("Failure to locate/delete listener for ALB named [{}]. Response was: {}".format(lambda_name, repr(response)))
             else:
                 listener_arn = response["Listeners"][0]["ListenerArn"]
-                # Remove the listener. This explicit deletion of the listener seems necessary to avoid ResourceInUseExceptions when deleting target groups.
-                # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.delete_listener
-                response = self.elbv2_client.delete_listener(ListenerArn=listener_arn)
-            # Remove the load balancer and wait for completion
-            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.delete_load_balancer
-            response = self.elbv2_client.delete_load_balancer(LoadBalancerArn=load_balancer_arn)
-            waiter = self.elbv2_client.get_waiter('load_balancers_deleted')
-            print('Waiting for load balancer [{}] to be deleted..'.format(lambda_name))
-            waiter.wait(LoadBalancerArns=[load_balancer_arn], WaiterConfig={"Delay": 3})
+
+            if 'LoadBalancerArn' not in alb_vpc_config:
+                # Remove the load balancer and wait for completion
+                # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.delete_load_balancer
+                response = self.elbv2_client.delete_load_balancer(LoadBalancerArn=load_balancer_arn)
+                waiter = self.elbv2_client.get_waiter('load_balancers_deleted')
+                print('Waiting for load balancer [{}] to be deleted..'.format(lambda_name))
+                waiter.wait(LoadBalancerArns=[load_balancer_arn], WaiterConfig={"Delay": 3})
         except botocore.exceptions.ClientError as e: # pragma: no cover
             print(e.response["Error"]["Code"])
             if "LoadBalancerNotFound" in e.response["Error"]["Code"]:
@@ -1483,7 +1529,7 @@ class Zappa(object):
             else:
                 raise e
 
-        # Locate and delete target group
+        # Locate and delete target group and listener Rules if we arn't managing the ALB
         try:
             # Locate the lambda ARN
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.get_function
@@ -1495,6 +1541,19 @@ class Zappa(object):
             if not(response["TargetGroups"]) or len(response["TargetGroups"]) > 1:
                 raise EnvironmentError("Failure to locate/delete ALB target group named [{}]. Response was: {}".format(lambda_name, repr(response)))
             target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
+
+            # If the ALB is provided to us the listener rules need to be removed before the target group is deleted
+            if 'LoadBalancerArn' in alb_vpc_config:
+                # Locate and remove Listener Rule
+                response = self.elbv2_client.describe_rules(ListenerArn=listener_arn)
+                if not(response["Rules"]):
+                    print('No rules found.')
+                for rule in response['Rules']:
+                    for action in rule['Actions']:
+                        if action['Type'] == 'forward' and action['TargetGroupArn'] == target_group_arn:
+                            self.elbv2_client.delete_rule(RuleArn=rule['RuleArn'])
+                            break
+
             # Deregister targets and wait for completion
             self.elbv2_client.deregister_targets(
                 TargetGroupArn=target_group_arn,


### PR DESCRIPTION

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

## Description
I have been following along and using the ALB events and provisioning PR #1807  that was just merged in by @PeteW and @youcandanch.

I was using those changes and integrating my Lambda's into an existing ALB provisioned via terraform

I have some proposed zappa settings and code changes to allow the use of an existing ALB, multiple Zappa projects can then be deployed onto the same ALB


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#1832


