### PR TITLE
Fix binary_support handling

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -540,13 +540,11 @@ class LambdaHandler(object):
                         zappa_returndict.setdefault('statusDescription', response.status)
 
                     if response.data:
-                        if settings.BINARY_SUPPORT:
-                            if not response.mimetype.startswith("text/") \
-                                or response.mimetype != "application/json":
-                                    zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
-                                    zappa_returndict["isBase64Encoded"] = True
-                            else:
-                                zappa_returndict['body'] = response.data
+                        if settings.BINARY_SUPPORT and \
+                                not response.mimetype.startswith("text/") \
+                                and response.mimetype != "application/json":
+                            zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
+                            zappa_returndict["isBase64Encoded"] = True
                         else:
                             zappa_returndict['body'] = response.get_data(as_text=True)
 


### PR DESCRIPTION

## Description

The logic of handling response data when binary_support is True, was faulty. It base64-encoded every response, regardless of the content-type, which caused the user/browser to receive base64-encoded bodies if deployed with an API Gateway. ALB apparently supports base64-encoded responses and manages to decode them.

## GitHub Issues

Relevant tickets:
- https://github.com/Miserlou/Zappa/issues/1605
- https://github.com/Miserlou/Zappa/issues/1871
