### PR TITLE
Fix syntax warnings due to comparison of literals using is.

### DIFF
--- a/example/authmodule.py
+++ b/example/authmodule.py
@@ -75,7 +75,7 @@ class AuthPolicy:
     """The principal used for the policy, this should be a unique identifier for the end user."""
     version = "2012-10-17"
     """The policy version used for the evaluation. This should always be '2012-10-17'"""
-    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
+    pathRegex = r"^[/.a-zA-Z0-9-\*]+$"
     """The regular expression used to validate resource paths for the policy"""
 
     """these are the internal lists of allowed and denied methods. These are lists


### PR DESCRIPTION
## Description

Fix syntax warnings due to comparison of literals using is.

## GitHub Issues

Fixes #2048 

