### PR TITLE
Use safe load with yaml

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2177,7 +2177,7 @@ class ZappaCLI(object):
         if ext == '.yml' or ext == '.yaml':
             with open(settings_file) as yaml_file:
                 try:
-                    self.zappa_settings = yaml.load(yaml_file)
+                    self.zappa_settings = yaml.safe_load(yaml_file)
                 except ValueError: # pragma: no cover
                     raise ValueError("Unable to load the Zappa settings YAML. It may be malformed.")
         elif ext == '.toml':


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Really small change to get rid of deprecation warning for YAML due to this - https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation. I double-checked in yaml repo and `safe_load` was added 13 years ago!

Tested this via cloning zappa client and running it locally, where you no longer see DeprecationWarning.  I _think_ this is probably okay to go without tests.

## GitHub Issues
Since so small I thought okay to open without a ticket.
