### PR TITLE
Enable configuration of logging API requests to Cloudwatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
+- [Zappa - Serverless Python](#zappa---serverless-python)
 - [About](#about)
 - [Installation and Configuration](#installation-and-configuration)
   - [Running the Initial Setup / Settings](#running-the-initial-setup--settings)
@@ -856,6 +857,7 @@ to change Zappa's behavior. Use these at your own risk!
         "certificate_chain": "my_cert_chain.pem", // SSL certificate chain file location. Used to manually certify a custom domain
         "certificate_arn": "arn:aws:acm:us-east-1:1234512345:certificate/aaaa-bbb-cccc-dddd", // ACM certificate ARN (needs to be in us-east-1 region).
         "cloudwatch_log_level": "OFF", // Enables/configures a level of logging for the given staging. Available options: "OFF", "INFO", "ERROR", default "OFF".
+        "cloudwatch_log_role_arn": None, // Configures a Role in the API Gateway settings that has write permissions to Cloudwatch (policy `AmazonAPIGatewayPushToCloudWatchLogs`)
         "cloudwatch_data_trace": false, // Logs all data about received events. Default false.
         "cloudwatch_metrics_enabled": false, // Additional metrics for the API Gateway. Default false.
         "cognito": { // for Cognito event triggers

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2672,6 +2672,7 @@ class ZappaCLI(object):
             cache_cluster_enabled=cache_cluster_enabled,
             cache_cluster_size=cache_cluster_size,
             cloudwatch_log_level=self.stage_config.get('cloudwatch_log_level', 'OFF'),
+            cloudwatch_log_role_arn=self.stage_config.get('cloudwatch_log_role_arn', None),
             cloudwatch_data_trace=self.stage_config.get('cloudwatch_data_trace', False),
             cloudwatch_metrics_enabled=self.stage_config.get('cloudwatch_metrics_enabled', False),
             cache_cluster_ttl=self.stage_config.get('cache_cluster_ttl', 300),

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1765,6 +1765,7 @@ class Zappa(object):
                             cache_cluster_size='0.5',
                             variables=None,
                             cloudwatch_log_level='OFF',
+                            cloudwatch_log_role_arn=None,
                             cloudwatch_data_trace=False,
                             cloudwatch_metrics_enabled=False,
                             cache_cluster_ttl=300,
@@ -1789,6 +1790,13 @@ class Zappa(object):
 
         if cloudwatch_log_level not in self.cloudwatch_log_levels:
             cloudwatch_log_level = 'OFF'
+
+        if cloudwatch_log_role_arn:
+            self.apigateway_client.update_account(
+                patchOperations=[
+                    {'op': 'replace', 'path': '/cloudwatchRoleArn', 'value': cloudwatch_log_role_arn}
+                ]
+            )
 
         self.apigateway_client.update_stage(
             restApiId=api_id,


### PR DESCRIPTION
## Description
This adds a new configuration parameter named `cloudwatch_log_role_arn` that enables setting the ARN of a role which grants permissions to the API Gateway to write to Cloudwatch.

## GitHub Issues
#1946 
