### PR TITLE
Fixes issue that makes API gateway duplicate set-cookie headers

### DIFF
--- a/zappa/middleware.py
+++ b/zappa/middleware.py
@@ -38,32 +38,17 @@ class ZappaWSGIMiddleware(object):
 
         def encode_response(status, headers, exc_info=None):
             """
-            Create an APIGW-acceptable version of our cookies.
-
-            We have to use a bizarre hack that turns multiple Set-Cookie headers into
-            their case-permutated format, ex:
-
-            Set-cookie:
-            sEt-cookie:
-            seT-cookie:
-
-            To get around an API Gateway limitation.
-
-            This is weird, but better than our previous hack of creating a Base58-encoded
-            supercookie.
+            This makes the 'set-cookie' headers name lowercase,
+            all the non-cookie headers should be sent unharmed.
+            Related: https://github.com/Miserlou/Zappa/issues/1965
             """
 
-            # All the non-cookie headers should be sent unharmed.
-            
-            # The main app can send 'set-cookie' headers in any casing
-            # Related: https://github.com/Miserlou/Zappa/issues/990
             new_headers = [header for header in headers
                            if ((type(header[0]) != str) or (header[0].lower() != 'set-cookie'))]
-            cookie_headers = [header for header in headers 
+            cookie_headers = [(header[0].lower(), header[1]) for header in headers
                               if ((type(header[0]) == str) and (header[0].lower() == "set-cookie"))]
-            for header, new_name in zip(cookie_headers,
-                                        all_casings("Set-Cookie")):
-                new_headers.append((new_name, header[1]))
+            new_headers = new_headers + cookie_headers
+
             return start_response(status, new_headers, exc_info)
 
         # Call the application with our modifier


### PR DESCRIPTION
## Description
Fixes a issue that makes API Gateway duplicate set-cookie response headers when they are sent in multiple casing (like Set-cookie, set-cookie, set-Cookie).

## GitHub Issues
fixes #1965 