### PR TITLE
Fixed typo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,4 +25,4 @@
 * Operating System and Python version:
 * The output of `pip freeze`:
 * Link to your project (optional):
-* Your `zappa_settings.py`: 
+* Your `zappa_settings.json`: 


### PR DESCRIPTION
## Description
Changed `zappa_settings.py` to `zappa_settings.json` in the issue template

