### PR TITLE
Update BINARY_SUPPORT to use Content-Encoding to identify if data is binary

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -549,9 +549,9 @@ class LambdaHandler:
                         zappa_returndict.setdefault('statusDescription', response.status)
 
                     if response.data:
-                        if settings.BINARY_SUPPORT and \
-                                not response.mimetype.startswith("text/") \
-                                and response.mimetype != "application/json":
+                        content_encoding = response.headers.get("Content-Encoding", None)
+                        binary_encodings = ("gzip", "compress", "deflate", "br")
+                        if settings.BINARY_SUPPORT and content_encoding in binary_encodings:
                             zappa_returndict['body'] = base64.b64encode(response.data).decode('utf-8')
                             zappa_returndict["isBase64Encoded"] = True
                         else:


### PR DESCRIPTION

## Description

Alternative solution to https://github.com/Miserlou/Zappa/issues/2080 intended to allow BINARY and text by making use of Content-Encoding header in the response.

When using _whitenoise_ for caching, which provides compression, binary types may include mimetypes, "text/", "application/json":

- response.mimetype.startswith("text/")
- response.mimetype == "application/json"

Assuming that Content-Encoding will be set (as whitenoise apparently does) this allows compression to be applied by the application for "text/" and "application/json".

About Content-Encoding:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

Not sure if this works for all use cases, but it currently appears to work for my workcase where _whitenoise_ is performing compression of text/json files intended for caching, while still allowing text for html.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/2080
