### PR TITLE
Add S3 upload arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,9 @@ to change Zappa's behavior. Use these at your own risk!
         "route53_enabled": true, // Have Zappa update your Route53 Hosted Zones when certifying with a custom domain. Default true.
         "runtime": "python3.6", // Python runtime to use on Lambda. Can be one of "python3.6", "python3.7" or "python3.8". Defaults to whatever the current Python being used is.
         "s3_bucket": "dev-bucket", // Zappa zip bucket,
+        "s3_upload_args": { // Arguments to pass to the s3 client when uploading
+            "ServerSideEncryption": "AES256"  // Add server side encryption to the upload request
+        },
         "slim_handler": false, // Useful if project >50M. Set true to just upload a small handler to Lambda and load actual project from S3 at runtime. Default false.
         "settings_file": "~/Projects/MyApp/settings/dev_settings.py", // Server side settings file location,
         "tags": { // Attach additional tags to AWS Resources
@@ -1293,6 +1296,27 @@ To add permissions to the default Zappa execution policy, use the `extra_permiss
             "Action": ["rekognition:*"], // AWS Service ARN
             "Resource": "*"
         }]
+    },
+    ...
+}
+```
+
+### AWS S3 Server Side Encryption
+
+Zappa can upload artifacts to an S3 bucket which requires server side encryption.
+This is useful for environments that have strict compliance on PUT requests into
+S3 Buckets.
+
+*An important note*: Zappa can deploy into buckets that already exist. This
+feature is useful if your deployment buckets are managed outside of Zappa.
+
+```javascript
+{
+    "dev": {
+        ...
+        "s3_upload_args": {
+            "ServerSideEncryption": "AES256"
+        }
     },
     ...
 }

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -232,6 +232,7 @@ class Zappa:
     apigateway_policy = None
     cloudwatch_log_levels = ['OFF', 'ERROR', 'INFO']
     xray_tracing = False
+    s3_upload_args = None
 
     ##
     # Credentials
@@ -248,6 +249,7 @@ class Zappa:
             desired_role_name=None,
             desired_role_arn=None,
             runtime='python3.6', # Detected at runtime in CLI
+            s3_upload_args=None,
             tags=(),
             endpoint_urls={},
             xray_tracing=False
@@ -288,6 +290,7 @@ class Zappa:
 
         self.endpoint_urls = endpoint_urls
         self.xray_tracing = xray_tracing
+        self.s3_upload_args = s3_upload_args
 
         # Some common invocations, such as DB migrations,
         # can take longer than the default.
@@ -887,7 +890,7 @@ class Zappa:
     # S3
     ##
 
-    def upload_to_s3(self, source_path, bucket_name, disable_progress=False):
+    def upload_to_s3(self, source_path, bucket_name, disable_progress=False, upload_args=None):
         r"""
         Given a file, upload it to S3.
         Credentials should be stored in environment variables or ~/.aws/credentials (%USERPROFILE%\.aws\credentials on Windows).
@@ -934,10 +937,10 @@ class Zappa:
             try:
                 self.s3_client.upload_file(
                     source_path, bucket_name, dest_path,
-                    Callback=progress.update
+                    Callback=progress.update, ExtraArgs=upload_args
                 )
             except Exception as e:  # pragma: no cover
-                self.s3_client.upload_file(source_path, bucket_name, dest_path)
+                self.s3_client.upload_file(source_path, bucket_name, dest_path, ExtraArgs=upload_args)
 
             progress.close()
         except (KeyboardInterrupt, SystemExit):  # pragma: no cover
@@ -2160,7 +2163,7 @@ class Zappa:
         with open(template, 'wb') as out:
             out.write(bytes(self.cf_template.to_json(indent=None, separators=(',',':')), "utf-8"))
 
-        self.upload_to_s3(template, working_bucket, disable_progress=disable_progress)
+        self.upload_to_s3(template, working_bucket, disable_progress=disable_progress, upload_args=self.s3_upload_args)
         if self.boto_session.region_name == "us-gov-west-1":
             url = 'https://s3-us-gov-west-1.amazonaws.com/{0}/{1}'.format(working_bucket, template)
         else:


### PR DESCRIPTION
This allows the use of upload arguments to be passed through to the S3
client.

This will enable server side encryption on S3 buckets.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS

For https://github.com/Miserlou/Zappa/issues/1792

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

