### PR TITLE
Add Logging on Zappa Get_Function Call

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -881,7 +881,7 @@ class ZappaCLI(object):
                 sys.exit(-1)
             except Exception as e:
                 click.echo(click.style("Warning!", fg="red") + " Couldn't get function " + self.lambda_name +
-                           " in " + self.zappa.aws_region + " - have you deployed yet?")
+                           " in " + self.zappa.aws_region + " - have you deployed yet? Exception: " + str(e))
                 sys.exit(-1)
 
             if last_updated_unix <= updated_time:


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?
It's Trivial
* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
Logged exception on zappa's get_function call, so the error message is more verbose.

Before:
```
Calling update for stage dev_unstable..
Warning! Couldn't get function net-dev-unstable in us-east-1 - have you deployed yet?
```

After:
```
Warning! Couldn't get function net-dev-unstable in us-east-1 - have you deployed yet? Exception: An error occurred (InvalidSignatureException) when calling the GetFunction operation: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```
## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

https://github.com/Miserlou/Zappa/issues/1663