### PR TITLE
Remove python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"


### PR DESCRIPTION
So, an update on 0.49 actually broke python 2 installations (zipp==2.2.0 is py3 only) but nobody seems to want to actually fix it given python 2's looming end of life, so I'm removing the tests for now.