### PR TITLE
Fixes bug which assigns kwargs to None when peforming `zappa update stage --zip s3://path.zip`

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -937,7 +937,7 @@ class ZappaCLI(object):
         )
         if source_zip and source_zip.startswith('s3://'):
             bucket, key_name = parse_s3_url(source_zip)
-            kwargs = kwargs.update(dict(
+            kwargs.update(dict(
                 bucket=bucket,
                 s3_key=key_name
             ))


### PR DESCRIPTION
The CLI script `zappa update stage --zip s3://path/to/zipfile.zip` command is no longer working in `0.4.82`.

This is because of assigning `kwargs = kwargs.update({...})` assigns `kwargs` to `None` as the `update` dictionary operation updates in place.

Performing the above command results in this traceback (without fix):

```
Traceback (most recent call last):
  File "/opt/my_project/shared/virtualenv-python3.6/lib/python3.6/site-packages/zappa/cli.py", line 2779, in handle
    sys.exit(cli.handle())
  File "/opt/my_project/shared/virtualenv-python3.6/lib/python3.6/site-packages/zappa/cli.py", line 509, in handle
    self.dispatch_command(self.command, stage)
  File "/opt/my_project/shared/virtualenv-python3.6/lib/python3.6/site-packages/zappa/cli.py", line 556, in dispatch_command
    self.update(self.vargs['zip'], self.vargs['no_upload'])
  File "/opt/my_project/shared/virtualenv-python3.6/lib/python3.6/site-packages/zappa/cli.py", line 944, in update
    self.lambda_arn = self.zappa.update_lambda_function(**kwargs)
TypeError: update_lambda_function() argument after ** must be a mapping, not NoneType
```