### PR TITLE
CloudWatch events are not handled by Zappa

### DIFF
--- a/tests/test_event_script_app.py
+++ b/tests/test_event_script_app.py
@@ -1,0 +1,6 @@
+from __future__ import print_function
+
+
+def handler_for_events(event, context):
+    print('Event:', event)
+    return True

--- a/tests/test_event_script_settings.py
+++ b/tests/test_event_script_settings.py
@@ -1,0 +1,10 @@
+API_STAGE = 'dev'
+APP_FUNCTION = 'handler_for_events'
+APP_MODULE = 'tests.test_event_script_app'
+DEBUG = 'True'
+DJANGO_SETTINGS = None
+DOMAIN = 'api.example.com'
+ENVIRONMENT_VARIABLES = {}
+LOG_LEVEL = 'DEBUG'
+PROJECT_NAME = 'test_event_script_app'
+COGNITO_TRIGGER_MAPPING = {}

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -425,7 +425,7 @@ class TestZappa(unittest.TestCase):
         { "awslogs": {"data": "BASE64ENCODED_GZIP_COMPRESSED_DATA"} }
         https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
         """
-        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
+        lh = LambdaHandler('tests.test_event_script_settings')
 
         event = {
             'awslogs': {
@@ -434,5 +434,4 @@ class TestZappa(unittest.TestCase):
         }
         response = lh.handler(event, None)
 
-        self.assertEqual(response['statusCode'], 200)
-        self.assertEqual(response['statusDescription'], '200 OK')
+        self.assertEqual(response, True)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -417,6 +417,22 @@ class TestZappa(unittest.TestCase):
         self.assertEqual(merged['a'], 'c, d')
         self.assertEqual(merged['x'], 'y, z, f')
 
+    def test_cloudwatch_subscription_event(self):
+        """
+        Test that events sent in the format used by CloudWatch logs via
+        subscription filters are handled properly.
+        The actual payload that Lambda receives is in the following format
+        { "awslogs": {"data": "BASE64ENCODED_GZIP_COMPRESSED_DATA"} }
+        https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
+        """
+        lh = LambdaHandler('tests.test_wsgi_script_name_settings')
 
-    def test_foo(self):
-        pass
+        event = {
+            'awslogs': {
+                'data': "some-data-not-important-for-test"
+            }
+        }
+        response = lh.handler(event, None)
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['statusDescription'], '200 OK')

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -416,3 +416,7 @@ class TestZappa(unittest.TestCase):
         merged = merge_headers(event)
         self.assertEqual(merged['a'], 'c, d')
         self.assertEqual(merged['x'], 'y, z, f')
+
+
+    def test_foo(self):
+        pass

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -343,7 +343,7 @@ class LambdaHandler(object):
     def handler(self, event, context):
         """
         An AWS Lambda function which parses specific API Gateway input into a
-        WSGI request, feeds it to our WSGI app, procceses the response, and returns
+        WSGI request, feeds it to our WSGI app, processes the response, and returns
         that back to the API Gateway.
 
         """
@@ -461,6 +461,20 @@ class LambdaHandler(object):
                 logger.debug(result)
             else:
                 logger.error("Cannot find a function to handle cognito trigger {}".format(triggerSource))
+            return result
+
+        # This is a CloudWatch event
+        # Related: https://github.com/Miserlou/Zappa/issues/205
+        elif event.get('awslogs', None):
+            result = None
+            whole_function = '{}.{}'.format(settings.APP_MODULE, settings.APP_FUNCTION)
+            app_function = self.import_module_and_get_function(whole_function)
+            if app_function:
+                result = self.run_function(app_function, event, context)
+                logger.debug("Result of %s:" % whole_function)
+                logger.debug(result)
+            else:
+                logger.error("Cannot find a function to process the triggered event.")
             return result
 
         # Normal web app flow

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -464,7 +464,7 @@ class LambdaHandler(object):
             return result
 
         # This is a CloudWatch event
-        # Related: https://github.com/Miserlou/Zappa/issues/205
+        # Related: https://github.com/Miserlou/Zappa/issues/1924
         elif event.get('awslogs', None):
             result = None
             whole_function = '{}.{}'.format(settings.APP_MODULE, settings.APP_FUNCTION)


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Expand the `LambdaHandler.handler()` function to consider events with the key `awslogs` and trigger the configured `settings.APP_FUNCTION` function. The event and context objects are passed to the handler function.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/1924

