### PR TITLE
Fix issue when handler fails initialization

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -50,10 +50,11 @@ class LambdaHandler(object):
     app_module = None
     wsgi_app = None
     trailing_slash = False
+    initialized = False
 
     def __new__(cls, settings_name="zappa_settings", session=None):
         """Singleton instance to avoid repeat setup"""
-        if LambdaHandler.__instance is None:
+        if LambdaHandler.__instance is None or not LambdaHandler.__instance.initialized:
             if sys.version_info[0] < 3:
                 LambdaHandler.__instance = object.__new__(cls, settings_name, session)
             else:
@@ -64,7 +65,7 @@ class LambdaHandler(object):
     def __init__(self, settings_name="zappa_settings", session=None):
 
         # We haven't cached our settings yet, load the settings and app.
-        if not self.settings:
+        if not self.initialized:
             # Loading settings from a python module
             self.settings = importlib.import_module(settings_name)
             self.settings_name = settings_name
@@ -152,6 +153,7 @@ class LambdaHandler(object):
                 self.trailing_slash = True
 
             self.wsgi_app = ZappaWSGIMiddleware(wsgi_app_function)
+            self.initialized = True
 
     def load_remote_project_archive(self, project_zip_path):
         """


### PR DESCRIPTION
If the LambdaHandler fails to initialize, the lambda stays in the
failed state until AWS stops it. This change causes the initializer
to continue to attempt to initialize the LambdaHandler until it
is successful.

See https://github.com/Miserlou/Zappa/issues/1949

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

