### PR TITLE
Set python 3.8 manylinux wheel suffix correctly

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -176,11 +176,11 @@ class TestZappa(unittest.TestCase):
 
     def test_get_manylinux_python38(self):
         z = Zappa(runtime='python3.8')
-        self.assertIsNotNone(z.get_cached_manylinux_wheel('psycopg2', '2.7.6'))
+        self.assertIsNotNone(z.get_cached_manylinux_wheel('psycopg2-binary', '2.8.4'))
         self.assertIsNone(z.get_cached_manylinux_wheel('derp_no_such_thing', '0.0'))
 
         # mock with a known manylinux wheel package so that code for downloading them gets invoked
-        mock_installed_packages = {'psycopg2': '2.7.6'}
+        mock_installed_packages = {'psycopg2-binary': '2.8.4'}
         with mock.patch('zappa.core.Zappa.get_installed_packages', return_value=mock_installed_packages):
             z = Zappa(runtime='python3.8')
             path = z.create_lambda_zip(handler_file=os.path.realpath(__file__))

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -286,8 +286,12 @@ class Zappa(object):
             self.manylinux_wheel_file_suffix = 'cp27mu-manylinux1_x86_64.whl'
         elif self.runtime == 'python3.6':
             self.manylinux_wheel_file_suffix = 'cp36m-manylinux1_x86_64.whl'
-        else:
+        elif self.runtime == 'python3.7':
             self.manylinux_wheel_file_suffix = 'cp37m-manylinux1_x86_64.whl'
+        else:
+            # The 'm' has been dropped in python 3.8+ since builds with and without pymalloc are ABI compatible
+            # See https://github.com/pypa/manylinux for a more detailed explanation
+            self.manylinux_wheel_file_suffix = 'cp38-manylinux1_x86_64.whl'
 
         self.endpoint_urls = endpoint_urls
         self.xray_tracing = xray_tracing


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with both **Python 2.7** and **Python 3.6**? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
This change is to correctly set the manylinux wheel suffix for python 3.8. I have made the change in keeping with the current style, however I would also support something like the following:
```
'cp{major}{minor}m-manylinux1_x86_64.whl'.format(major=sys.version_info.major,
                                                 minor=sys.version_info.minor)
```
which would set the suffix correctly for future versions of python too. If you prefer that, let me know and I'll update the PR. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/1968
