### PR TITLE
Python 3.8 runtime support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
 dist: xenial
 # command to install dependencies
 cache:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,13 @@
-from cgi import parse_qs, escape
 from zappa.asynchronous import task
+try:
+    from urllib.parse import parse_qs
+except ImportError:
+    from cgi import parse_qs
+
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 
 def hello_world(environ, start_response):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -174,6 +174,19 @@ class TestZappa(unittest.TestCase):
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
+    def test_get_manylinux_python38(self):
+        z = Zappa(runtime='python3.8')
+        self.assertIsNotNone(z.get_cached_manylinux_wheel('psycopg2', '2.7.6'))
+        self.assertIsNone(z.get_cached_manylinux_wheel('derp_no_such_thing', '0.0'))
+
+        # mock with a known manylinux wheel package so that code for downloading them gets invoked
+        mock_installed_packages = {'psycopg2': '2.7.6'}
+        with mock.patch('zappa.core.Zappa.get_installed_packages', return_value=mock_installed_packages):
+            z = Zappa(runtime='python3.8')
+            path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
+
     def test_should_use_lambda_packages(self):
         z = Zappa(runtime='python2.7')
 

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-SUPPORTED_VERSIONS = [(2, 7), (3, 6), (3, 7)]
+SUPPORTED_VERSIONS = [(2, 7), (3, 6), (3, 7), (3, 8)]
 
 python_major_version = sys.version_info[0]
 python_minor_version = sys.version_info[1]

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -665,7 +665,7 @@ class Zappa(object):
                 # This is a special case!
                 # SQLite3 is part of the _system_ Python, not a package. Still, it lives in `lambda-packages`.
                 # Everybody on Python3 gets it!
-                if self.runtime in ("python3.6", "python3.7"):
+                if self.runtime in ("python3.6", "python3.7", "python3.8"):
                     print(" - sqlite==python3: Using precompiled lambda package")
                     self.extract_lambda_package('sqlite3', temp_project_path)
 

--- a/zappa/utilities.py
+++ b/zappa/utilities.py
@@ -181,8 +181,10 @@ def get_runtime_from_python_version():
     else:
         if sys.version_info[1] <= 6:
             return 'python3.6'
-        else:
+        elif sys.version_info[1] <= 7:
             return 'python3.7'
+        else:
+            return 'python3.8'
 
 ##
 # Async Tasks


### PR DESCRIPTION
## Description
Adds python38 as a runtime. 

Mimicked https://github.com/Miserlou/Zappa/pull/1762 as a guide for the changes.
The incompatable change was the use of `escape` and `parse_qs` from `cgi`.

~I also had to limit the docutils package so it matches botocode. A new version released on December 4th 2019 (https://pypi.org/project/docutils/0.16b0.dev0/#description) was being installed, which then caused conflicts when trying to install botocore.~ Fixed in master

## GitHub Issues
Resolves #1968 

