### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - TESTCASE=tests/tests.py
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1382,7 +1382,7 @@ class ZappaCLI:
             # UUIDs
             for token in final_string.replace('\t', ' ').split(' '):
                 try:
-                    if token.count('-') is 4 and token.replace('-', '').isalnum():
+                    if token.count('-') == 4 and token.replace('-', '').isalnum():
                         final_string = final_string.replace(
                             token,
                             click.style(token, fg='magenta')
@@ -2517,7 +2517,7 @@ class ZappaCLI:
         # IP address filter
         for token in string.replace('\t', ' ').split(' '):
             try:
-                if (token.count('.') is 3 and token.replace('.', '').isnumeric()):
+                if (token.count('.') == 3 and token.replace('.', '').isnumeric()):
                     return True
             except Exception: # pragma: no cover
                 pass
@@ -2552,14 +2552,14 @@ class ZappaCLI:
             # And UUIDs
             for token in final_string.replace('\t', ' ').split(' '):
                 try:
-                    if token.count('-') is 4 and token.replace('-', '').isalnum():
+                    if token.count('-') == 4 and token.replace('-', '').isalnum():
                         final_string = final_string.replace(token, click.style(token, fg="magenta"))
                 except Exception: # pragma: no cover
                     pass
 
                 # And IP addresses
                 try:
-                    if token.count('.') is 3 and token.replace('.', '').isnumeric():
+                    if token.count('.') == 3 and token.replace('.', '').isnumeric():
                         final_string = final_string.replace(token, click.style(token, fg="red"))
                 except Exception: # pragma: no cover
                     pass

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2031,7 +2031,7 @@ class Zappa:
                        'EmailConfiguration', 'SmsConfiguration', 'UserPoolTags',
                        'AdminCreateUserConfig'):
                 description_kwargs[key] = value
-            elif key is 'LambdaConfig':
+            elif key is 'LambdaConfig':  # noqa: F632  TODO: Change 'is' --> '=='
                 for lckey, lcvalue in value.items():
                     if lckey in LambdaConfig:
                         value[lckey] = LambdaConfig[lckey]


### PR DESCRIPTION
Add more key flake8 tests to the Travis CI run to detect and avoid Python 3.8 SyntaxWarnings:
% __python3.8__
```
>>> 3 is 3
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
>>> 'LambdaConfig' is 'LambdaConfig'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

