### PR TITLE
Corrected issue with base64 encoding on all responses

### DIFF
--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,6 +1,7 @@
 from mock import Mock
 import sys
 import unittest
+import json
 from zappa.handler import LambdaHandler
 from zappa.utilities import merge_headers
 
@@ -215,6 +216,34 @@ class TestZappa(unittest.TestCase):
         self.assertEqual(
             response['body'],
             'https://zappa:80/return/request/url'
+        )
+
+    def test_wsgi_script_name_on_test_json_request(self):
+        """
+        Ensure that requests with text responses are not base64 encoded
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_json')
+
+        event = {
+            'body': '',
+            'resource': '/{proxy+}',
+            'requestContext': {},
+            'queryStringParameters': {},
+            'headers': {},
+            'pathParameters': {
+                'proxy': 'json'
+            },
+            'httpMethod': 'GET',
+            'stageVariables': {},
+            'path': '/json'
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response.get('isBase64Encoded', False), False)
+        self.assertEqual(
+            json.loads(response['body']).get('data', ''),
+            'json_data'
         )
 
     def test_exception_handler_on_web_request(self):

--- a/tests/test_wsgi_script_json.py
+++ b/tests/test_wsgi_script_json.py
@@ -1,0 +1,20 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+API_STAGE = 'dev'
+APP_FUNCTION = 'app'
+APP_MODULE = 'tests.test_wsgi_script_json'
+BINARY_SUPPORT = True
+CONTEXT_HEADER_MAPPINGS = {}
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'wsgi_script_json'
+COGNITO_TRIGGER_MAPPING = {}
+
+@app.route('/json', methods=['GET'])
+def return_json():
+    return jsonify(data="json_data")

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -541,8 +541,10 @@ class LambdaHandler(object):
 
                     if response.data:
                         if settings.BINARY_SUPPORT:
-                            if not response.mimetype.startswith("text/") \
-                                or response.mimetype != "application/json":
+                            if (
+                                not response.mimetype.startswith("text/") and
+                                response.mimetype != "application/json"
+                            ):
                                     zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
                                     zappa_returndict["isBase64Encoded"] = True
                             else:


### PR DESCRIPTION
## Description
Fixed issue where all text/ and application/json responses are base64 encoded if binary_support is enabled.

## GitHub Issues
All responses are base64 encoded #1605
https://github.com/Miserlou/Zappa/issues/1605
