### PR TITLE
Resolving issue #1747 removing unexpected 'policy' keyword argument.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -663,7 +663,6 @@ class ZappaCLI(object):
                                             authorizer=self.authorizer,
                                             cors_options=self.cors,
                                             description=self.apigateway_description,
-                                            policy=self.apigateway_policy,
                                             endpoint_configuration=self.endpoint_configuration
                                         )
 


### PR DESCRIPTION



## Description
Attempt to resolve:
https://github.com/Miserlou/Zappa/issues/1747

Removes the _unexpected_ `policy` kwarg in the `self.zappa.create_stack_template()` call.

## GitHub Issues
Error occurs when callling `zappa template ....`
https://github.com/Miserlou/Zappa/issues/1747
