### PR TITLE
Bump boto3/botocore versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 argcomplete
-boto3
+boto3>=1.16.45
 durationpy
 hjson
 jmespath

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 argcomplete
-boto3>=1.16.45
+boto3>=1.16.46
 durationpy
 hjson
 jmespath

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,36 +4,37 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-argcomplete==1.11.1       # via -r requirements.in (line 1)
-boto3==1.14.2             # via -r requirements.in (line 2), kappa
-botocore==1.17.2          # via boto3, s3transfer
+argcomplete==1.11.1       # via -r requirements.in
+boto3==1.16.46            # via -r requirements.in, kappa
+botocore==1.19.46         # via boto3, s3transfer
 certifi==2020.4.5.2       # via requests
 cfn-flip==1.2.3           # via troposphere
 chardet==3.0.4            # via requests
 click==7.1.2              # via cfn-flip, kappa, pip-tools
-docutils==0.15.2          # via botocore
-durationpy==0.5           # via -r requirements.in (line 3)
-future==0.18.2            # via -r requirements.in (line 11)
-hjson==3.0.1              # via -r requirements.in (line 4)
+durationpy==0.5           # via -r requirements.in
+future==0.18.2            # via -r requirements.in
+hjson==3.0.1              # via -r requirements.in
 idna==2.9                 # via requests
-jmespath==0.10.0          # via -r requirements.in (line 5), boto3, botocore
-kappa==0.6.0              # via -r requirements.in (line 6)
-pip-tools==5.2.1          # via -r requirements.in (line 22)
+importlib-metadata==1.7.0  # via argcomplete
+jmespath==0.10.0          # via -r requirements.in, boto3, botocore
+kappa==0.6.0              # via -r requirements.in
+pip-tools==5.2.1          # via -r requirements.in
 placebo==0.9.0            # via kappa
-python-dateutil==2.8.1    # via -r requirements.in (line 8), botocore
-python-slugify==4.0.0     # via -r requirements.in (line 9)
-pyyaml==5.3.1             # via -r requirements.in (line 10), cfn-flip, kappa
-requests==2.23.0          # via -r requirements.in (line 13)
+python-dateutil==2.8.1    # via -r requirements.in, botocore
+python-slugify==4.0.0     # via -r requirements.in
+pyyaml==5.3.1             # via -r requirements.in, cfn-flip, kappa
+requests==2.23.0          # via -r requirements.in
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via -r requirements.in (line 14), cfn-flip, pip-tools, python-dateutil
+six==1.15.0               # via -r requirements.in, cfn-flip, pip-tools, python-dateutil
 text-unidecode==1.3       # via python-slugify
-toml==0.10.1              # via -r requirements.in (line 15)
-tqdm==4.46.1              # via -r requirements.in (line 16)
-troposphere==2.6.1        # via -r requirements.in (line 17)
+toml==0.10.1              # via -r requirements.in
+tqdm==4.46.1              # via -r requirements.in
+troposphere==2.6.1        # via -r requirements.in
 urllib3==1.25.9           # via botocore, requests
-werkzeug==0.16.1          # via -r requirements.in (line 19)
-wheel==0.34.2             # via -r requirements.in (line 20)
-wsgi-request-logger==0.4.6  # via -r requirements.in (line 21)
+werkzeug==0.16.1          # via -r requirements.in
+wheel==0.34.2             # via -r requirements.in
+wsgi-request-logger==0.4.6  # via -r requirements.in
+zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,54 +4,55 @@
 #
 #    pip-compile --output-file=test_requirements.txt requirements.in test_requirements.in
 #
-argcomplete==1.11.1       # via -r requirements.in (line 1)
+argcomplete==1.11.1       # via -r requirements.in
 asgiref==3.2.7            # via django
-boto3==1.14.2             # via -r requirements.in (line 2), kappa
-botocore==1.17.2          # via boto3, s3transfer
+boto3==1.16.46            # via -r requirements.in, kappa
+botocore==1.19.46         # via boto3, s3transfer
 certifi==2020.4.5.2       # via requests
 cfn-flip==1.2.3           # via troposphere
 chardet==3.0.4            # via requests
 click==7.1.2              # via cfn-flip, flask, kappa, pip-tools
 coverage==5.1             # via coveralls
