### PR TITLE
Exclude pre-compiled packages matching excludes list

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -650,6 +650,10 @@ class Zappa:
 
             try:
                 for installed_package_name, installed_package_version in installed_packages.items():
+                    if installed_package_name in excludes:
+                        print(" - %s==%s: ignored, skipping..." % (installed_package_name, installed_package_version,))
+                        continue
+
                     cached_wheel_path = self.get_cached_manylinux_wheel(installed_package_name, installed_package_version, disable_progress)
                     if cached_wheel_path:
                         # Otherwise try to use manylinux packages from PyPi..


### PR DESCRIPTION
## Description

There are some locally installed packages I don't want to install on my lambda function, such as coverage or mypy. They are in the `excludes` but somehow are still included in the final ZIP. This change prevents ignored packages from being included in the final ZIP file, resulting for me in a 30% reduction of the lambda size.

This works fine for me locally using Python3.7 and Python3.8

One caveat I just discovered is that patterns (like `packagename*`) will not be interpreted and will be used as plain strings.

Resulting output:
```
Downloading and installing dependencies..                                                                                                                                    
 - psycopg2==2.7.7: Using locally cached manylinux wheel                                                                                                                     
 - pip==19.0.3: ignored, skipping...                                                                                                                                         
 - mypy==0.720: ignored, skipping...                                                                                                                                         
 - markupsafe==1.1.1: Using locally cached manylinux wheel                                                                                                                   
 - ipdb==0.12.3: ignored, skipping...                                                                                                                                        
 - cryptography==2.8: Warning! Using precompiled lambda package version 1.9 instead!                                                                                         
 - coverage==4.5.4: ignored, skipping...                                                                                                                                     
 - cffi==1.13.2: Using locally cached manylinux wheel                                                                                                                        
 - sqlite==python3: Using precompiled lambda package                                                                                                                         
Packaging project as zip.                  
```
## GitHub Issues

I have not opened a GitHub issue first, I'm happy to do it if it's really required, but a PR likely describes more what I want to do :)