### PR TITLE
Fix for abi3 filename matching

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -284,7 +284,7 @@ class Zappa:
         # AWS Lambda supports manylinux1/2010 and manylinux2014
         manylinux_suffixes = ("2014", "2010", "1")
         self.manylinux_wheel_file_match = re.compile(f'^.*{self.manylinux_suffix_start}-manylinux({"|".join(manylinux_suffixes)})_x86_64.whl$')
-        self.manylinux_wheel_abi3_file_match = re.compile('^.*cp3.-abi3-manylinux({"|".join(manylinux_suffixes)})_x86_64.whl$')
+        self.manylinux_wheel_abi3_file_match = re.compile(f'^.*cp3.-abi3-manylinux({"|".join(manylinux_suffixes)})_x86_64.whl$')
 
         self.endpoint_urls = endpoint_urls
         self.xray_tracing = xray_tracing


### PR DESCRIPTION
Partly fixes https://github.com/Miserlou/Zappa/issues/2050 (e.g. cryptography abi3 manylinux not being downloaded from PyPi, so locally compiled version is used in the package instead).