### PR TITLE
Wait for the Load Balancer to become active before proceeding

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1990,6 +1990,19 @@ USE_TZ = True
                 }]
             },
         )
+        elbv2_stubber.add_response("describe_load_balancers",
+            expected_params={
+                "LoadBalancerArns": [loadbalancer_arn],
+            },
+            service_response={
+                "LoadBalancers": [{
+                    "LoadBalancerArn": loadbalancer_arn,
+                    "State": {
+                        "Code": "active"
+                    }
+                }]
+            },
+        )
         elbv2_stubber.add_response("modify_load_balancer_attributes",
             expected_params={
                 "LoadBalancerArn": loadbalancer_arn,

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1332,6 +1332,8 @@ class Zappa:
         load_balancer_dns = response["LoadBalancers"][0]["DNSName"]
         load_balancer_vpc = response["LoadBalancers"][0]["VpcId"]
         waiter = self.elbv2_client.get_waiter('load_balancer_available')
+        print('Waiting for load balancer [{}] to become active..'.format(load_balancer_arn))
+        waiter.wait(LoadBalancerArns=[load_balancer_arn], WaiterConfig={"Delay": 3})
 
         # Match the lambda timeout on the load balancer.
         self.elbv2_client.modify_load_balancer_attributes(


### PR DESCRIPTION
If the load balancer is not 'active', the subsequent commands will fail

## Description
Calls `waiter.wait` to wait for the ALB to become active before proceeding

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/2052

