### PR TITLE
Fix parsing of X-Forwarded-For header

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -116,7 +116,7 @@ def create_wsgi_request(event_info,
             # Everything else is user supplied and untrustworthy.
             remote_addr = x_forwarded_for.split(', ')[-2]
         else:
-            remote_addr = '127.0.0.1'
+            remote_addr = x_forwarded_for or '127.0.0.1'
 
         environ = {
             'PATH_INFO': get_wsgi_string(path),


### PR DESCRIPTION
When the header did not contain a comma, it was not parsed and
REMOTE_ADDR was always set to 127.0.0.1. This bug occurred when the project was deployed without a CloudFront, e.g. with an ALB only.