### PR TITLE
GH-2116 deal with non-alphanumeric package names

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -813,7 +813,8 @@ class Zappa:
             os.makedirs(cached_wheels_dir)
         else:
             # Check if we already have a cached copy
-            wheel_file = f'{package_name}-{package_version}-*_x86_64.whl'
+            wheel_name = re.sub("[^\w\d.]+", "_", package_name, re.UNICODE)
+            wheel_file = f'{wheel_name}-{package_version}-*_x86_64.whl'
             wheel_path = os.path.join(cached_wheels_dir, wheel_file)
 
             for pathname in glob.iglob(wheel_path):


### PR DESCRIPTION
## Description
Apply the same filter defined in the PEP referred to in the ticket comment.

## GitHub Issues
Fixes #2116 
