### PR TITLE
Fix #1816: Add basic support for authorization scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,23 @@ You can also use AWS Cognito User Pool Authorizer by adding:
 }
 ```
 
+You can also define a list of authorization scopes, which will be applied globally across all endpoints and methods in the API Gateway:
+
+```javascript
+{
+    "authorizer": {
+        "type": "COGNITO_USER_POOLS",
+        "provider_arns": [
+            "arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}"
+        ],
+        "scopes": [
+            "com.example/view-products",
+            "com.example/view-users"
+        ]
+    }
+}
+```
+
 #### API Gateway Resource Policy
 
 You can also use API Gateway Resource Policies. Example of IP Whitelisting:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1535,6 +1535,7 @@ class Zappa(object):
                                     api_name=None,
                                     api_key_required=False,
                                     authorization_type='NONE',
+                                    authorization_scopes=None,
                                     authorizer=None,
                                     cors_options=None,
                                     description=None,
@@ -1586,6 +1587,7 @@ class Zappa(object):
                                         api_key_required,
                                         invocations_uri,
                                         authorization_type,
+                                        authorization_scopes,
                                         authorizer_resource,
                                         0
                                         )
@@ -1610,6 +1612,7 @@ class Zappa(object):
                                         api_key_required,
                                         invocations_uri,
                                         authorization_type,
+                                        authorization_scopes,
                                         authorizer_resource,
                                         1
                                     )  # pragma: no cover
@@ -1659,6 +1662,7 @@ class Zappa(object):
                                     api_key_required,
                                     uri,
                                     authorization_type,
+                                    authorization_scopes,
                                     authorizer_resource,
                                     depth
                                 ):
@@ -1674,6 +1678,8 @@ class Zappa(object):
                 method.ResourceId = resource
             method.HttpMethod = method_name.upper()
             method.AuthorizationType = authorization_type
+            if authorization_scopes:
+                method.AuthorizationScopes = authorization_scopes
             if authorizer_resource:
                 method.AuthorizerId = troposphere.Ref(authorizer_resource)
             method.ApiKeyRequired = api_key_required
@@ -2119,6 +2125,7 @@ class Zappa(object):
         """
 
         auth_type = "NONE"
+        auth_scopes = None
         if iam_authorization and authorizer:
             logger.warn("Both IAM Authorization and Authorizer are specified, this is not possible. "
                         "Setting Auth method to IAM Authorization")
@@ -2128,6 +2135,7 @@ class Zappa(object):
             auth_type = "AWS_IAM"
         elif authorizer:
             auth_type = authorizer.get("type", "CUSTOM")
+            auth_scopes = authorizer.get("scopes", [])
 
         # build a fresh template
         self.cf_template = troposphere.Template()
@@ -2140,6 +2148,7 @@ class Zappa(object):
                                             api_name=lambda_name,
                                             api_key_required=api_key_required,
                                             authorization_type=auth_type,
+                                            authorization_scopes=auth_scopes,
                                             authorizer=authorizer,
                                             cors_options=cors_options,
                                             description=description,


### PR DESCRIPTION
## Description
When using a Cognito User Pool as the authorizer, it is possible to define which authorization scopes should have access to each API method.

When authorization scopes are defined, the authorizer will use an access token, whereas the ID token must be used otherwise. This is only of limited use in the case of Zappa, because it does not define an API method for every endpoint of the underlying app, but at least now authorization scopes can be set globally for the entire API.

Troposphere supported this already, but Zappa did not. This PR resolves that. The new `<stage>.authorizer.scopes` property can be set to a list of scopes that will then be configured for both the `/` and the `/{proxy+}` endpoints.

I tested it and it works. I couldn't find any automated tests that would be impacted or needed extending to cover this new setting.

## GitHub Issues
Closes #1816 