### PR TITLE
Handling non-dict SNS messages

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -301,7 +301,7 @@ class LambdaHandler:
                 message = json.loads(record['Sns']['Message'])
                 if message.get('command'):
                     return message['command']
-            except ValueError:
+            except (AttributeError, ValueError):
                 pass
             arn = record['Sns'].get('TopicArn')
         elif 'dynamodb' in record or 'kinesis' in record:


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/Miserlou/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 
The main SNS message handler incorrectly assumes that every message that was parsed using json.loads() without throwing an exception is of dict type, and then uses dict methods like .get() on the parsed object which eventually leads to a crash. In our case this has prevented us from sending a list of dicts, but there's more examples. This PR fixes it by handling the AttributeError exception

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
https://github.com/Miserlou/Zappa/issues/1466
https://github.com/Miserlou/Zappa/issues/1864

