### PR TITLE
2123 Fix `endpoint_url` when `use_apigateway` is false

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1022,11 +1022,14 @@ class ZappaCLI:
             # but we're also updating a few of the APIGW settings.
             endpoint_url = self.deploy_api_gateway(api_id)
 
-            if self.stage_config.get('domain', None):
-                endpoint_url = self.stage_config.get('domain')
+        if self.domain:
+            endpoint_url = self.domain
 
-        else:
-            endpoint_url = None
+        if endpoint_url:
+            if self.base_path and not endpoint_url.endswith('/' + self.base_path):
+                endpoint_url += '/' + self.base_path
+            if endpoint_url and not endpoint_url.startswith('https://'):
+                endpoint_url = 'https://' + endpoint_url
 
         self.schedule()
 
@@ -1035,12 +1038,6 @@ class ZappaCLI:
         self.update_cognito_triggers()
 
         self.callback('post')
-
-        if endpoint_url and 'https://' not in endpoint_url:
-            endpoint_url = 'https://' + endpoint_url
-
-        if self.base_path:
-            endpoint_url += '/' + self.base_path
 
         deployed_string = "Your updated Zappa deployment is " + click.style("live", fg='green', bold=True) + "!"
         if self.use_apigateway:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -1040,10 +1040,12 @@ class ZappaCLI:
         self.callback('post')
 
         deployed_string = "Your updated Zappa deployment is " + click.style("live", fg='green', bold=True) + "!"
-        if self.use_apigateway:
+
+        if endpoint_url:
             deployed_string = deployed_string + ": " + click.style("{}".format(endpoint_url), bold=True)
 
-            api_url = None
+        api_url = None
+        if self.use_apigateway:
             if endpoint_url and 'amazonaws.com' not in endpoint_url:
                 api_url = self.zappa.get_api_url(
                     self.lambda_name,
@@ -1052,11 +1054,8 @@ class ZappaCLI:
                 if endpoint_url != api_url:
                     deployed_string = deployed_string + " (" + api_url + ")"
 
-            if self.stage_config.get('touch', True):
-                if api_url:
-                    self.touch_endpoint(api_url)
-                elif endpoint_url:
-                    self.touch_endpoint(endpoint_url)
+        if self.stage_config.get('touch', True) and (api_url or endpoint_url):
+            self.touch_endpoint(api_url or endpoint_url)
 
         click.echo(deployed_string)
 


### PR DESCRIPTION
## Description
Update no longer raises an exception while updating `endpoint_url` with `base_path` when `use_apigateway` is `False`.

Further, when `use_apigateway` is `False`, update now also:
* amends `deployed_string` with `endpoint_url` (admittedly, Zappa's formatting for this could be improved)
* attempts to touch the endpoint based on Zappa's settings

## GitHub Issues
See issue #2123 for more information and for further discussion.
