### PR TITLE
asynchronous: memoize session client objects to fix slow import

### DIFF
--- a/zappa/asynchronous.py
+++ b/zappa/asynchronous.py
@@ -108,6 +108,7 @@ aws_session = boto3.Session()
 
 
 def client(service):
+    """Memoize client sessions: https://github.com/Miserlou/Zappa/issues/2072"""
     global CLIENTS
     if service not in CLIENTS:
         try:


### PR DESCRIPTION
## Description
This memoizes client sessions, so they aren't all run just on `import` but rather 'on first need'.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/2072