-coveralls==2.0.0          # via -r test_requirements.in (line 1)
-django==3.0.7             # via -r test_requirements.in (line 2)
+coveralls==2.0.0          # via -r test_requirements.in
+django==3.0.7             # via -r test_requirements.in
 docopt==0.6.2             # via coveralls
-docutils==0.15.2          # via botocore
-durationpy==0.5           # via -r requirements.in (line 3)
-flake8==3.8.3             # via -r test_requirements.in (line 3)
-flask==1.1.2              # via -r test_requirements.in (line 4)
-future==0.18.2            # via -r requirements.in (line 11)
-hjson==3.0.1              # via -r requirements.in (line 4)
+durationpy==0.5           # via -r requirements.in
+flake8==3.8.3             # via -r test_requirements.in
+flask==1.1.2              # via -r test_requirements.in
+future==0.18.2            # via -r requirements.in
+hjson==3.0.1              # via -r requirements.in
 idna==2.9                 # via requests
+importlib-metadata==1.7.0  # via argcomplete, flake8
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
-jmespath==0.10.0          # via -r requirements.in (line 5), boto3, botocore
-kappa==0.6.0              # via -r requirements.in (line 6)
+jmespath==0.10.0          # via -r requirements.in, boto3, botocore
+kappa==0.6.0              # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-mock==4.0.2               # via -r test_requirements.in (line 5)
-nose-timer==1.0.0         # via -r test_requirements.in (line 7)
-nose==1.3.7               # via -r test_requirements.in (line 6), nose-timer
-pip-tools==5.2.1          # via -r requirements.in (line 22)
-placebo==0.9.0            # via -r test_requirements.in (line 8), kappa
+mock==4.0.2               # via -r test_requirements.in
+nose-timer==1.0.0         # via -r test_requirements.in
+nose==1.3.7               # via -r test_requirements.in, nose-timer
+pip-tools==5.2.1          # via -r requirements.in
+placebo==0.9.0            # via -r test_requirements.in, kappa
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
-python-dateutil==2.8.1    # via -r requirements.in (line 8), botocore
-python-slugify==4.0.0     # via -r requirements.in (line 9)
+python-dateutil==2.8.1    # via -r requirements.in, botocore
+python-slugify==4.0.0     # via -r requirements.in
 pytz==2020.1              # via django
-pyyaml==5.3.1             # via -r requirements.in (line 10), cfn-flip, kappa
-requests==2.23.0          # via -r requirements.in (line 13), coveralls
+pyyaml==5.3.1             # via -r requirements.in, cfn-flip, kappa
+requests==2.23.0          # via -r requirements.in, coveralls
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via -r requirements.in (line 14), cfn-flip, pip-tools, python-dateutil
+six==1.15.0               # via -r requirements.in, cfn-flip, pip-tools, python-dateutil
 sqlparse==0.3.1           # via django
 text-unidecode==1.3       # via python-slugify
-toml==0.10.1              # via -r requirements.in (line 15)
-tqdm==4.46.1              # via -r requirements.in (line 16)
-troposphere==2.6.1        # via -r requirements.in (line 17)
+toml==0.10.1              # via -r requirements.in
+tqdm==4.46.1              # via -r requirements.in
+troposphere==2.6.1        # via -r requirements.in
 urllib3==1.25.9           # via botocore, requests
-werkzeug==0.16.1          # via -r requirements.in (line 19), flask
-wheel==0.34.2             # via -r requirements.in (line 20)
-wsgi-request-logger==0.4.6  # via -r requirements.in (line 21)
+werkzeug==0.16.1          # via -r requirements.in, flask
+wheel==0.34.2             # via -r requirements.in
+wsgi-request-logger==0.4.6  # via -r requirements.in
+zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
# Description
In support of #2188, this PR bumps the versions of boto3/botocore, so that we have access to the new Docker image functionality. 

# GitHub Issues
Related #2188

# Testing

I created a new virtual env with the new dependencies and ran several Zappa workflows: `deploy`, `update`, `status`, and `undeploy`. 

![image](https://user-images.githubusercontent.com/11096727/103387166-84abe980-4abf-11eb-9bd5-9205f5021013.png)

![image](https://user-images.githubusercontent.com/11096727/103387183-98efe680-4abf-11eb-848f-91a0f5b70f94.png)

Any other tests you'd recommend running?