### PR TITLE
Add missing supported regions

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -174,26 +174,32 @@ API_GATEWAY_REGIONS = ['us-east-1', 'us-east-2',
                        'us-west-1', 'us-west-2',
                        'eu-central-1',
                        'eu-west-1', 'eu-west-2', 'eu-west-3',
+                       'eu-north-1',
                        'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
                        'ap-southeast-1', 'ap-southeast-2',
+                       'ap-east-1',
                        'ap-south-1',
                        'ca-central-1',
                        'cn-north-1',
                        'cn-northwest-1',
-                       'sa-east-1']
+                       'sa-east-1',
+                       'us-gov-east-1', 'us-gov-west-1']
 
 # Latest list: https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region
 LAMBDA_REGIONS = ['us-east-1', 'us-east-2',
                   'us-west-1', 'us-west-2',
                   'eu-central-1',
                   'eu-west-1', 'eu-west-2', 'eu-west-3',
+                  'eu-north-1',
                   'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
                   'ap-southeast-1', 'ap-southeast-2',
+                  'ap-east-1',
                   'ap-south-1',
                   'ca-central-1',
                   'cn-north-1',
                   'cn-northwest-1',
                   'sa-east-1',
+                  'us-gov-east-1',
                   'us-gov-west-1']
 
 # We never need to include these.


### PR DESCRIPTION
## Description

The goal of this PR is to add all supported regions to the `zappa.core.API_GATEWAY_REGIONS` and `zappa.core.LAMBDA_REGIONS` lists per the relevant AWS documentation.

Relevant documentation:

- https://docs.aws.amazon.com/general/latest/gr/rande.html#apigateway_region
- https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region
