### PR TITLE
Add support for REQUEST type Lambda Authorizers

### DIFF
--- a/tests/tests_placebo.py
+++ b/tests/tests_placebo.py
@@ -403,6 +403,9 @@ class TestZappa(unittest.TestCase):
         event = {'authorizationToken': 'hubtoken1', 'methodArn': 'arn:aws:execute-api:us-west-2:1234:xxxxx/dev/GET/v1/endpoint/param', 'type': 'TOKEN'}
         self.assertEqual("AUTHORIZER_EVENT", lh.handler(event, None))
 
+        event = {'methodArn': 'arn:aws:execute-api:us-west-2:1234:xxxxx/dev/GET/v1/endpoint/param', 'type': 'REQUEST'}
+        self.assertEqual("AUTHORIZER_EVENT", lh.handler(event, None))
+
         # Ensure Zappa does return 401 if no function was defined.
         lh.settings.AUTHORIZER_FUNCTION = None
         with self.assertRaisesRegexp(Exception, 'Unauthorized'):

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1635,7 +1635,7 @@ class Zappa:
         if identity_validation_expression:
             authorizer_resource.IdentityValidationExpression = identity_validation_expression
 
-        if authorizer_type == 'TOKEN':
+        if authorizer_type in ['TOKEN', 'REQUEST']:
             if not self.credentials_arn:
                 self.get_credentials_arn()
             authorizer_resource.AuthorizerResultTtlInSeconds = authorizer.get('result_ttl', 300)
@@ -2130,7 +2130,9 @@ class Zappa:
         elif iam_authorization:
             auth_type = "AWS_IAM"
         elif authorizer:
-            auth_type = authorizer.get("type", "CUSTOM")
+            auth_type = authorizer.get("type", "TOKEN").upper()
+            if auth_type in ["TOKEN", "REQUEST"]:
+                auth_type = "CUSTOM"
 
         # build a fresh template
         self.cf_template = troposphere.Template()

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -435,7 +435,7 @@ class LambdaHandler:
             return result
 
         # This is an API Gateway authorizer event
-        elif event.get('type') == 'TOKEN':
+        elif event.get('type') in ['TOKEN', 'REQUEST']:
             whole_function = self.settings.AUTHORIZER_FUNCTION
             if whole_function:
                 app_function = self.import_module_and_get_function(whole_function)


### PR DESCRIPTION
## Description
Support for REQUEST authorizers was almost there, as the `type` authorizer property was mostly passed through to the CloudFormation templates. This PR extends the handler middleware to also treat events of type REQUEST as authorization events. It also extends the template creation to treat TOKEN and REQUEST type authorizers equal (defaulting to TOKEN just as before).
The most significant change is in the logic how the authoriz*ation* type for API routes is derived from the authoriz*er* type: Instead of assuming CUSTOM if the type is not specified, the authorizer type correctly defaults to TOKEN. The authorization type is then mapped to CUSTOM for both, TOKEN and REQUEST authorizers.

Added unit tests and tested on live environments on AWS.

## GitHub Issues
Fixes #1159 
