### PR TITLE
Fix when no expressions or keep_warm is false

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2780,6 +2780,7 @@ class Zappa:
                 elif rule_response == 'dryrun':
                     print("Dryrun for creating {} event schedule for {}!!".format(svc, function))
             else:
+                name = self.get_scheduled_event_name(event, function, lambda_name)
                 print("Could not create event {} - Please define either an expression or an event source".format(name))
 
 


### PR DESCRIPTION
When I set keep_warm_expression it fails with 
```
    events=events
  File "/Users/valery/.local/share/virtualenvs/document_data_extract_zappa-j8vc3Vbe/lib/python3.6/site-packages/zappa/core.py", line 2783, in schedule_events
    print("Could not create event {} - Please define either an expression or an event source".format(name))
UnboundLocalError: local variable 'name' referenced before assignment
```

So I fixed it.

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

