### PR TITLE
Remove api_gateway policy from template creation

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -663,7 +663,6 @@ class ZappaCLI(object):
                                             authorizer=self.authorizer,
                                             cors_options=self.cors,
                                             description=self.apigateway_description,
-                                            policy=self.apigateway_policy,
                                             endpoint_configuration=self.endpoint_configuration
                                         )
 


### PR DESCRIPTION
The PR #1903 attempted to fix issue #1747, however, the
travis build failed because at the time `botocore`, required
a version of `docutils` >= 0.10 and <0.15. `botocore` has
since changed the requirements to docutils>=0.10,<0.16. So

This should fix the build issue for the PR to address #1747.

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Removed `policy` from template creation. This fix was attempted in PR #1903, but failed because of `botocore` requirements for `docutils` at the time.

## GitHub Issues
#1747 

