### PR TITLE
Add a default handler for AWS events

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,18 @@ def your_recurring_function(event, context):
 
 You can find more [example event sources here](http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html).
 
+You can also respond to events dynamically using the `default_event_handler` setting, which can be useful for handling events from unknown sources or sources configured at run time:
+
+```javascript
+{
+  "production": {
+    ...,
+    "default_event_handler": "your_module.your_handler_function",
+    ...
+  }
+}
+```
+
 ## Asynchronous Task Execution
 
 Zappa also now offers the ability to seamlessly execute functions asynchronously in a completely separate AWS Lambda instance!

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2389,6 +2389,9 @@ class ZappaCLI:
                     event_mapping[arn] = function
             settings_s = settings_s + "AWS_EVENT_MAPPING={0!s}\n".format(event_mapping)
 
+            default_event_handler = self.stage_config.get('default_event_handler')
+            settings_s = settings_s + "AWS_DEFAULT_EVENT_HANDLER={0!r}\n".format(default_event_handler)
+
             # Map Lext bot events
             bot_events = self.stage_config.get('bot_events', [])
             bot_events_mapping = {}

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -312,7 +312,7 @@ class LambdaHandler:
             arn = record['s3']['bucket']['arn']
 
         if arn:
-            return self.settings.AWS_EVENT_MAPPING.get(arn, self.settings.DEFAULT_EVENT_HANDLER)
+            return self.settings.AWS_EVENT_MAPPING.get(arn, self.settings.AWS_DEFAULT_EVENT_HANDLER)
 
         return None
 

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -312,7 +312,7 @@ class LambdaHandler:
             arn = record['s3']['bucket']['arn']
 
         if arn:
-            return self.settings.AWS_EVENT_MAPPING.get(arn)
+            return self.settings.AWS_EVENT_MAPPING.get(arn, self.settings.DEFAULT_EVENT_HANDLER)
 
         return None
 


### PR DESCRIPTION
Ticket: #2112 

This PR adds a way for users to define a default handler for AWS events. This allows for handling events for sources that don't exist at the time of deployment (like temporary SQS queues) as well as resources managed by systems like terraform whose ARNs are not yet known at the time the Zappa package is built.

Finally, it allows users to handle events from new AWS systems that Zappa has not specifically integrated yet.