### PR TITLE
Update core.py

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2063,6 +2063,7 @@ class Zappa(object):
         # If you set a value for TemporaryPasswordValidityDays in PasswordPolicy , 
         # that value will be used and UnusedAccountValidityDays will be deprecated for that user pool.
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.update_user_pool
+        # Related: https://github.com/Miserlou/Zappa/issues/1879
         if 'TemporaryPasswordValidityDays' in description_kwargs['Policies']['PasswordPolicy']:
             description_kwargs['AdminCreateUserConfig'].pop('UnusedAccountValidityDays', None)            
             

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2058,6 +2058,14 @@ class Zappa(object):
                 description_kwargs[key] = value
         if 'LambdaConfig' not in description_kwargs:
             description_kwargs['LambdaConfig'] = LambdaConfig
+
+        # Note
+        # If you set a value for TemporaryPasswordValidityDays in PasswordPolicy , 
+        # that value will be used and UnusedAccountValidityDays will be deprecated for that user pool.
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.update_user_pool
+        if 'TemporaryPasswordValidityDays' in description_kwargs['Policies']['PasswordPolicy']:
+            description_kwargs['AdminCreateUserConfig'].pop('UnusedAccountValidityDays', None)            
+            
         result = self.cognito_client.update_user_pool(UserPoolId=user_pool, **description_kwargs)
         if result['ResponseMetadata']['HTTPStatusCode'] != 200:
             print("Cognito:  Failed to update user pool", result)


### PR DESCRIPTION
Trivial code, tested on Python 3.

## Description
AWS deprecated a field and that broke the cognito event setting.
This is an implementation of the solution suggested by @Yaronn44.
It follows the boto3 documentation (specifically the Note for deprecation): https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.update_user_pool 


## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1879

