### PR TITLE
2139 use shlex to split management args

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -406,7 +406,7 @@ class LambdaHandler:
 
             # Couldn't figure out how to get the value into stdout with StringIO..
             # Read the log for now. :[]
-            management.call_command(shlex.split(*event['manage']))
+            management.call_command(*shlex.split(event['manage']))
             return {}
 
         # This is an AWS-event triggered invocation.

--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import os
+import shlex
 import sys
 import traceback
 import tarfile
@@ -405,7 +406,7 @@ class LambdaHandler:
 
             # Couldn't figure out how to get the value into stdout with StringIO..
             # Read the log for now. :[]
-            management.call_command(*event['manage'].split(' '))
+            management.call_command(shlex.split(*event['manage']))
             return {}
 
         # This is an AWS-event triggered invocation.


### PR DESCRIPTION
fixes https://github.com/Miserlou/Zappa/issues/2139

## Description
management.call_command wasn't working for quoted arguments (such as `manage "shell -c 'import os; print(os.listdir())'"`)

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/2139

