### PR TITLE
Fix typo at code block before Endpoint Configuration session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,6 +1392,7 @@ Like API Gateway, Zappa can automatically provision ALB resources for you.  You'
         // And here, a list of security group IDs, eg. 'sg-fbacb791'
     ]
 }
+```
 
 More information on using ALB as an event source for Lambda can be found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html).
 


### PR DESCRIPTION
## Description

The closing of the code block right before that session was
missing. This made the whole session and its sub-sessions
appear as parts of the code block itself.

## GitHub Issues
#1862 
