### PR TITLE
Update version to 0.48.3 (removes hard limitations from dependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zappa Changelog
 
 ## 0.48.3
-* remove limitations from dependencies
+* remove hard limitations from dependencies
 
 ## 0.48.2
 * Fix for invalid values of HTTP_HOST and others (introduced in 0.48.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zappa Changelog
 
+## 0.48.3
+* remove limitations from dependencies
+
 ## 0.48.2
 * Fix for invalid values of HTTP_HOST and others (introduced in 0.48.0)
 

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -11,4 +11,4 @@ if (python_major_version, python_minor_version) not in SUPPORTED_VERSIONS:
               'Zappa (and AWS Lambda) support the following versions of Python: {}'.format(formatted_supported_versions)
     raise RuntimeError(err_msg)
 
-__version__ = '0.48.2'
+__version__ = '0.48.3'


### PR DESCRIPTION
https://github.com/Mattlk13/Zappa/pull/6

Removes hard dependencies.

Allows getting lambda-packages 0.21.0 thus getting newer packages